### PR TITLE
Export list of supported algorithms from mas-jose

### DIFF
--- a/crates/handlers/src/oauth2/discovery.rs
+++ b/crates/handlers/src/oauth2/discovery.rs
@@ -13,13 +13,11 @@
 // limitations under the License.
 
 use axum::{extract::State, response::IntoResponse, Json};
-use mas_iana::{
-    jose::JsonWebSignatureAlg,
-    oauth::{
-        OAuthAuthorizationEndpointResponseType, OAuthClientAuthenticationMethod,
-        PkceCodeChallengeMethod,
-    },
+use mas_iana::oauth::{
+    OAuthAuthorizationEndpointResponseType, OAuthClientAuthenticationMethod,
+    PkceCodeChallengeMethod,
 };
+use mas_jose::jwa::SUPPORTED_SIGNING_ALGORITHMS;
 use mas_keystore::Keystore;
 use mas_router::UrlBuilder;
 use oauth2_types::{
@@ -43,20 +41,7 @@ pub(crate) async fn get(
     ]);
 
     // Those are the algorithms supported by `mas-jose`
-    let client_auth_signing_alg_values_supported = Some(vec![
-        JsonWebSignatureAlg::Hs256,
-        JsonWebSignatureAlg::Hs384,
-        JsonWebSignatureAlg::Hs512,
-        JsonWebSignatureAlg::Rs256,
-        JsonWebSignatureAlg::Rs384,
-        JsonWebSignatureAlg::Rs512,
-        JsonWebSignatureAlg::Ps256,
-        JsonWebSignatureAlg::Ps384,
-        JsonWebSignatureAlg::Ps512,
-        JsonWebSignatureAlg::Es256,
-        JsonWebSignatureAlg::Es384,
-        JsonWebSignatureAlg::Es256K,
-    ]);
+    let client_auth_signing_alg_values_supported = Some(SUPPORTED_SIGNING_ALGORITHMS.to_vec());
 
     // This is how we can sign stuff
     let jwt_signing_alg_values_supported = Some(key_store.available_signing_algorithms());

--- a/crates/jose/src/jwa/mod.rs
+++ b/crates/jose/src/jwa/mod.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use mas_iana::jose::JsonWebSignatureAlg;
 use sha2::{Sha256, Sha384, Sha512};
 
 mod asymmetric;
@@ -49,3 +50,19 @@ pub type Es384SigningKey = ecdsa::SigningKey<p384::NistP384>;
 pub type Es384VerifyingKey = ecdsa::VerifyingKey<p384::NistP384>;
 pub type Es256KSigningKey = ecdsa::SigningKey<k256::Secp256k1>;
 pub type Es256KVerifyingKey = ecdsa::VerifyingKey<k256::Secp256k1>;
+
+/// All the signing algorithms supported by this crate.
+pub const SUPPORTED_SIGNING_ALGORITHMS: [JsonWebSignatureAlg; 12] = [
+    JsonWebSignatureAlg::Hs256,
+    JsonWebSignatureAlg::Hs384,
+    JsonWebSignatureAlg::Hs512,
+    JsonWebSignatureAlg::Rs256,
+    JsonWebSignatureAlg::Rs384,
+    JsonWebSignatureAlg::Rs512,
+    JsonWebSignatureAlg::Ps256,
+    JsonWebSignatureAlg::Ps384,
+    JsonWebSignatureAlg::Ps512,
+    JsonWebSignatureAlg::Es256,
+    JsonWebSignatureAlg::Es384,
+    JsonWebSignatureAlg::Es256K,
+];


### PR DESCRIPTION
Sorry, I should probably have realized that with #430, but I'm also going to need this list for the client library so I'd rather export it from a common place.