### PR TITLE
Allow access token types in introspection auth methods

### DIFF
--- a/crates/handlers/src/oauth2/discovery.rs
+++ b/crates/handlers/src/oauth2/discovery.rs
@@ -90,7 +90,8 @@ pub(crate) async fn get(
     let token_endpoint_auth_signing_alg_values_supported =
         client_auth_signing_alg_values_supported.clone();
 
-    let introspection_endpoint_auth_methods_supported = client_auth_methods_supported;
+    let introspection_endpoint_auth_methods_supported =
+        client_auth_methods_supported.map(|v| v.into_iter().map(Into::into).collect());
     let introspection_endpoint_auth_signing_alg_values_supported =
         client_auth_signing_alg_values_supported;
 


### PR DESCRIPTION
According to [RFC8414](https://www.rfc-editor.org/rfc/rfc8414#page-7).