### PR TITLE
Disable wasmtime cache in the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -132,12 +132,22 @@ RUN mv target/$(/docker-arch-to-rust-target.sh "${TARGETPLATFORM}")/release/mas-
 
 ## Runtime stage, debug variant ##
 FROM --platform=${TARGETPLATFORM} gcr.io/distroless/cc-debian${DEBIAN_VERSION}:debug-nonroot AS debug
+
+# Inject a wasmtime config which disables cache to avoid issues running with a read-only root filesystem
+ENV XDG_CONFIG_HOME=/etc
+COPY ./misc/wasmtime-config.toml /etc/wasmtime/config.toml
+
 COPY --from=builder /usr/local/bin/mas-cli /usr/local/bin/mas-cli
 WORKDIR /
 ENTRYPOINT ["/mas-cli"]
 
 ## Runtime stage ##
 FROM --platform=${TARGETPLATFORM} gcr.io/distroless/cc-debian${DEBIAN_VERSION}:nonroot
+
+# Inject a wasmtime config which disables cache to avoid issues running with a read-only root filesystem
+ENV XDG_CONFIG_HOME=/etc
+COPY ./misc/wasmtime-config.toml /etc/wasmtime/config.toml
+
 COPY --from=builder /usr/local/bin/mas-cli /usr/local/bin/mas-cli
 WORKDIR /
 ENTRYPOINT ["/usr/local/bin/mas-cli"]

--- a/misc/wasmtime-config.toml
+++ b/misc/wasmtime-config.toml
@@ -1,0 +1,4 @@
+# Disable wasmtime cache by default in the Docker image, because the rootfs is likely to be read-only
+
+[cache]
+enabled = false


### PR DESCRIPTION
This disables the wasmtime cache in the Docker image because

 1. it probably would never be used (unless you mounted `/home/nonroot/.cache/wasmtime` to a persistent place)
 2. makes it crash if it can't write to the default cache location (so if you run the image with `--read-only` for example)