### PR TITLE
Disable the Prometheus feature by default

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -186,9 +186,6 @@ jobs:
           rustup default 1.65.0
           rustup component add clippy
 
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v1
-
       - name: Setup OPA
         uses: open-policy-agent/setup-opa@v2.0.1
         with:
@@ -245,9 +242,6 @@ jobs:
         run: |
           rustup toolchain install ${{ matrix.toolchain }}
           rustup default ${{ matrix.toolchain }}
-
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v1
 
       - name: Setup OPA
         uses: open-policy-agent/setup-opa@v2.0.1
@@ -310,9 +304,6 @@ jobs:
           rustup toolchain install stable
           rustup default stable
           rustup component add llvm-tools-preview
-
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v1
 
       - name: Setup OPA
         uses: open-policy-agent/setup-opa@v2.0.1

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -57,7 +57,7 @@ mas-templates = { path = "../templates" }
 indoc = "1.0.7"
 
 [features]
-default = ["jaeger", "zipkin", "prometheus", "webpki-roots", "policy-cache"]
+default = ["jaeger", "zipkin", "webpki-roots", "policy-cache"]
 
 # Features used in the Docker image
 docker = ["otlp", "jaeger", "zipkin", "prometheus", "native-roots", "mas-config/docker"]


### PR DESCRIPTION
It remains enabled in the Docker image, but this avoids having to have
protoc installed to build the binary
