### PR TITLE
Fix some false-positive clippy lints

### DIFF
--- a/crates/data-model/src/lib.rs
+++ b/crates/data-model/src/lib.rs
@@ -19,7 +19,8 @@
     clippy::module_name_repetitions,
     clippy::missing_panics_doc,
     clippy::missing_errors_doc,
-    clippy::trait_duplication_in_bounds
+    clippy::trait_duplication_in_bounds,
+    clippy::type_repetition_in_bounds
 )]
 
 pub(crate) mod compat;

--- a/crates/handlers/src/lib.rs
+++ b/crates/handlers/src/lib.rs
@@ -50,7 +50,8 @@ mod views;
 #[allow(
     clippy::too_many_lines,
     clippy::missing_panics_doc,
-    clippy::too_many_arguments
+    clippy::too_many_arguments,
+    clippy::trait_duplication_in_bounds
 )]
 pub fn router<B>(
     pool: &PgPool,

--- a/crates/http/src/lib.rs
+++ b/crates/http/src/lib.rs
@@ -121,12 +121,12 @@ where
 }
 
 #[must_use]
-pub fn client<B, E: 'static>(
+pub fn client<B, E>(
     operation: &'static str,
 ) -> BoxCloneService<Request<B>, Response<BoxBody<bytes::Bytes, ClientError>>, ClientError>
 where
     B: http_body::Body<Data = Bytes, Error = E> + Default + Send + 'static,
-    E: Into<BoxError>,
+    E: Into<BoxError> + 'static,
 {
     let fut = make_base_client()
         // Map the error to a ClientError

--- a/crates/templates/src/context.rs
+++ b/crates/templates/src/context.rs
@@ -14,7 +14,7 @@
 
 //! Contexts used in templates
 
-#![allow(clippy::trait_duplication_in_bounds)]
+#![allow(clippy::trait_duplication_in_bounds, clippy::type_repetition_in_bounds)]
 
 use chrono::Utc;
 use mas_data_model::{


### PR DESCRIPTION
Those were introduced in clippy 1.62 (under clippy::pedantic) and are in
proc-macro generated code
