### PR TITLE
Modular password hasher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2684,7 +2684,6 @@ name = "mas-cli"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "argon2",
  "atty",
  "axum",
  "camino",
@@ -3101,21 +3100,16 @@ dependencies = [
 name = "mas-storage"
 version = "0.1.0"
 dependencies = [
- "anyhow",
- "argon2",
  "chrono",
  "mas-data-model",
  "mas-iana",
  "mas-jose",
  "oauth2-types",
- "password-hash",
  "rand 0.8.5",
- "rand_chacha 0.3.1",
  "serde",
  "serde_json",
  "sqlx",
  "thiserror",
- "tokio",
  "tracing",
  "ulid",
  "url",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -705,6 +705,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b645a089122eccb6111b4f81cbc1a49f5900ac4666bb93ac027feaecf15607bf"
 
 [[package]]
+name = "bcrypt"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7e7c93a3fb23b2fdde989b2c9ec4dd153063ec81f408507f84c090cd91c6641"
+dependencies = [
+ "base64",
+ "blowfish",
+ "getrandom 0.2.8",
+ "zeroize",
+]
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -744,6 +756,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a90ec2df9600c28a01c56c4784c9207a96d2451833aeceb8cc97e4c9548bb78"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "blowfish"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e412e2cd0f2b2d93e02543ceae7917b3c70331573df19ee046bcbc35e45e87d7"
+dependencies = [
+ "byteorder",
+ "cipher",
 ]
 
 [[package]]
@@ -2805,12 +2827,14 @@ dependencies = [
  "axum",
  "axum-extra",
  "axum-macros",
+ "bcrypt",
  "camino",
  "chrono",
  "futures-util",
  "headers",
  "hyper",
  "indoc",
+ "insta",
  "lettre",
  "mas-axum-utils",
  "mas-data-model",
@@ -2827,6 +2851,7 @@ dependencies = [
  "mas-templates",
  "mime",
  "oauth2-types",
+ "pbkdf2",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "serde",
@@ -2842,6 +2867,7 @@ dependencies = [
  "tracing",
  "ulid",
  "url",
+ "zeroize",
 ]
 
 [[package]]
@@ -3728,6 +3754,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
 dependencies = [
  "digest",
+ "hmac",
+ "password-hash",
+ "sha2",
 ]
 
 [[package]]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -7,7 +7,6 @@ license = "Apache-2.0"
 
 [dependencies]
 anyhow = "1.0.66"
-argon2 = { version = "0.4.1", features = ["password-hash"] }
 atty = "0.2.14"
 axum = "0.6.1"
 camino = "1.1.1"

--- a/crates/cli/src/commands/server.rs
+++ b/crates/cli/src/commands/server.rs
@@ -20,7 +20,7 @@ use futures_util::stream::{StreamExt, TryStreamExt};
 use itertools::Itertools;
 use mas_config::RootConfig;
 use mas_email::Mailer;
-use mas_handlers::{AppState, HttpClientFactory, MatrixHomeserver};
+use mas_handlers::{passwords::PasswordManager, AppState, HttpClientFactory, MatrixHomeserver};
 use mas_listener::{server::Server, shutdown::ShutdownStream};
 use mas_policy::PolicyFactory;
 use mas_router::UrlBuilder;
@@ -168,6 +168,24 @@ impl Options {
 
         let listeners_config = config.http.listeners.clone();
 
+        let password_manager = config
+            .passwords
+            .load()
+            .await
+            .context("failed to load the password schemes")?
+            .into_iter()
+            .map(|(version, algorithm, secret)| {
+                use mas_handlers::passwords::Hasher;
+                let hasher = match algorithm {
+                    mas_config::PasswordAlgorithm::Pbkdf2 => Hasher::pbkdf2(secret),
+                    mas_config::PasswordAlgorithm::Bcrypt { cost } => Hasher::bcrypt(cost, secret),
+                    mas_config::PasswordAlgorithm::Argon2id => Hasher::argon2id(secret),
+                };
+
+                (version, hasher)
+            });
+        let password_manager = PasswordManager::new(password_manager)?;
+
         // Explicitely the config to properly zeroize secret keys
         drop(config);
 
@@ -199,6 +217,7 @@ impl Options {
             policy_factory,
             graphql_schema,
             http_client_factory,
+            password_manager,
         };
 
         let mut fd_manager = listenfd::ListenFd::from_env();

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -28,6 +28,7 @@ use tracing_subscriber::{
 mod commands;
 mod server;
 mod telemetry;
+mod util;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {

--- a/crates/cli/src/util.rs
+++ b/crates/cli/src/util.rs
@@ -1,0 +1,37 @@
+// Copyright 2022 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use mas_config::PasswordsConfig;
+use mas_handlers::passwords::PasswordManager;
+
+pub async fn password_manager_from_config(
+    config: &PasswordsConfig,
+) -> Result<PasswordManager, anyhow::Error> {
+    let schemes = config
+        .load()
+        .await?
+        .into_iter()
+        .map(|(version, algorithm, secret)| {
+            use mas_handlers::passwords::Hasher;
+            let hasher = match algorithm {
+                mas_config::PasswordAlgorithm::Pbkdf2 => Hasher::pbkdf2(secret),
+                mas_config::PasswordAlgorithm::Bcrypt { cost } => Hasher::bcrypt(cost, secret),
+                mas_config::PasswordAlgorithm::Argon2id => Hasher::argon2id(secret),
+            };
+
+            (version, hasher)
+        });
+
+    PasswordManager::new(schemes)
+}

--- a/crates/config/src/sections/mod.rs
+++ b/crates/config/src/sections/mod.rs
@@ -23,6 +23,7 @@ mod database;
 mod email;
 mod http;
 mod matrix;
+mod passwords;
 mod policy;
 mod secrets;
 mod telemetry;
@@ -38,6 +39,7 @@ pub use self::{
         Resource as HttpResource, TlsConfig as HttpTlsConfig, UnixOrTcp,
     },
     matrix::MatrixConfig,
+    passwords::{Algorithm as PasswordAlgorithm, PasswordsConfig},
     policy::PolicyConfig,
     secrets::SecretsConfig,
     telemetry::{
@@ -82,6 +84,10 @@ pub struct RootConfig {
     /// Application secrets
     pub secrets: SecretsConfig,
 
+    /// Configuration related to user passwords
+    #[serde(default)]
+    pub passwords: PasswordsConfig,
+
     /// Configuration related to the homeserver
     #[serde(default)]
     pub matrix: MatrixConfig,
@@ -109,6 +115,7 @@ impl ConfigurationSection<'_> for RootConfig {
             templates: TemplatesConfig::generate(&mut rng).await?,
             csrf: CsrfConfig::generate(&mut rng).await?,
             email: EmailConfig::generate(&mut rng).await?,
+            passwords: PasswordsConfig::generate(&mut rng).await?,
             secrets: SecretsConfig::generate(&mut rng).await?,
             matrix: MatrixConfig::generate(&mut rng).await?,
             policy: PolicyConfig::generate(&mut rng).await?,
@@ -122,6 +129,7 @@ impl ConfigurationSection<'_> for RootConfig {
             database: DatabaseConfig::test(),
             telemetry: TelemetryConfig::test(),
             templates: TemplatesConfig::test(),
+            passwords: PasswordsConfig::test(),
             csrf: CsrfConfig::test(),
             email: EmailConfig::test(),
             secrets: SecretsConfig::test(),

--- a/crates/config/src/sections/passwords.rs
+++ b/crates/config/src/sections/passwords.rs
@@ -1,0 +1,156 @@
+// Copyright 2022 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::borrow::Cow;
+
+use anyhow::bail;
+use async_trait::async_trait;
+use camino::Utf8PathBuf;
+use rand::Rng;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::ConfigurationSection;
+
+fn default_schemes() -> Vec<HashingScheme> {
+    vec![HashingScheme {
+        version: 1,
+        algorithm: Algorithm::Argon2id,
+        secret: None,
+    }]
+}
+
+/// User password hashing config
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct PasswordsConfig {
+    #[serde(default = "default_schemes")]
+    schemes: Vec<HashingScheme>,
+}
+
+impl Default for PasswordsConfig {
+    fn default() -> Self {
+        Self {
+            schemes: default_schemes(),
+        }
+    }
+}
+
+#[async_trait]
+impl ConfigurationSection<'_> for PasswordsConfig {
+    fn path() -> &'static str {
+        "passwords"
+    }
+
+    async fn generate<R>(_rng: R) -> anyhow::Result<Self>
+    where
+        R: Rng + Send,
+    {
+        Ok(Self::default())
+    }
+
+    fn test() -> Self {
+        Self::default()
+    }
+}
+
+impl PasswordsConfig {
+    /// Load the password hashing schemes defined by the config
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the config is invalid, or if the secret file could
+    /// not be read.
+    pub async fn load(&self) -> Result<Vec<(u16, Algorithm, Option<Vec<u8>>)>, anyhow::Error> {
+        let mut schemes: Vec<&HashingScheme> = self.schemes.iter().collect();
+        schemes.sort_unstable_by_key(|a| a.version);
+        schemes.dedup_by_key(|a| a.version);
+        schemes.reverse();
+
+        if schemes.len() != self.schemes.len() {
+            // Some schemes had duplicated versions
+            bail!("Multiple password schemes have the same versions");
+        }
+
+        if schemes.is_empty() {
+            bail!("Requires at least one password scheme in the config");
+        }
+
+        let mut mapped_result = Vec::with_capacity(schemes.len());
+
+        for scheme in schemes {
+            let secret = if let Some(secret_or_file) = &scheme.secret {
+                Some(secret_or_file.load().await?.into_owned())
+            } else {
+                None
+            };
+
+            mapped_result.push((scheme.version, scheme.algorithm, secret));
+        }
+
+        Ok(mapped_result)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum SecretOrFile {
+    Secret(String),
+    #[schemars(with = "String")]
+    SecretFile(Utf8PathBuf),
+}
+
+impl SecretOrFile {
+    async fn load(&self) -> Result<Cow<'_, [u8]>, std::io::Error> {
+        match self {
+            Self::Secret(secret) => Ok(Cow::Borrowed(secret.as_bytes())),
+            Self::SecretFile(path) => {
+                let secret = tokio::fs::read(path).await?;
+                Ok(Cow::Owned(secret))
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct HashingScheme {
+    version: u16,
+
+    #[serde(flatten)]
+    algorithm: Algorithm,
+
+    #[serde(flatten)]
+    secret: Option<SecretOrFile>,
+}
+
+fn default_bcrypt_cost() -> u32 {
+    12
+}
+
+/// A hashing algorithm
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "lowercase", tag = "algorithm")]
+pub enum Algorithm {
+    /// bcrypt
+    Bcrypt {
+        /// Hashing cost
+        #[serde(default = "default_bcrypt_cost")]
+        cost: u32,
+    },
+
+    /// argon2id
+    Argon2id,
+
+    /// PBKDF2
+    Pbkdf2,
+}

--- a/crates/data-model/src/lib.rs
+++ b/crates/data-model/src/lib.rs
@@ -43,7 +43,7 @@ pub use self::{
         UpstreamOAuthAuthorizationSession, UpstreamOAuthLink, UpstreamOAuthProvider,
     },
     users::{
-        Authentication, BrowserSession, User, UserEmail, UserEmailVerification,
+        Authentication, BrowserSession, Password, User, UserEmail, UserEmailVerification,
         UserEmailVerificationState,
     },
 };

--- a/crates/data-model/src/users.rs
+++ b/crates/data-model/src/users.rs
@@ -38,6 +38,15 @@ impl User {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct Password {
+    pub id: Ulid,
+    pub hashed_password: String,
+    pub version: u16,
+    pub upgraded_from_id: Option<Ulid>,
+    pub created_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct Authentication {
     pub id: Ulid,
     pub created_at: DateTime<Utc>,

--- a/crates/handlers/Cargo.toml
+++ b/crates/handlers/Cargo.toml
@@ -40,7 +40,10 @@ serde_json = "1.0.89"
 serde_urlencoded = "0.7.1"
 
 # Password hashing
-argon2 = { version = "0.4.1", features = ["password-hash"] }
+argon2 = { version = "0.4.1", features = ["password-hash", "std"] }
+bcrypt = "0.13.0"
+pbkdf2 = { version = "0.11.0", features = ["password-hash", "std"] }
+zeroize = "1.5.7"
 
 # Various data types and utilities
 camino = "1.1.1"
@@ -70,6 +73,7 @@ oauth2-types = { path = "../oauth2-types" }
 
 [dev-dependencies]
 indoc = "1.0.7"
+insta = "1.22.0"
 
 [features]
 # Use the native root certificates

--- a/crates/handlers/src/app_state.rs
+++ b/crates/handlers/src/app_state.rs
@@ -23,7 +23,7 @@ use mas_router::UrlBuilder;
 use mas_templates::Templates;
 use sqlx::PgPool;
 
-use crate::MatrixHomeserver;
+use crate::{passwords::PasswordManager, MatrixHomeserver};
 
 #[derive(Clone)]
 pub struct AppState {
@@ -37,6 +37,7 @@ pub struct AppState {
     pub policy_factory: Arc<PolicyFactory>,
     pub graphql_schema: mas_graphql::Schema,
     pub http_client_factory: HttpClientFactory,
+    pub password_manager: PasswordManager,
 }
 
 impl FromRef<AppState> for PgPool {
@@ -92,8 +93,15 @@ impl FromRef<AppState> for Arc<PolicyFactory> {
         input.policy_factory.clone()
     }
 }
+
 impl FromRef<AppState> for HttpClientFactory {
     fn from_ref(input: &AppState) -> Self {
         input.http_client_factory.clone()
+    }
+}
+
+impl FromRef<AppState> for PasswordManager {
+    fn from_ref(input: &AppState) -> Self {
+        input.password_manager.clone()
     }
 }

--- a/crates/handlers/src/lib.rs
+++ b/crates/handlers/src/lib.rs
@@ -41,6 +41,7 @@ use mas_keystore::{Encrypter, Keystore};
 use mas_policy::PolicyFactory;
 use mas_router::{Route, UrlBuilder};
 use mas_templates::{ErrorContext, Templates};
+use passwords::PasswordManager;
 use rand::SeedableRng;
 use sqlx::PgPool;
 use tower::util::AndThenLayer;
@@ -253,6 +254,7 @@ where
     Mailer: FromRef<S>,
     Keystore: FromRef<S>,
     HttpClientFactory: FromRef<S>,
+    PasswordManager: FromRef<S>,
 {
     Router::new()
         .route(
@@ -351,7 +353,7 @@ where
 async fn test_state(pool: PgPool) -> Result<AppState, anyhow::Error> {
     use mas_email::MailTransport;
 
-    use crate::passwords::{Hasher, PasswordManager};
+    use crate::passwords::Hasher;
 
     let workspace_root = camino::Utf8Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("..")

--- a/crates/handlers/src/lib.rs
+++ b/crates/handlers/src/lib.rs
@@ -51,6 +51,7 @@ mod compat;
 mod graphql;
 mod health;
 mod oauth2;
+pub mod passwords;
 mod upstream_oauth2;
 mod views;
 
@@ -350,6 +351,8 @@ where
 async fn test_state(pool: PgPool) -> Result<AppState, anyhow::Error> {
     use mas_email::MailTransport;
 
+    use crate::passwords::{Hasher, PasswordManager};
+
     let workspace_root = camino::Utf8Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("..")
         .join("..");
@@ -362,6 +365,8 @@ async fn test_state(pool: PgPool) -> Result<AppState, anyhow::Error> {
     let key_store = Keystore::default();
 
     let encrypter = Encrypter::new(&[0x42; 32]);
+
+    let password_manager = PasswordManager::new([(1, Hasher::argon2id(None))])?;
 
     let transport = MailTransport::blackhole();
     let mailbox = "server@example.com".parse()?;
@@ -397,6 +402,7 @@ async fn test_state(pool: PgPool) -> Result<AppState, anyhow::Error> {
         policy_factory,
         graphql_schema,
         http_client_factory,
+        password_manager,
     })
 }
 

--- a/crates/handlers/src/lib.rs
+++ b/crates/handlers/src/lib.rs
@@ -208,6 +208,7 @@ where
     UrlBuilder: FromRef<S>,
     PgPool: FromRef<S>,
     MatrixHomeserver: FromRef<S>,
+    PasswordManager: FromRef<S>,
 {
     Router::new()
         .route(

--- a/crates/handlers/src/passwords.rs
+++ b/crates/handlers/src/passwords.rs
@@ -1,0 +1,542 @@
+// Copyright 2022 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{collections::HashMap, sync::Arc};
+
+use anyhow::Context;
+use argon2::{password_hash::SaltString, Argon2, PasswordHash, PasswordHasher, PasswordVerifier};
+use futures_util::future::OptionFuture;
+use pbkdf2::Pbkdf2;
+use rand::{CryptoRng, Rng, RngCore, SeedableRng};
+use zeroize::Zeroizing;
+
+pub type SchemeVersion = u32;
+
+#[derive(Clone)]
+pub struct PasswordManager {
+    hashers: Arc<HashMap<SchemeVersion, Hasher>>,
+    default_hasher: SchemeVersion,
+}
+
+impl PasswordManager {
+    /// Creates a new [`PasswordManager`] from an iterator. The first item in
+    /// the iterator will be the default hashing scheme.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// pub use mas_handlers::passwords::{PasswordManager, Hasher};
+    ///
+    /// PasswordManager::new([
+    ///     (3, Hasher::argon2id(Some(b"a-secret-pepper".to_vec()))),
+    ///     (2, Hasher::argon2id(None)),
+    ///     (1, Hasher::bcrypt(10, None)),
+    /// ]).unwrap();
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the iterator was empty
+    pub fn new<I: IntoIterator<Item = (SchemeVersion, Hasher)>>(
+        iter: I,
+    ) -> Result<Self, anyhow::Error> {
+        let mut iter = iter.into_iter().peekable();
+        let (default_hasher, _) = iter
+            .peek()
+            .context("Iterator must have at least one item")?;
+        let default_hasher = *default_hasher;
+
+        let hashers = iter.collect();
+
+        Ok(Self {
+            hashers: Arc::new(hashers),
+            default_hasher,
+        })
+    }
+
+    /// Hash a password with the default hashing scheme.
+    /// Returns the version of the hashing scheme used and the hashed password.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the hashing failed
+    pub async fn hash<R: CryptoRng + RngCore + Send>(
+        &self,
+        rng: R,
+        password: Zeroizing<Vec<u8>>,
+    ) -> Result<(SchemeVersion, String), anyhow::Error> {
+        // Seed a future-local RNG so the RNG passed in parameters doesn't have to be
+        // 'static
+        let mut rng = rand_chacha::ChaChaRng::from_rng(rng)?;
+        let hashers = self.hashers.clone();
+        let default_hasher_version = self.default_hasher;
+
+        let hashed = tokio::task::spawn_blocking(move || {
+            let default_hasher = hashers
+                .get(&default_hasher_version)
+                .context("Default hasher not found")?;
+
+            default_hasher.hash_blocking(&mut rng, &password)
+        })
+        .await??;
+
+        Ok((default_hasher_version, hashed))
+    }
+
+    /// Verify a password hash for the given hashing scheme.
+    async fn verify(
+        &self,
+        scheme: SchemeVersion,
+        password: Zeroizing<Vec<u8>>,
+        hashed_password: String,
+    ) -> Result<(), anyhow::Error> {
+        let hashers = self.hashers.clone();
+
+        tokio::task::spawn_blocking(move || {
+            let hasher = hashers.get(&scheme).context("Hashing scheme not found")?;
+            hasher.verify_blocking(&hashed_password, &password)
+        })
+        .await??;
+
+        Ok(())
+    }
+
+    /// Verify a password hash for the given hashing scheme, and upgrade it on
+    /// the fly, if it was not hashed with the default scheme
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the password hash verification failed
+    pub async fn verify_and_upgrade<R: CryptoRng + RngCore + Send>(
+        &self,
+        rng: R,
+        scheme: SchemeVersion,
+        password: Zeroizing<Vec<u8>>,
+        hashed_password: String,
+    ) -> Result<Option<(SchemeVersion, String)>, anyhow::Error> {
+        // If the current scheme isn't the default one, we also hash with the default
+        // one so that
+        let new_hash_fut: OptionFuture<_> = (scheme != self.default_hasher)
+            .then(|| self.hash(rng, password.clone()))
+            .into();
+
+        let verify_fut = self.verify(scheme, password, hashed_password);
+
+        let (new_hash_res, verify_res) = tokio::join!(new_hash_fut, verify_fut);
+        verify_res?;
+
+        let new_hash = new_hash_res.transpose()?;
+
+        Ok(new_hash)
+    }
+}
+
+/// A hashing scheme, with an optional pepper
+pub struct Hasher {
+    algorithm: Algorithm,
+    pepper: Option<Vec<u8>>,
+}
+
+impl Hasher {
+    /// Creates a new hashing scheme based on the bcrypt algorithm
+    #[must_use]
+    pub const fn bcrypt(cost: u32, pepper: Option<Vec<u8>>) -> Self {
+        let algorithm = Algorithm::Bcrypt { cost };
+        Self { algorithm, pepper }
+    }
+
+    /// Creates a new hashing scheme based on the argon2id algorithm
+    #[must_use]
+    pub const fn argon2id(pepper: Option<Vec<u8>>) -> Self {
+        let algorithm = Algorithm::Argon2id;
+        Self { algorithm, pepper }
+    }
+
+    /// Creates a new hashing scheme based on the pbkdf2 algorithm
+    #[must_use]
+    pub const fn pbkdf2(pepper: Option<Vec<u8>>) -> Self {
+        let algorithm = Algorithm::Pbkdf2;
+        Self { algorithm, pepper }
+    }
+
+    fn hash_blocking<R: CryptoRng + RngCore>(
+        &self,
+        rng: &mut R,
+        password: &[u8],
+    ) -> Result<String, anyhow::Error> {
+        self.algorithm
+            .hash_blocking(rng, password, self.pepper.as_deref())
+    }
+
+    fn verify_blocking(&self, hashed_password: &str, password: &[u8]) -> Result<(), anyhow::Error> {
+        self.algorithm
+            .verify_blocking(hashed_password, password, self.pepper.as_deref())
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum Algorithm {
+    Bcrypt { cost: u32 },
+    Argon2id,
+    Pbkdf2,
+}
+
+impl Algorithm {
+    fn hash_blocking<R: CryptoRng + RngCore>(
+        self,
+        rng: &mut R,
+        password: &[u8],
+        pepper: Option<&[u8]>,
+    ) -> Result<String, anyhow::Error> {
+        match self {
+            Self::Bcrypt { cost } => {
+                let mut password = Zeroizing::new(password.to_vec());
+                if let Some(pepper) = pepper {
+                    password.extend_from_slice(pepper);
+                }
+
+                let salt = rng.gen();
+
+                let hashed = bcrypt::hash_with_salt(password, cost, salt)?;
+                Ok(hashed.format_for_version(bcrypt::Version::TwoB))
+            }
+
+            Self::Argon2id => {
+                let algorithm = argon2::Algorithm::default();
+                let version = argon2::Version::default();
+                let params = argon2::Params::default();
+
+                let phf = if let Some(secret) = pepper {
+                    Argon2::new_with_secret(secret, algorithm, version, params)?
+                } else {
+                    Argon2::new(algorithm, version, params)
+                };
+
+                let salt = SaltString::generate(rng);
+                let hashed = phf.hash_password(password.as_ref(), &salt)?;
+                Ok(hashed.to_string())
+            }
+
+            Self::Pbkdf2 => {
+                let mut password = Zeroizing::new(password.to_vec());
+                if let Some(pepper) = pepper {
+                    password.extend_from_slice(pepper);
+                }
+
+                let salt = SaltString::generate(rng);
+                let hashed = Pbkdf2.hash_password(password.as_ref(), &salt)?;
+                Ok(hashed.to_string())
+            }
+        }
+    }
+
+    fn verify_blocking(
+        self,
+        hashed_password: &str,
+        password: &[u8],
+        pepper: Option<&[u8]>,
+    ) -> Result<(), anyhow::Error> {
+        match self {
+            Algorithm::Bcrypt { .. } => {
+                let mut password = Zeroizing::new(password.to_vec());
+                if let Some(pepper) = pepper {
+                    password.extend_from_slice(pepper);
+                }
+
+                let result = bcrypt::verify(password, hashed_password)?;
+                anyhow::ensure!(result, "wrong password");
+            }
+
+            Algorithm::Argon2id => {
+                let algorithm = argon2::Algorithm::default();
+                let version = argon2::Version::default();
+                let params = argon2::Params::default();
+
+                let phf = if let Some(secret) = pepper {
+                    Argon2::new_with_secret(secret, algorithm, version, params)?
+                } else {
+                    Argon2::new(algorithm, version, params)
+                };
+
+                let hashed_password = PasswordHash::new(hashed_password)?;
+
+                phf.verify_password(password.as_ref(), &hashed_password)?;
+            }
+
+            Algorithm::Pbkdf2 => {
+                let mut password = Zeroizing::new(password.to_vec());
+                if let Some(pepper) = pepper {
+                    password.extend_from_slice(pepper);
+                }
+
+                let hashed_password = PasswordHash::new(hashed_password)?;
+
+                Pbkdf2.verify_password(password.as_ref(), &hashed_password)?;
+            }
+        };
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rand::SeedableRng;
+
+    use super::*;
+
+    #[test]
+    fn hashing_bcrypt() {
+        let mut rng = rand_chacha::ChaChaRng::seed_from_u64(42);
+        let password = b"hunter2";
+        let password2 = b"wrong-password";
+        let pepper = b"a-secret-pepper";
+        let pepper2 = b"the-wrong-pepper";
+
+        let alg = Algorithm::Bcrypt { cost: 10 };
+        // Hash with a pepper
+        let hash = alg
+            .hash_blocking(&mut rng, password, Some(pepper))
+            .expect("Couldn't hash password");
+        insta::assert_snapshot!(hash);
+
+        assert!(alg.verify_blocking(&hash, password, Some(pepper)).is_ok());
+        assert!(alg.verify_blocking(&hash, password2, Some(pepper)).is_err());
+        assert!(alg.verify_blocking(&hash, password, Some(pepper2)).is_err());
+        assert!(alg.verify_blocking(&hash, password, None).is_err());
+
+        // Hash without pepper
+        let hash = alg
+            .hash_blocking(&mut rng, password, None)
+            .expect("Couldn't hash password");
+        insta::assert_snapshot!(hash);
+
+        assert!(alg.verify_blocking(&hash, password, None).is_ok());
+        assert!(alg.verify_blocking(&hash, password2, None).is_err());
+        assert!(alg.verify_blocking(&hash, password, Some(pepper)).is_err());
+    }
+
+    #[test]
+    fn hashing_argon2id() {
+        let mut rng = rand_chacha::ChaChaRng::seed_from_u64(42);
+        let password = b"hunter2";
+        let password2 = b"wrong-password";
+        let pepper = b"a-secret-pepper";
+        let pepper2 = b"the-wrong-pepper";
+
+        let alg = Algorithm::Argon2id;
+        // Hash with a pepper
+        let hash = alg
+            .hash_blocking(&mut rng, password, Some(pepper))
+            .expect("Couldn't hash password");
+        insta::assert_snapshot!(hash);
+
+        assert!(alg.verify_blocking(&hash, password, Some(pepper)).is_ok());
+        assert!(alg.verify_blocking(&hash, password2, Some(pepper)).is_err());
+        assert!(alg.verify_blocking(&hash, password, Some(pepper2)).is_err());
+        assert!(alg.verify_blocking(&hash, password, None).is_err());
+
+        // Hash without pepper
+        let hash = alg
+            .hash_blocking(&mut rng, password, None)
+            .expect("Couldn't hash password");
+        insta::assert_snapshot!(hash);
+
+        assert!(alg.verify_blocking(&hash, password, None).is_ok());
+        assert!(alg.verify_blocking(&hash, password2, None).is_err());
+        assert!(alg.verify_blocking(&hash, password, Some(pepper)).is_err());
+    }
+
+    #[test]
+    fn hashing_pbkdf2() {
+        let mut rng = rand_chacha::ChaChaRng::seed_from_u64(42);
+        let password = b"hunter2";
+        let password2 = b"wrong-password";
+        let pepper = b"a-secret-pepper";
+        let pepper2 = b"the-wrong-pepper";
+
+        let alg = Algorithm::Pbkdf2;
+        // Hash with a pepper
+        let hash = alg
+            .hash_blocking(&mut rng, password, Some(pepper))
+            .expect("Couldn't hash password");
+        insta::assert_snapshot!(hash);
+
+        assert!(alg.verify_blocking(&hash, password, Some(pepper)).is_ok());
+        assert!(alg.verify_blocking(&hash, password2, Some(pepper)).is_err());
+        assert!(alg.verify_blocking(&hash, password, Some(pepper2)).is_err());
+        assert!(alg.verify_blocking(&hash, password, None).is_err());
+
+        // Hash without pepper
+        let hash = alg
+            .hash_blocking(&mut rng, password, None)
+            .expect("Couldn't hash password");
+        insta::assert_snapshot!(hash);
+
+        assert!(alg.verify_blocking(&hash, password, None).is_ok());
+        assert!(alg.verify_blocking(&hash, password2, None).is_err());
+        assert!(alg.verify_blocking(&hash, password, Some(pepper)).is_err());
+    }
+
+    #[tokio::test]
+    async fn hash_verify_and_upgrade() {
+        // Tests the whole password manager, by hashing a password and upgrading it
+        // after changing the hashing schemes. The salt generation is done with a seeded
+        // RNG, so that we can do stable snapshots of hashed passwords
+        let mut rng = rand_chacha::ChaChaRng::seed_from_u64(42);
+        let password = Zeroizing::new(b"hunter2".to_vec());
+        let wrong_password = Zeroizing::new(b"wrong-password".to_vec());
+
+        let manager = PasswordManager::new([
+            // Start with one hashing scheme: the one used by synapse, bcrypt + pepper
+            (1, Hasher::bcrypt(10, Some(b"a-secret-pepper".to_vec()))),
+        ])
+        .unwrap();
+
+        let (version, hash) = manager
+            .hash(&mut rng, password.clone())
+            .await
+            .expect("Failed to hash");
+
+        assert_eq!(version, 1);
+        insta::assert_snapshot!(hash);
+
+        // Just verifying works
+        manager
+            .verify(version, password.clone(), hash.clone())
+            .await
+            .expect("Failed to verify");
+
+        // And doesn't work with the wrong password
+        manager
+            .verify(version, wrong_password.clone(), hash.clone())
+            .await
+            .expect_err("Verification should have failed");
+
+        // Verifying with the wrong version doesn't work
+        manager
+            .verify(2, password.clone(), hash.clone())
+            .await
+            .expect_err("Verification should have failed");
+
+        // Upgrading does nothing
+        let res = manager
+            .verify_and_upgrade(&mut rng, version, password.clone(), hash.clone())
+            .await
+            .expect("Failed to verify");
+
+        assert!(res.is_none());
+
+        // Upgrading still verify that the password matches
+        manager
+            .verify_and_upgrade(&mut rng, version, wrong_password.clone(), hash.clone())
+            .await
+            .expect_err("Verification should have failed");
+
+        let manager = PasswordManager::new([
+            (2, Hasher::argon2id(None)),
+            (1, Hasher::bcrypt(10, Some(b"a-secret-pepper".to_vec()))),
+        ])
+        .unwrap();
+
+        // Verifying still works
+        manager
+            .verify(version, password.clone(), hash.clone())
+            .await
+            .expect("Failed to verify");
+
+        // And doesn't work with the wrong password
+        manager
+            .verify(version, wrong_password.clone(), hash.clone())
+            .await
+            .expect_err("Verification should have failed");
+
+        // Upgrading does re-hash
+        let res = manager
+            .verify_and_upgrade(&mut rng, version, password.clone(), hash.clone())
+            .await
+            .expect("Failed to verify");
+
+        assert!(res.is_some());
+        let (version, hash) = res.unwrap();
+
+        assert_eq!(version, 2);
+        insta::assert_snapshot!(hash);
+
+        // Upgrading works with the new hash, but does not upgrade
+        let res = manager
+            .verify_and_upgrade(&mut rng, version, password.clone(), hash.clone())
+            .await
+            .expect("Failed to verify");
+
+        assert!(res.is_none());
+
+        // Upgrading still verify that the password matches
+        manager
+            .verify_and_upgrade(&mut rng, version, wrong_password.clone(), hash.clone())
+            .await
+            .expect_err("Verification should have failed");
+
+        // Upgrading still verify that the password matches
+        manager
+            .verify_and_upgrade(&mut rng, version, wrong_password.clone(), hash.clone())
+            .await
+            .expect_err("Verification should have failed");
+
+        let manager = PasswordManager::new([
+            (3, Hasher::argon2id(Some(b"a-secret-pepper".to_vec()))),
+            (2, Hasher::argon2id(None)),
+            (1, Hasher::bcrypt(10, Some(b"a-secret-pepper".to_vec()))),
+        ])
+        .unwrap();
+
+        // Verifying still works
+        manager
+            .verify(version, password.clone(), hash.clone())
+            .await
+            .expect("Failed to verify");
+
+        // And doesn't work with the wrong password
+        manager
+            .verify(version, wrong_password.clone(), hash.clone())
+            .await
+            .expect_err("Verification should have failed");
+
+        // Upgrading does re-hash
+        let res = manager
+            .verify_and_upgrade(&mut rng, version, password.clone(), hash.clone())
+            .await
+            .expect("Failed to verify");
+
+        assert!(res.is_some());
+        let (version, hash) = res.unwrap();
+
+        assert_eq!(version, 3);
+        insta::assert_snapshot!(hash);
+
+        // Upgrading works with the new hash, but does not upgrade
+        let res = manager
+            .verify_and_upgrade(&mut rng, version, password.clone(), hash.clone())
+            .await
+            .expect("Failed to verify");
+
+        assert!(res.is_none());
+
+        // Upgrading still verify that the password matches
+        manager
+            .verify_and_upgrade(&mut rng, version, wrong_password.clone(), hash.clone())
+            .await
+            .expect_err("Verification should have failed");
+    }
+}

--- a/crates/handlers/src/passwords.rs
+++ b/crates/handlers/src/passwords.rs
@@ -21,7 +21,7 @@ use pbkdf2::Pbkdf2;
 use rand::{CryptoRng, Rng, RngCore, SeedableRng};
 use zeroize::Zeroizing;
 
-pub type SchemeVersion = u32;
+pub type SchemeVersion = u16;
 
 #[derive(Clone)]
 pub struct PasswordManager {

--- a/crates/handlers/src/snapshots/mas_handlers__passwords__tests__hash_verify_and_upgrade-2.snap
+++ b/crates/handlers/src/snapshots/mas_handlers__passwords__tests__hash_verify_and_upgrade-2.snap
@@ -1,0 +1,5 @@
+---
+source: crates/handlers/src/passwords.rs
+expression: hash
+---
+$argon2id$v=19$m=4096,t=3,p=1$4aRFZH7bgRs24delZVap/Q$x9rbM2Yx2N/aWfSuyVJGZGaQ+zyoE4Vz1FO2+q9fu2Q

--- a/crates/handlers/src/snapshots/mas_handlers__passwords__tests__hash_verify_and_upgrade-3.snap
+++ b/crates/handlers/src/snapshots/mas_handlers__passwords__tests__hash_verify_and_upgrade-3.snap
@@ -1,0 +1,5 @@
+---
+source: crates/handlers/src/passwords.rs
+expression: hash
+---
+$argon2id$v=19$m=4096,t=3,p=1$1Ke64U6Mrdl5imSjjFRU+g$nL9kuMffxzJtFwANOEudh7FCpNJFPcYOA7xTbBLTCKI

--- a/crates/handlers/src/snapshots/mas_handlers__passwords__tests__hash_verify_and_upgrade.snap
+++ b/crates/handlers/src/snapshots/mas_handlers__passwords__tests__hash_verify_and_upgrade.snap
@@ -1,0 +1,5 @@
+---
+source: crates/handlers/src/passwords.rs
+expression: hash
+---
+$2b$10$1Mgv9BLlKUPw2H3LIWlseeWUiTWF2yZC/.TyzuC3bGuB9XacoEUu6

--- a/crates/handlers/src/snapshots/mas_handlers__passwords__tests__hashing_argon2id-2.snap
+++ b/crates/handlers/src/snapshots/mas_handlers__passwords__tests__hashing_argon2id-2.snap
@@ -1,0 +1,5 @@
+---
+source: crates/handlers/src/passwords.rs
+expression: hash
+---
+$argon2id$v=19$m=4096,t=3,p=1$1WdxAF1UChkYSTnJ6NDbKg$5Gxr/7C+gWUwqDLQmLJ2JiAzg/VxVb5Z+A65bqVoFkU

--- a/crates/handlers/src/snapshots/mas_handlers__passwords__tests__hashing_argon2id.snap
+++ b/crates/handlers/src/snapshots/mas_handlers__passwords__tests__hashing_argon2id.snap
@@ -1,0 +1,5 @@
+---
+source: crates/handlers/src/passwords.rs
+expression: hash
+---
+$argon2id$v=19$m=4096,t=3,p=1$eEi11xG8mIOZYxej+ckCaQ$pHZ/JwntSCS5qx6+MPK8XJUQSmSZ5rdXtxUew+rnXQI

--- a/crates/handlers/src/snapshots/mas_handlers__passwords__tests__hashing_bcrypt-2.snap
+++ b/crates/handlers/src/snapshots/mas_handlers__passwords__tests__hashing_bcrypt-2.snap
@@ -1,0 +1,5 @@
+---
+source: crates/handlers/src/passwords.rs
+expression: hash
+---
+$2b$10$mqjtwG6w3GawhuQQdwBCqOt0TQ0V4vGhB.tMuCZO8WL.ycBHkOLca

--- a/crates/handlers/src/snapshots/mas_handlers__passwords__tests__hashing_bcrypt.snap
+++ b/crates/handlers/src/snapshots/mas_handlers__passwords__tests__hashing_bcrypt.snap
@@ -1,0 +1,5 @@
+---
+source: crates/handlers/src/passwords.rs
+expression: hash
+---
+$2b$10$c/EX8bTbEMfTn4oCvcQyBOR1zPyLmGzZ2pMXoElLASqv2qpq5X15i

--- a/crates/handlers/src/snapshots/mas_handlers__passwords__tests__hashing_pbkdf2-2.snap
+++ b/crates/handlers/src/snapshots/mas_handlers__passwords__tests__hashing_pbkdf2-2.snap
@@ -1,0 +1,5 @@
+---
+source: crates/handlers/src/passwords.rs
+expression: hash
+---
+$pbkdf2-sha256$i=10000,l=32$1WdxAF1UChkYSTnJ6NDbKg$zxGEM53FY8GA0fV4augAeFIaoPbdia6Tni7yr77kdhg

--- a/crates/handlers/src/snapshots/mas_handlers__passwords__tests__hashing_pbkdf2.snap
+++ b/crates/handlers/src/snapshots/mas_handlers__passwords__tests__hashing_pbkdf2.snap
@@ -1,0 +1,5 @@
+---
+source: crates/handlers/src/passwords.rs
+expression: hash
+---
+$pbkdf2-sha256$i=10000,l=32$eEi11xG8mIOZYxej+ckCaQ$aDuBA/KhwMgMTrjrBqVHaZ8Zsyzs9IN8aq0iPgWoebc

--- a/crates/handlers/src/upstream_oauth2/link.rs
+++ b/crates/handlers/src/upstream_oauth2/link.rs
@@ -28,9 +28,7 @@ use mas_storage::{
     upstream_oauth2::{
         associate_link_to_user, consume_session, lookup_link, lookup_session_on_link,
     },
-    user::{
-        authenticate_session_with_upstream, lookup_user, register_passwordless_user, start_session,
-    },
+    user::{add_user, authenticate_session_with_upstream, lookup_user, start_session},
 };
 use mas_templates::{
     EmptyContext, TemplateContext, Templates, UpstreamExistingLinkContext, UpstreamRegister,
@@ -236,7 +234,7 @@ pub(crate) async fn post(
         }
 
         (None, None, FormData::Register { username }) => {
-            let user = register_passwordless_user(&mut txn, &mut rng, &clock, &username).await?;
+            let user = add_user(&mut txn, &mut rng, &clock, &username).await?;
             associate_link_to_user(&mut txn, &link, &user).await?;
 
             start_session(&mut txn, &mut rng, &clock, user).await?

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -6,20 +6,15 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
-tokio = "1.23.0"
 sqlx = { version = "0.6.2", features = ["runtime-tokio-rustls", "postgres", "migrate", "chrono", "offline", "json", "uuid"] }
 chrono = { version = "0.4.23", features = ["serde"] }
 serde = { version = "1.0.149", features = ["derive"] }
 serde_json = "1.0.89"
 thiserror = "1.0.37"
-anyhow = "1.0.66"
 tracing = "0.1.37"
 
 # Password hashing
-argon2 = { version = "0.4.1", features = ["password-hash"] }
-password-hash = { version = "0.4.2", features = ["std"] }
 rand = "0.8.5"
-rand_chacha = "0.3.1"
 url = { version = "2.3.1", features = ["serde"] }
 uuid = "1.2.2"
 ulid = { version = "1.0.0", features = ["uuid", "serde"] }

--- a/crates/storage/migrations/20221213145242_password_schemes.sql
+++ b/crates/storage/migrations/20221213145242_password_schemes.sql
@@ -1,0 +1,24 @@
+-- Copyright 2022 The Matrix.org Foundation C.I.C.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+ALTER TABLE "user_passwords"
+  ADD COLUMN "version" INTEGER NOT NULL DEFAULT 1,
+  ADD COLUMN "upgraded_from_id" UUID
+    CONSTRAINT "user_passwords_upgraded_from_id_fkey"
+    REFERENCES "user_passwords" ("user_password_id")
+    ON DELETE SET NULL;
+
+-- Remove the default after creating the column
+ALTER TABLE "user_passwords"
+  ALTER COLUMN "version" DROP DEFAULT;

--- a/crates/storage/sqlx-data.json
+++ b/crates/storage/sqlx-data.json
@@ -988,21 +988,6 @@
     },
     "query": "\n            SELECT\n                upstream_oauth_link_id,\n                upstream_oauth_provider_id,\n                user_id,\n                subject,\n                created_at\n            FROM upstream_oauth_links\n            WHERE upstream_oauth_link_id = $1\n        "
   },
-  "47fff42fd9871f73baf3e3ebb9e296fa65f7bc99f94639891f29d56d204b659a": {
-    "describe": {
-      "columns": [],
-      "nullable": [],
-      "parameters": {
-        "Left": [
-          "Uuid",
-          "Uuid",
-          "Text",
-          "Timestamptz"
-        ]
-      }
-    },
-    "query": "\n            INSERT INTO user_passwords (user_password_id, user_id, hashed_password, created_at)\n            VALUES ($1, $2, $3, $4)\n        "
-  },
   "4f8ec19f3f1bfe0268fe102a24e5a9fa542e77eccbebdce65e6deb1c197adf36": {
     "describe": {
       "columns": [
@@ -2170,6 +2155,50 @@
     },
     "query": "\n            SELECT\n                ct.compat_access_token_id,\n                ct.access_token    AS \"compat_access_token\",\n                ct.created_at      AS \"compat_access_token_created_at\",\n                ct.expires_at      AS \"compat_access_token_expires_at\",\n                cs.compat_session_id,\n                cs.created_at      AS \"compat_session_created_at\",\n                cs.finished_at     AS \"compat_session_finished_at\",\n                cs.device_id       AS \"compat_session_device_id\",\n                 u.user_id         AS \"user_id!\",\n                 u.username        AS \"user_username!\",\n                ue.user_email_id   AS \"user_email_id?\",\n                ue.email           AS \"user_email?\",\n                ue.created_at      AS \"user_email_created_at?\",\n                ue.confirmed_at    AS \"user_email_confirmed_at?\"\n\n            FROM compat_access_tokens ct\n            INNER JOIN compat_sessions cs\n              USING (compat_session_id)\n            INNER JOIN users u\n              USING (user_id)\n            LEFT JOIN user_emails ue\n              ON ue.user_email_id = u.primary_user_email_id\n\n            WHERE ct.access_token = $1\n              AND ct.expires_at < $2\n              AND cs.finished_at IS NULL \n        "
   },
+  "a1c19d9d7f1522d126787c7f9946ed51cbbd8f27a4947bc371acab3e7bf23267": {
+    "describe": {
+      "columns": [
+        {
+          "name": "user_password_id",
+          "ordinal": 0,
+          "type_info": "Uuid"
+        },
+        {
+          "name": "hashed_password",
+          "ordinal": 1,
+          "type_info": "Text"
+        },
+        {
+          "name": "version",
+          "ordinal": 2,
+          "type_info": "Int4"
+        },
+        {
+          "name": "upgraded_from_id",
+          "ordinal": 3,
+          "type_info": "Uuid"
+        },
+        {
+          "name": "created_at",
+          "ordinal": 4,
+          "type_info": "Timestamptz"
+        }
+      ],
+      "nullable": [
+        false,
+        false,
+        false,
+        true,
+        false
+      ],
+      "parameters": {
+        "Left": [
+          "Uuid"
+        ]
+      }
+    },
+    "query": "\n            SELECT up.user_password_id\n                 , up.hashed_password\n                 , up.version\n                 , up.upgraded_from_id\n                 , up.created_at\n            FROM user_passwords up\n            WHERE up.user_id = $1\n            ORDER BY up.created_at DESC\n            LIMIT 1\n        "
+  },
   "a5a7dad633396e087239d5629092e4a305908ffce9c2610db07372f719070546": {
     "describe": {
       "columns": [],
@@ -2365,6 +2394,23 @@
       }
     },
     "query": "\n            INSERT INTO oauth2_sessions\n                (oauth2_session_id, user_session_id, oauth2_client_id, scope, created_at)\n            SELECT\n                $1,\n                $2,\n                og.oauth2_client_id,\n                og.scope,\n                $3\n            FROM\n                oauth2_authorization_grants og\n            WHERE\n                og.oauth2_authorization_grant_id = $4\n        "
+  },
+  "bd7a4a008851f3f6d7591e3463e4369cee08820af57dcd3faf95f8e9be82857d": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          "Uuid",
+          "Text",
+          "Int4",
+          "Uuid",
+          "Timestamptz"
+        ]
+      }
+    },
+    "query": "\n            INSERT INTO user_passwords\n                (user_password_id, user_id, hashed_password, version, upgraded_from_id, created_at)\n            VALUES ($1, $2, $3, $4, $5, $6)\n        "
   },
   "c52c911bf39ada298bfdc4526028f1b29fdcb6f557b288bb7ea2472b160c8698": {
     "describe": {

--- a/crates/storage/src/user/authentication.rs
+++ b/crates/storage/src/user/authentication.rs
@@ -1,0 +1,105 @@
+// Copyright 2022 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use mas_data_model::{Authentication, BrowserSession, Password, UpstreamOAuthLink};
+use rand::Rng;
+use sqlx::PgExecutor;
+use ulid::Ulid;
+use uuid::Uuid;
+
+use crate::Clock;
+
+#[tracing::instrument(
+    skip_all,
+    fields(
+        user.id = %user_session.user.id,
+        %user_password.id,
+        %user_session.id,
+        user_session_authentication.id,
+    ),
+    err,
+)]
+pub async fn authenticate_session_with_password(
+    executor: impl PgExecutor<'_>,
+    mut rng: impl Rng + Send,
+    clock: &Clock,
+    user_session: &mut BrowserSession,
+    user_password: &Password,
+) -> Result<(), sqlx::Error> {
+    let created_at = clock.now();
+    let id = Ulid::from_datetime_with_source(created_at.into(), &mut rng);
+    tracing::Span::current().record(
+        "user_session_authentication.id",
+        tracing::field::display(id),
+    );
+
+    sqlx::query!(
+        r#"
+            INSERT INTO user_session_authentications
+                (user_session_authentication_id, user_session_id, created_at)
+            VALUES ($1, $2, $3)
+        "#,
+        Uuid::from(id),
+        Uuid::from(user_session.id),
+        created_at,
+    )
+    .execute(executor)
+    .await?;
+
+    user_session.last_authentication = Some(Authentication { id, created_at });
+
+    Ok(())
+}
+
+#[tracing::instrument(
+    skip_all,
+    fields(
+        user.id = %user_session.user.id,
+        %upstream_oauth_link.id,
+        %user_session.id,
+        user_session_authentication.id,
+    ),
+    err,
+)]
+pub async fn authenticate_session_with_upstream(
+    executor: impl PgExecutor<'_>,
+    mut rng: impl Rng + Send,
+    clock: &Clock,
+    user_session: &mut BrowserSession,
+    upstream_oauth_link: &UpstreamOAuthLink,
+) -> Result<(), sqlx::Error> {
+    let created_at = clock.now();
+    let id = Ulid::from_datetime_with_source(created_at.into(), &mut rng);
+    tracing::Span::current().record(
+        "user_session_authentication.id",
+        tracing::field::display(id),
+    );
+
+    sqlx::query!(
+        r#"
+            INSERT INTO user_session_authentications
+                (user_session_authentication_id, user_session_id, created_at)
+            VALUES ($1, $2, $3)
+        "#,
+        Uuid::from(id),
+        Uuid::from(user_session.id),
+        created_at,
+    )
+    .execute(executor)
+    .await?;
+
+    user_session.last_authentication = Some(Authentication { id, created_at });
+
+    Ok(())
+}

--- a/crates/storage/src/user/password.rs
+++ b/crates/storage/src/user/password.rs
@@ -1,0 +1,135 @@
+// Copyright 2022 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use chrono::{DateTime, Utc};
+use mas_data_model::{Password, User};
+use rand::Rng;
+use sqlx::PgExecutor;
+use ulid::Ulid;
+use uuid::Uuid;
+
+use crate::{Clock, DatabaseError, DatabaseInconsistencyError, LookupResultExt};
+
+#[tracing::instrument(
+    skip_all,
+    fields(
+        %user.id,
+        %user.username,
+        user_password.id,
+        user_password.version = version,
+    ),
+    err,
+)]
+pub async fn add_user_password(
+    executor: impl PgExecutor<'_>,
+    mut rng: impl Rng + Send,
+    clock: &Clock,
+    user: &User,
+    version: u16,
+    hashed_password: String,
+    upgraded_from: Option<Password>,
+) -> Result<Password, DatabaseError> {
+    let created_at = clock.now();
+    let id = Ulid::from_datetime_with_source(created_at.into(), &mut rng);
+    tracing::Span::current().record("user_password.id", tracing::field::display(id));
+
+    let upgraded_from_id = upgraded_from.map(|p| p.id);
+
+    sqlx::query!(
+        r#"
+            INSERT INTO user_passwords
+                (user_password_id, user_id, hashed_password, version, upgraded_from_id, created_at)
+            VALUES ($1, $2, $3, $4, $5, $6)
+        "#,
+        Uuid::from(id),
+        Uuid::from(user.id),
+        hashed_password,
+        i32::from(version),
+        upgraded_from_id.map(Uuid::from),
+        created_at,
+    )
+    .execute(executor)
+    .await?;
+
+    Ok(Password {
+        id,
+        hashed_password,
+        version,
+        upgraded_from_id,
+        created_at,
+    })
+}
+
+struct UserPasswordLookup {
+    user_password_id: Uuid,
+    hashed_password: String,
+    version: i32,
+    upgraded_from_id: Option<Uuid>,
+    created_at: DateTime<Utc>,
+}
+
+#[tracing::instrument(
+    skip_all,
+    fields(
+        %user.id,
+        %user.username,
+    ),
+    err,
+)]
+pub async fn lookup_user_password(
+    executor: impl PgExecutor<'_>,
+    user: &User,
+) -> Result<Option<Password>, DatabaseError> {
+    let res = sqlx::query_as!(
+        UserPasswordLookup,
+        r#"
+            SELECT up.user_password_id
+                 , up.hashed_password
+                 , up.version
+                 , up.upgraded_from_id
+                 , up.created_at
+            FROM user_passwords up
+            WHERE up.user_id = $1
+            ORDER BY up.created_at DESC
+            LIMIT 1
+        "#,
+        Uuid::from(user.id),
+    )
+    .fetch_one(executor)
+    .await
+    .to_option()?;
+
+    let Some(res) = res else { return Ok(None) };
+
+    let id = Ulid::from(res.user_password_id);
+
+    let version = res.version.try_into().map_err(|e| {
+        DatabaseInconsistencyError::on("user_passwords")
+            .column("version")
+            .row(id)
+            .source(e)
+    })?;
+
+    let upgraded_from_id = res.upgraded_from_id.map(Ulid::from);
+    let created_at = res.created_at;
+    let hashed_password = res.hashed_password;
+
+    Ok(Some(Password {
+        id,
+        hashed_password,
+        version,
+        upgraded_from_id,
+        created_at,
+    }))
+}

--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -128,6 +128,22 @@
         }
       ]
     },
+    "passwords": {
+      "description": "Configuration related to user passwords",
+      "default": {
+        "schemes": [
+          {
+            "algorithm": "argon2id",
+            "version": 1
+          }
+        ]
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/PasswordsConfig"
+        }
+      ]
+    },
     "policy": {
       "description": "Configuration related to the OPA policies",
       "default": {
@@ -645,6 +661,74 @@
           ]
         }
       ]
+    },
+    "HashingScheme": {
+      "description": "A hashing algorithm",
+      "type": "object",
+      "oneOf": [
+        {
+          "description": "bcrypt",
+          "type": "object",
+          "required": [
+            "algorithm"
+          ],
+          "properties": {
+            "algorithm": {
+              "type": "string",
+              "enum": [
+                "bcrypt"
+              ]
+            },
+            "cost": {
+              "description": "Hashing cost",
+              "default": 12,
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0.0
+            }
+          }
+        },
+        {
+          "description": "argon2id",
+          "type": "object",
+          "required": [
+            "algorithm"
+          ],
+          "properties": {
+            "algorithm": {
+              "type": "string",
+              "enum": [
+                "argon2id"
+              ]
+            }
+          }
+        },
+        {
+          "description": "PBKDF2",
+          "type": "object",
+          "required": [
+            "algorithm"
+          ],
+          "properties": {
+            "algorithm": {
+              "type": "string",
+              "enum": [
+                "pbkdf2"
+              ]
+            }
+          }
+        }
+      ],
+      "required": [
+        "version"
+      ],
+      "properties": {
+        "version": {
+          "type": "integer",
+          "format": "uint16",
+          "minimum": 0.0
+        }
+      }
     },
     "HttpConfig": {
       "description": "Configuration related to the web server",
@@ -1207,6 +1291,24 @@
           }
         }
       ]
+    },
+    "PasswordsConfig": {
+      "description": "User password hashing config",
+      "type": "object",
+      "properties": {
+        "schemes": {
+          "default": [
+            {
+              "algorithm": "argon2id",
+              "version": 1
+            }
+          ],
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/HashingScheme"
+          }
+        }
+      }
     },
     "PolicyConfig": {
       "description": "Application secrets",


### PR DESCRIPTION
This starts a modular password hasher, which works with different algorithms, including:

 - argon2id, which we were using so far
 - bcrypt2, used by Synapse and Dendrite
 - pbkdf2, used by Keycloak

The goal being to be able to import a Keycloak, Dendrite or Synapse user database
