### PR TITLE
Reduce GitHub Actions usage

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,8 +2,13 @@ name: CI
 
 on:
   push:
+    branches: [ main ]
   pull_request:
     branches: [ main ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
This removes the run on push for branches other than main, and
preemptively stops runs on the same ref