### PR TITLE
Database testing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -259,12 +259,20 @@ jobs:
             target
           key: ${{ runner.os }}-cargo-build-${{ steps.toolchain.outputs.rustc_hash }}-${{ hashFiles('**/Cargo.lock') }}
 
+      - name: Start PostgreSQL database
+        run: |
+          sudo systemctl start postgresql.service
+          pg_isready
+          sudo -u postgres psql --command="CREATE USER test PASSWORD 'test'" --command="\du"
+
       - name: Test
         id: test
         uses: actions-rs/cargo@v1
         with:
           command: test
           args: --offline --workspace
+        env:
+          DATABASE_URL: postgresql://test:test@localhost/postgres
 
         # Ignore errors on the nightly toolchain
         continue-on-error: "${{ matrix.toolchain == 'nightly' }}"
@@ -328,6 +336,12 @@ jobs:
           curl -sL https://github.com/mozilla/grcov/releases/download/v0.8.7/grcov-x86_64-unknown-linux-gnu.tar.bz2 | tar jxf - -C "${HOME}/.local/bin"
           echo "$HOME/.local/bin" >> $GITHUB_PATH
 
+      - name: Start PostgreSQL database
+        run: |
+          sudo systemctl start postgresql.service
+          pg_isready
+          sudo -u postgres psql --command="CREATE USER test PASSWORD 'test'" --command="\du"
+
       - name: Run test suite with profiling enabled
         uses: actions-rs/cargo@v1
         with:
@@ -337,6 +351,7 @@ jobs:
           CARGO_INCREMENTAL: '0'
           RUSTFLAGS: '-Cinstrument-coverage'
           LLVM_PROFILE_FILE: "cargo-test-%p-%m.profraw"
+          DATABASE_URL: postgresql://test:test@localhost/postgres
 
       - name: Build grcov report
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -273,6 +273,7 @@ jobs:
           args: --offline --workspace
         env:
           DATABASE_URL: postgresql://test:test@localhost/postgres
+          SQLX_OFFLINE: '1'
 
         # Ignore errors on the nightly toolchain
         continue-on-error: "${{ matrix.toolchain == 'nightly' }}"
@@ -352,6 +353,7 @@ jobs:
           RUSTFLAGS: '-Cinstrument-coverage'
           LLVM_PROFILE_FILE: "cargo-test-%p-%m.profraw"
           DATABASE_URL: postgresql://test:test@localhost/postgres
+          SQLX_OFFLINE: '1'
 
       - name: Build grcov report
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -220,6 +220,21 @@ jobs:
           - beta
           - nightly
 
+    services:
+      postgres:
+        image: docker.io/library/postgres:14.4
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - "5432:5432"
+
     steps:
       - name: Checkout the code
         uses: actions/checkout@v3
@@ -259,12 +274,6 @@ jobs:
             target
           key: ${{ runner.os }}-cargo-build-${{ steps.toolchain.outputs.rustc_hash }}-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: Start PostgreSQL database
-        run: |
-          sudo systemctl start postgresql.service
-          pg_isready
-          sudo -u postgres psql --command="CREATE USER test PASSWORD 'test'" --command="\du"
-
       - name: Test
         id: test
         uses: actions-rs/cargo@v1
@@ -272,7 +281,7 @@ jobs:
           command: test
           args: --offline --workspace
         env:
-          DATABASE_URL: postgresql://test:test@localhost/postgres
+          DATABASE_URL: postgresql://postgres:postgres@localhost/postgres
           SQLX_OFFLINE: '1'
 
         # Ignore errors on the nightly toolchain
@@ -291,6 +300,21 @@ jobs:
 
     permissions:
       contents: read
+
+    services:
+      postgres:
+        image: docker.io/library/postgres:14.4
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - "5432:5432"
 
     steps:
       - name: Checkout the code
@@ -337,12 +361,6 @@ jobs:
           curl -sL https://github.com/mozilla/grcov/releases/download/v0.8.7/grcov-x86_64-unknown-linux-gnu.tar.bz2 | tar jxf - -C "${HOME}/.local/bin"
           echo "$HOME/.local/bin" >> $GITHUB_PATH
 
-      - name: Start PostgreSQL database
-        run: |
-          sudo systemctl start postgresql.service
-          pg_isready
-          sudo -u postgres psql --command="CREATE USER test PASSWORD 'test'" --command="\du"
-
       - name: Run test suite with profiling enabled
         uses: actions-rs/cargo@v1
         with:
@@ -352,7 +370,7 @@ jobs:
           CARGO_INCREMENTAL: '0'
           RUSTFLAGS: '-Cinstrument-coverage'
           LLVM_PROFILE_FILE: "cargo-test-%p-%m.profraw"
-          DATABASE_URL: postgresql://test:test@localhost/postgres
+          DATABASE_URL: postgresql://postgres:postgres@localhost/postgres
           SQLX_OFFLINE: '1'
 
       - name: Build grcov report


### PR DESCRIPTION
This adds tests which depend on a postgres database.
It leverages the new `sqlx::test` introduced in sqlx 0.6.1, which creates, migrate and teardown a database for each test.

This PR does 3 things:

 - setup GitHub Actions to have a PostgreSQL instance when running tests
 - adds a first simple database test in `mas-storage`, which registers a user, tries to login, etc.
 - adds a helper to create an `axum::Router` used in tests, which helps writing tests in `mas-handlers`

Note that this also enables the `wasmtime` compilation cache to speed up tests (else we compile the WASM module on each test in `mas-handlers`, which takes about a second)