### PR TITLE
Make the OIDC issuer a string instead of a URL

### DIFF
--- a/crates/handlers/src/oauth2/discovery.rs
+++ b/crates/handlers/src/oauth2/discovery.rs
@@ -47,7 +47,7 @@ pub(crate) async fn get(
     let jwt_signing_alg_values_supported = Some(key_store.available_signing_algorithms());
 
     // Prepare all the endpoints
-    let issuer = Some(url_builder.oidc_issuer());
+    let issuer = Some(url_builder.oidc_issuer().into());
     let authorization_endpoint = Some(url_builder.oauth_authorization_endpoint());
     let token_endpoint = Some(url_builder.oauth_token_endpoint());
     let jwks_uri = Some(url_builder.jwks_uri());

--- a/crates/oidc-client/src/requests/discovery.rs
+++ b/crates/oidc-client/src/requests/discovery.rs
@@ -31,11 +31,11 @@ use crate::{
 /// Fetch the provider metadata.
 async fn discover_inner(
     http_service: &HttpService,
-    issuer: &Url,
+    issuer: Url,
 ) -> Result<ProviderMetadata, DiscoveryError> {
     tracing::debug!("Fetching provider metadata...");
 
-    let mut config_url = issuer.clone();
+    let mut config_url = issuer;
 
     // If the path doesn't end with a slash, the last segment is removed when
     // using `join`.
@@ -69,9 +69,9 @@ async fn discover_inner(
 #[tracing::instrument(skip_all, fields(issuer))]
 pub async fn discover(
     http_service: &HttpService,
-    issuer: &Url,
+    issuer: &str,
 ) -> Result<VerifiedProviderMetadata, DiscoveryError> {
-    let provider_metadata = discover_inner(http_service, issuer).await?;
+    let provider_metadata = discover_inner(http_service, issuer.parse()?).await?;
 
     Ok(provider_metadata.validate(issuer)?)
 }
@@ -101,9 +101,9 @@ pub async fn discover(
 #[tracing::instrument(skip_all, fields(issuer))]
 pub async fn insecure_discover(
     http_service: &HttpService,
-    issuer: &Url,
+    issuer: &str,
 ) -> Result<VerifiedProviderMetadata, DiscoveryError> {
-    let provider_metadata = discover_inner(http_service, issuer).await?;
+    let provider_metadata = discover_inner(http_service, issuer.parse()?).await?;
 
     Ok(provider_metadata.insecure_verify_metadata()?)
 }

--- a/crates/oidc-client/src/requests/jose.rs
+++ b/crates/oidc-client/src/requests/jose.rs
@@ -66,7 +66,7 @@ pub async fn fetch_jwks(
 #[derive(Clone, Copy)]
 pub struct JwtVerificationData<'a> {
     /// The URL of the issuer that generated the ID Token.
-    pub issuer: &'a Url,
+    pub issuer: &'a str,
 
     /// The issuer's JWKS.
     pub jwks: &'a PublicJsonWebKeySet,
@@ -127,7 +127,7 @@ pub fn verify_signed_jwt<'a>(
     let (header, mut claims) = jwt.clone().into_parts();
 
     // Must have the proper issuer.
-    claims::ISS.extract_required_with_options(&mut claims, issuer.as_str())?;
+    claims::ISS.extract_required_with_options(&mut claims, issuer)?;
 
     // Must have the proper audience.
     claims::AUD.extract_required_with_options(&mut claims, client_id)?;

--- a/crates/oidc-client/tests/it/main.rs
+++ b/crates/oidc-client/tests/it/main.rs
@@ -87,7 +87,7 @@ fn keystore(alg: &JsonWebSignatureAlg) -> Keystore {
 }
 
 /// Generate an ID token.
-fn id_token(issuer: &Url) -> (IdToken, PublicJsonWebKeySet) {
+fn id_token(issuer: &str) -> (IdToken, PublicJsonWebKeySet) {
     let signing_alg = ID_TOKEN_SIGNING_ALG;
 
     let keystore = keystore(&signing_alg);

--- a/crates/oidc-client/tests/it/requests/authorization_code.rs
+++ b/crates/oidc-client/tests/it/requests/authorization_code.rs
@@ -262,9 +262,9 @@ async fn pass_access_token_with_authorization_code() {
         code_challenge_verifier: Some(CODE_VERIFIER.to_owned()),
     };
 
-    let (id_token, jwks) = id_token(&issuer);
+    let (id_token, jwks) = id_token(issuer.as_str());
     let id_token_verification_data = JwtVerificationData {
-        issuer: &issuer,
+        issuer: issuer.as_str(),
         jwks: &jwks,
         client_id: &CLIENT_ID.to_owned(),
         signing_algorithm: &ID_TOKEN_SIGNING_ALG,
@@ -321,9 +321,9 @@ async fn fail_access_token_with_authorization_code_wrong_nonce() {
         code_challenge_verifier: Some(CODE_VERIFIER.to_owned()),
     };
 
-    let (id_token, jwks) = id_token(&issuer);
+    let (id_token, jwks) = id_token(issuer.as_str());
     let id_token_verification_data = JwtVerificationData {
-        issuer: &issuer,
+        issuer: issuer.as_str(),
         jwks: &jwks,
         client_id: &CLIENT_ID.to_owned(),
         signing_algorithm: &ID_TOKEN_SIGNING_ALG,
@@ -385,7 +385,7 @@ async fn fail_access_token_with_authorization_code_no_id_token() {
     };
 
     let id_token_verification_data = JwtVerificationData {
-        issuer: &issuer,
+        issuer: issuer.as_str(),
         jwks: &PublicJsonWebKeySet::default(),
         client_id: &CLIENT_ID.to_owned(),
         signing_algorithm: &ID_TOKEN_SIGNING_ALG,

--- a/crates/oidc-client/tests/it/requests/discovery.rs
+++ b/crates/oidc-client/tests/it/requests/discovery.rs
@@ -30,7 +30,7 @@ use crate::init_test;
 
 fn provider_metadata(issuer: &Url) -> ProviderMetadata {
     ProviderMetadata {
-        issuer: Some(issuer.clone()),
+        issuer: Some(issuer.as_str().to_owned()),
         authorization_endpoint: issuer.join("authorize").ok(),
         token_endpoint: issuer.join("token").ok(),
         jwks_uri: issuer.join("jwks").ok(),
@@ -52,16 +52,18 @@ async fn pass_discover() {
         .mount(&mock_server)
         .await;
 
-    let provider_metadata = insecure_discover(&http_service, &issuer).await.unwrap();
+    let provider_metadata = insecure_discover(&http_service, issuer.as_str())
+        .await
+        .unwrap();
 
-    assert_eq!(*provider_metadata.issuer(), issuer);
+    assert_eq!(provider_metadata.issuer(), issuer.as_str());
 }
 
 #[tokio::test]
 async fn fail_discover_404() {
     let (http_service, _mock_server, issuer) = init_test().await;
 
-    let error = discover(&http_service, &issuer).await.unwrap_err();
+    let error = discover(&http_service, issuer.as_str()).await.unwrap_err();
 
     assert_matches!(error, DiscoveryError::Http(_));
 }
@@ -76,7 +78,7 @@ async fn fail_discover_not_json() {
         .mount(&mock_server)
         .await;
 
-    let error = discover(&http_service, &issuer).await.unwrap_err();
+    let error = discover(&http_service, issuer.as_str()).await.unwrap_err();
 
     assert_matches!(error, DiscoveryError::FromJson(_));
 }
@@ -91,7 +93,7 @@ async fn fail_discover_invalid_metadata() {
         .mount(&mock_server)
         .await;
 
-    let error = discover(&http_service, &issuer).await.unwrap_err();
+    let error = discover(&http_service, issuer.as_str()).await.unwrap_err();
 
     assert_matches!(error, DiscoveryError::Validation(_));
 }

--- a/crates/oidc-client/tests/it/requests/userinfo.rs
+++ b/crates/oidc-client/tests/it/requests/userinfo.rs
@@ -29,7 +29,7 @@ use crate::{id_token, init_test, ACCESS_TOKEN, SUBJECT_IDENTIFIER};
 async fn pass_fetch_userinfo() {
     let (http_service, mock_server, issuer) = init_test().await;
     let userinfo_endpoint = issuer.join("userinfo").unwrap();
-    let (auth_id_token, _) = id_token(&issuer);
+    let (auth_id_token, _) = id_token(issuer.as_str());
 
     Mock::given(method("GET"))
         .and(path("/userinfo"))
@@ -61,7 +61,7 @@ async fn pass_fetch_userinfo() {
 async fn fail_wrong_subject_identifier() {
     let (http_service, mock_server, issuer) = init_test().await;
     let userinfo_endpoint = issuer.join("userinfo").unwrap();
-    let (auth_id_token, _) = id_token(&issuer);
+    let (auth_id_token, _) = id_token(issuer.as_str());
 
     Mock::given(method("GET"))
         .and(path("/userinfo"))


### PR DESCRIPTION
`url::Url` normalizes the URL a bit, by, for example, adding a trailing slash if the URL path is empty.
This is an issue for example with `https://account.google.com`, which doesn't have a trailing slash ; but then when verifying the `iss` in the ID token, it mismatches because of that normalization.

This changes the issuer in the provider metadata with a string instead.

cc @zecakeh 