### PR TITLE
Bump dependencies in Docker image and CI improvements

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -387,7 +387,7 @@ jobs:
 
   build-image:
     name: Build and push Docker image
-    needs: [rustfmt, clippy, opa-lint]
+    needs: [opa-lint]
     runs-on: ubuntu-latest
     env:
       IMAGE: ghcr.io/matrix-org/matrix-authentication-service

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -451,11 +451,13 @@ jobs:
 
       # For pull-requests, only read from the cache, do not try to push to the
       # cache or the image itself
+      # We only build for the amd64 platform in pul-requests to speed-up CI
       - name: Build
         uses: docker/bake-action@v2
         if: github.event_name == 'pull_request'
         with:
           set: |
+            base.platform=linux/amd64
             base.cache-from=type=registry,ref=${{ env.IMAGE }}:buildcache
 
       - name: Build and push

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# syntax = docker/dockerfile:1.3
+# syntax = docker/dockerfile:1.4
 
 # Builds a minimal image with the binary only. It is multi-arch capable,
 # cross-building to aarch64 and x86_64. When cross-compiling, Docker sets two
@@ -12,9 +12,9 @@
 # The Debian version and version name must be in sync
 ARG DEBIAN_VERSION=11
 ARG DEBIAN_VERSION_NAME=bullseye
-ARG RUSTC_VERSION=1.61.0
+ARG RUSTC_VERSION=1.63.0
 ARG NODEJS_VERSION=16
-ARG OPA_VERSION=0.40.0
+ARG OPA_VERSION=0.43.0
 
 ## Build stage that builds the static files/frontend ##
 FROM --platform=${BUILDPLATFORM} docker.io/library/node:${NODEJS_VERSION}-${DEBIAN_VERSION_NAME}-slim AS static-files

--- a/crates/policy/policies/Makefile
+++ b/crates/policy/policies/Makefile
@@ -1,12 +1,13 @@
 # Set to 1 to run OPA through Docker
 DOCKER := 0
+OPA_DOCKER_IMAGE := docker.io/openpolicyagent/opa:0.43.0
 
 ifeq ($(DOCKER), 0)
 	OPA := opa
 	OPA_RW := opa
 else
-	OPA := docker run -i -v $(shell pwd):/policies:ro -w /policies --rm docker.io/openpolicyagent/opa:0.41.0
-	OPA_RW := docker run -i -v $(shell pwd):/policies -w /policies --rm docker.io/openpolicyagent/opa:0.41.0
+	OPA := docker run -i -v $(shell pwd):/policies:ro -w /policies --rm $(OPA_DOCKER_IMAGE)
+	OPA_RW := docker run -i -v $(shell pwd):/policies -w /policies --rm $(OPA_DOCKER_IMAGE)
 endif
 
 policy.wasm: client_registration.rego register.rego authorization_grant.rego


### PR DESCRIPTION
- Bumps OPA to 0.43.0
- Bumps Rust to 1.63.0
- Bumps the dockerfile frontend to 1.4
- Speeds up CI by only building the Docker image for the arm64 platform in PRs
- Speeds up CI by building the Docker image earlier