### PR TITLE
Make more enum types accept unknown values

### DIFF
--- a/crates/handlers/src/oauth2/authorization/complete.rs
+++ b/crates/handlers/src/oauth2/authorization/complete.rs
@@ -39,7 +39,9 @@ use oauth2_types::requests::{AccessTokenResponse, AuthorizationResponse};
 use sqlx::{PgPool, Postgres, Transaction};
 use thiserror::Error;
 
-use super::callback::{CallbackDestination, CallbackDestinationError, InvalidRedirectUriError};
+use super::callback::{
+    CallbackDestination, CallbackDestinationError, IntoCallbackDestinationError,
+};
 
 #[derive(Debug, Error)]
 pub enum RouteError {
@@ -90,8 +92,8 @@ impl From<ActiveSessionLookupError> for RouteError {
     }
 }
 
-impl From<InvalidRedirectUriError> for RouteError {
-    fn from(e: InvalidRedirectUriError) -> Self {
+impl From<IntoCallbackDestinationError> for RouteError {
+    fn from(e: IntoCallbackDestinationError) -> Self {
         Self::Internal(Box::new(e))
     }
 }
@@ -175,8 +177,8 @@ impl From<sqlx::Error> for GrantCompletionError {
     }
 }
 
-impl From<InvalidRedirectUriError> for GrantCompletionError {
-    fn from(e: InvalidRedirectUriError) -> Self {
+impl From<IntoCallbackDestinationError> for GrantCompletionError {
+    fn from(e: IntoCallbackDestinationError) -> Self {
         Self::Internal(Box::new(e))
     }
 }

--- a/crates/oauth2-types/src/requests.rs
+++ b/crates/oauth2-types/src/requests.rs
@@ -41,13 +41,13 @@ use crate::{response_type::ResponseType, scope::Scope};
     PartialOrd,
     Ord,
     Clone,
-    Copy,
     Display,
     FromStr,
     SerializeDisplay,
     DeserializeFromStr,
 )]
 #[display(style = "snake_case")]
+#[non_exhaustive]
 pub enum ResponseMode {
     /// Authorization Response parameters are encoded in the query string added
     /// to the `redirect_uri`.
@@ -65,6 +65,10 @@ pub enum ResponseMode {
     ///
     /// Defined in [OAuth 2.0 Form Post Response Mode](https://openid.net/specs/oauth-v2-form-post-response-mode-1_0.html).
     FormPost,
+
+    /// An unknown value.
+    #[display("{0}")]
+    Unknown(String),
 }
 
 /// Value that specifies how the Authorization Server displays the
@@ -79,13 +83,13 @@ pub enum ResponseMode {
     PartialOrd,
     Ord,
     Clone,
-    Copy,
     Display,
     FromStr,
     SerializeDisplay,
     DeserializeFromStr,
 )]
 #[display(style = "snake_case")]
+#[non_exhaustive]
 pub enum Display {
     /// The Authorization Server should display the authentication and consent
     /// UI consistent with a full User Agent page view.
@@ -104,6 +108,10 @@ pub enum Display {
     /// The Authorization Server should display the authentication and consent
     /// UI consistent with a "feature phone" type display.
     Wap,
+
+    /// An unknown value.
+    #[display("{0}")]
+    Unknown(String),
 }
 
 impl Default for Display {
@@ -124,13 +132,13 @@ impl Default for Display {
     PartialOrd,
     Ord,
     Clone,
-    Copy,
     Display,
     FromStr,
     SerializeDisplay,
     DeserializeFromStr,
 )]
 #[display(style = "snake_case")]
+#[non_exhaustive]
 pub enum Prompt {
     /// The Authorization Server must not display any authentication or consent
     /// user interface pages.
@@ -157,6 +165,10 @@ pub enum Prompt {
     ///
     /// Defined in [Initiating User Registration via OpenID Connect](https://openid.net/specs/openid-connect-prompt-create-1_0.html).
     Create,
+
+    /// An unknown value.
+    #[display("{0}")]
+    Unknown(String),
 }
 
 /// The body of a request to the [Authorization Endpoint].


### PR DESCRIPTION
Needed for interacting with the Keycloak and Okta servers in the OIDC Playground.

I changed the error name for `CallbackDestination` because it's not only about the redirect URI now. Also there's one unused variant (about the query params) that I left, maybe I should remove it.