### PR TITLE
Disable autocorrection/captialisation on username text fields

### DIFF
--- a/crates/templates/src/res/components/field.html
+++ b/crates/templates/src/res/components/field.html
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 #}
 
-{% macro input(label, name, type="text", form_state=false, autocomplete=false, class="", inputmode="text") %}
+{% macro input(label, name, type="text", form_state=false, autocomplete=false, class="", inputmode="text", autocorrect=false, autocapitalize=false) %}
   {% if not form_state %}
     {% set form_state = dict(errors=[], fields=dict()) %}
   {% endif %}
@@ -37,6 +37,8 @@ limitations under the License.
       inputmode="{{ inputmode }}"
       {% if autocomplete %} autocomplete="{{ autocomplete }}" {% endif %} 
       {% if state.value %} value="{{ state.value }}" {% endif %}  
+      {% if autocorrect %} autocorrect="{{ autocorrect }}" {% endif %} 
+      {% if autocapitalize %} autocapitalize="{{ autocapitalize }}" {% endif %} 
       />
 
     {% if state.errors is not empty %}

--- a/crates/templates/src/res/pages/login.html
+++ b/crates/templates/src/res/pages/login.html
@@ -32,7 +32,7 @@ limitations under the License.
       {% endif %}
 
       <input type="hidden" name="csrf" value="{{ csrf_token }}" />
-      {{ field::input(label="Username", name="username", form_state=form, autocomplete="username") }}
+      {{ field::input(label="Username", name="username", form_state=form, autocomplete="username", autocorrect="off", autocapitalize="none") }}
       {{ field::input(label="Password", name="password", type="password", form_state=form, autocomplete="password") }}
       {% if next and next.kind == "continue_authorization_grant" %}
         <div class="grid grid-cols-2 gap-4">

--- a/crates/templates/src/res/pages/register.html
+++ b/crates/templates/src/res/pages/register.html
@@ -32,7 +32,7 @@ limitations under the License.
       {% endif %}
 
       <input type="hidden" name="csrf" value="{{ csrf_token }}" />
-      {{ field::input(label="Username", name="username", form_state=form, autocomplete="username") }}
+      {{ field::input(label="Username", name="username", form_state=form, autocomplete="username", autocorrect="off", autocapitalize="none") }}
       {{ field::input(label="Email", name="email", type="email", form_state=form, autocomplete="email") }}
       {{ field::input(label="Password", name="password", type="password", form_state=form, autocomplete="new-password") }}
       {{ field::input(label="Confirm Password", name="password_confirm", type="password", form_state=form, autocomplete="new-password") }}


### PR DESCRIPTION
When using the login form on iOS it becomes rather annoying with the system constantly trying to correct and capitalise what you're typing. I *think* this PR fixes that assuming the attributes I’ve added to are regular html?

This is similar to https://github.com/matrix-org/synapse/pull/13350 which has links for necessary docs.