### PR TITLE
Improve docs for the `prompt_values_supported` field

### DIFF
--- a/crates/oauth2-types/src/oidc.rs
+++ b/crates/oauth2-types/src/oidc.rs
@@ -344,6 +344,11 @@ pub struct ProviderMetadata {
     pub require_pushed_authorization_requests: Option<bool>,
 
     /// Array containing the list of prompt values that this OP supports.
+    ///
+    /// This field can be used to detect if the OP supports the [prompt
+    /// `create`] value.
+    ///
+    /// [prompt `create`]: https://openid.net/specs/openid-connect-prompt-create-1_0.html
     pub prompt_values_supported: Option<Vec<Prompt>>,
 }
 


### PR DESCRIPTION
Link to the spec that introduces it since it's not in the IANA list.

Based on #350.