### PR TITLE
Fix the authorization grant template

### DIFF
--- a/crates/data-model/src/oauth2/client.rs
+++ b/crates/data-model/src/oauth2/client.rs
@@ -12,12 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use chrono::{DateTime, Utc};
 use mas_iana::{
     jose::JsonWebSignatureAlg,
     oauth::{OAuthAuthorizationEndpointResponseType, OAuthClientAuthenticationMethod},
 };
 use mas_jose::jwk::PublicJsonWebKeySet;
 use oauth2_types::requests::GrantType;
+use rand::RngCore;
 use serde::Serialize;
 use thiserror::Error;
 use ulid::Ulid;
@@ -119,5 +121,57 @@ impl Client {
             (uris, Some(uri)) if uris.contains(uri) => Ok(uri),
             _ => Err(InvalidRedirectUriError::NotAllowed),
         }
+    }
+
+    pub fn samples(now: DateTime<Utc>, rng: &mut impl RngCore) -> Vec<Client> {
+        vec![
+            // A client with all the URIs set
+            Self {
+                id: Ulid::from_datetime_with_source(now.into(), rng),
+                client_id: "client1".to_owned(),
+                encrypted_client_secret: None,
+                redirect_uris: vec![
+                    Url::parse("https://client1.example.com/redirect").unwrap(),
+                    Url::parse("https://client1.example.com/redirect2").unwrap(),
+                ],
+                response_types: vec![OAuthAuthorizationEndpointResponseType::Code],
+                grant_types: vec![GrantType::AuthorizationCode, GrantType::RefreshToken],
+                contacts: vec!["foo@client1.example.com".to_owned()],
+                client_name: Some("Client 1".to_owned()),
+                client_uri: Some(Url::parse("https://client1.example.com").unwrap()),
+                logo_uri: Some(Url::parse("https://client1.example.com/logo.png").unwrap()),
+                tos_uri: Some(Url::parse("https://client1.example.com/tos").unwrap()),
+                policy_uri: Some(Url::parse("https://client1.example.com/policy").unwrap()),
+                initiate_login_uri: Some(
+                    Url::parse("https://client1.example.com/initiate-login").unwrap(),
+                ),
+                token_endpoint_auth_method: Some(OAuthClientAuthenticationMethod::None),
+                token_endpoint_auth_signing_alg: None,
+                id_token_signed_response_alg: None,
+                userinfo_signed_response_alg: None,
+                jwks: None,
+            },
+            // Another client without any URIs set
+            Self {
+                id: Ulid::from_datetime_with_source(now.into(), rng),
+                client_id: "client2".to_owned(),
+                encrypted_client_secret: None,
+                redirect_uris: vec![Url::parse("https://client2.example.com/redirect").unwrap()],
+                response_types: vec![OAuthAuthorizationEndpointResponseType::Code],
+                grant_types: vec![GrantType::AuthorizationCode, GrantType::RefreshToken],
+                contacts: vec!["foo@client2.example.com".to_owned()],
+                client_name: None,
+                client_uri: None,
+                logo_uri: None,
+                tos_uri: None,
+                policy_uri: None,
+                initiate_login_uri: None,
+                token_endpoint_auth_method: None,
+                token_endpoint_auth_signing_alg: None,
+                id_token_signed_response_alg: None,
+                userinfo_signed_response_alg: None,
+                jwks: None,
+            },
+        ]
     }
 }

--- a/crates/handlers/src/oauth2/authorization/mod.rs
+++ b/crates/handlers/src/oauth2/authorization/mod.rs
@@ -341,6 +341,7 @@ pub(crate) async fn get(
                         rng,
                         clock,
                         grant,
+                        client,
                         user_session,
                         &policy_factory,
                         repo,
@@ -372,10 +373,7 @@ pub(crate) async fn get(
                         Err(GrantCompletionError::Internal(e)) => {
                             return Err(RouteError::Internal(e))
                         }
-                        Err(
-                            e @ (GrantCompletionError::NotPending
-                            | GrantCompletionError::NoSuchClient),
-                        ) => {
+                        Err(e @ GrantCompletionError::NotPending) => {
                             // This should never happen
                             return Err(RouteError::Internal(Box::new(e)));
                         }
@@ -388,6 +386,7 @@ pub(crate) async fn get(
                         rng,
                         clock,
                         grant,
+                        client,
                         user_session,
                         &policy_factory,
                         repo,
@@ -413,10 +412,7 @@ pub(crate) async fn get(
                         Err(GrantCompletionError::Internal(e)) => {
                             return Err(RouteError::Internal(e))
                         }
-                        Err(
-                            e @ (GrantCompletionError::NotPending
-                            | GrantCompletionError::NoSuchClient),
-                        ) => {
+                        Err(e @ GrantCompletionError::NotPending) => {
                             // This should never happen
                             return Err(RouteError::Internal(Box::new(e)));
                         }

--- a/crates/policy/src/lib.rs
+++ b/crates/policy/src/lib.rs
@@ -17,7 +17,7 @@
 #![warn(clippy::pedantic)]
 #![allow(clippy::missing_errors_doc)]
 
-use mas_data_model::{AuthorizationGrant, User};
+use mas_data_model::{AuthorizationGrant, Client, User};
 use oauth2_types::registration::VerifiedClientMetadata;
 use opa_wasm::Runtime;
 use serde::Deserialize;
@@ -246,6 +246,7 @@ impl Policy {
         skip_all,
         fields(
             data.authorization_grant.id = %authorization_grant.id,
+            data.client.id = %client.id,
             data.user.id = %user.id,
         ),
         err,
@@ -253,12 +254,14 @@ impl Policy {
     pub async fn evaluate_authorization_grant(
         &mut self,
         authorization_grant: &AuthorizationGrant,
+        client: &Client,
         user: &User,
     ) -> Result<EvaluationResult, EvaluationError> {
         let authorization_grant = serde_json::to_value(authorization_grant)?;
         let user = serde_json::to_value(user)?;
         let input = serde_json::json!({
             "authorization_grant": authorization_grant,
+            "client": client,
             "user": user,
         });
 

--- a/crates/templates/src/context.rs
+++ b/crates/templates/src/context.rs
@@ -18,8 +18,8 @@
 
 use chrono::Utc;
 use mas_data_model::{
-    AuthorizationGrant, BrowserSession, CompatSsoLogin, CompatSsoLoginState, UpstreamOAuthLink,
-    UpstreamOAuthProvider, User, UserEmail, UserEmailVerification,
+    AuthorizationGrant, BrowserSession, Client, CompatSsoLogin, CompatSsoLoginState,
+    UpstreamOAuthLink, UpstreamOAuthProvider, User, UserEmail, UserEmailVerification,
 };
 use mas_router::{PostAuthAction, Route};
 use rand::Rng;
@@ -395,25 +395,42 @@ impl RegisterContext {
 #[derive(Serialize)]
 pub struct ConsentContext {
     grant: AuthorizationGrant,
+    client: Client,
     action: PostAuthAction,
 }
 
 impl TemplateContext for ConsentContext {
-    fn sample(_now: chrono::DateTime<Utc>, _rng: &mut impl Rng) -> Vec<Self>
+    fn sample(now: chrono::DateTime<Utc>, rng: &mut impl Rng) -> Vec<Self>
     where
         Self: Sized,
     {
-        // TODO
-        vec![]
+        Client::samples(now, rng)
+            .into_iter()
+            .map(|client| {
+                let mut grant = AuthorizationGrant::sample(now, rng);
+                let action = PostAuthAction::continue_grant(grant.id);
+                // XXX
+                grant.client_id = client.id;
+                Self {
+                    grant,
+                    client,
+                    action,
+                }
+            })
+            .collect()
     }
 }
 
 impl ConsentContext {
     /// Constructs a context for the client consent page
     #[must_use]
-    pub fn new(grant: AuthorizationGrant) -> Self {
+    pub fn new(grant: AuthorizationGrant, client: Client) -> Self {
         let action = PostAuthAction::continue_grant(grant.id);
-        Self { grant, action }
+        Self {
+            grant,
+            client,
+            action,
+        }
     }
 }
 
@@ -421,25 +438,42 @@ impl ConsentContext {
 #[derive(Serialize)]
 pub struct PolicyViolationContext {
     grant: AuthorizationGrant,
+    client: Client,
     action: PostAuthAction,
 }
 
 impl TemplateContext for PolicyViolationContext {
-    fn sample(_now: chrono::DateTime<Utc>, _rng: &mut impl Rng) -> Vec<Self>
+    fn sample(now: chrono::DateTime<Utc>, rng: &mut impl Rng) -> Vec<Self>
     where
         Self: Sized,
     {
-        // TODO
-        vec![]
+        Client::samples(now, rng)
+            .into_iter()
+            .map(|client| {
+                let mut grant = AuthorizationGrant::sample(now, rng);
+                let action = PostAuthAction::continue_grant(grant.id);
+                // XXX
+                grant.client_id = client.id;
+                Self {
+                    grant,
+                    client,
+                    action,
+                }
+            })
+            .collect()
     }
 }
 
 impl PolicyViolationContext {
     /// Constructs a context for the policy violation page
     #[must_use]
-    pub const fn new(grant: AuthorizationGrant) -> Self {
+    pub const fn new(grant: AuthorizationGrant, client: Client) -> Self {
         let action = PostAuthAction::continue_grant(grant.id);
-        Self { grant, action }
+        Self {
+            grant,
+            client,
+            action,
+        }
     }
 }
 

--- a/templates/pages/consent.html
+++ b/templates/pages/consent.html
@@ -23,17 +23,17 @@ limitations under the License.
         <div class="rounded-lg bg-grey-25 dark:bg-grey-450 p-2 flex flex-col">
           <div class="text-center">
             <div class="bg-white rounded w-16 h-16 overflow-hidden mx-auto">
-              {% if grant.client.logo_uri %}
-              <img class="w-16 h-16" src="{{ grant.client.logo_uri }}" />
+              {% if client.logo_uri %}
+              <img class="w-16 h-16" src="{{ client.logo_uri }}" />
               {% endif %}
             </div>
-            <h1 class="text-lg text-center font-medium"><a target="_blank" href="{{ grant.client.client_uri }}" class="text-accent">{{ grant.client.client_name | default(value=grant.client.client_id) }}</a></h1>
+            <h1 class="text-lg text-center font-medium"><a target="_blank" href="{{ client.client_uri }}" class="text-accent">{{ client.client_name | default(value=client.client_id) }}</a></h1>
             <h1>at {{ grant.redirect_uri }}</h1>
             <h1>wants to access your Matrix account</h1>
           </div>
           <div class="flex items-center m-2">
             <div class="px-4 flex-1">
-              <p>This will allow <a target="_blank" href="{{ grant.client.client_uri }}" class="text-accent">{{ grant.client.client_name | default(value=grant.client.client_id) }}</a> to:</p>
+              <p>This will allow <a target="_blank" href="{{ client.client_uri }}" class="text-accent">{{ client.client_name | default(value=client.client_id) }}</a> to:</p>
 
               <p class="my-2">
                 <ul class="list-disc">
@@ -49,19 +49,19 @@ limitations under the License.
                   {% endfor %}
                 </ul>  
               </p>
-              <p class="font-bold my-2">Make sure that you trust {{ grant.client.client_name }}</p>
+              <p class="font-bold my-2">Make sure that you trust {{ client.client_name }}</p>
               <p>
                 You may be sharing sensitive information with this site or app.
-                {% if grant.client.policy_uri or grant.client.tos_uri %}
-                  Find out how {{ grant.client.client_name }} will handle your data by reviewing it's
-                  {% if grant.client.policy_uri %}
-                    <a target="_blank" href="{{ grant.client.policy_uri }}" class="text-accent">privacy policy</a>{% if not grant.client.tos_uri %}.{% endif %}
+                {% if client.policy_uri or client.tos_uri %}
+                  Find out how {{ client.client_name }} will handle your data by reviewing it's
+                  {% if client.policy_uri %}
+                    <a target="_blank" href="{{ client.policy_uri }}" class="text-accent">privacy policy</a>{% if not client.tos_uri %}.{% endif %}
                   {% endif %}
-                  {% if grant.client.policy_uri and grant.client.tos_uri%}
+                  {% if client.policy_uri and client.tos_uri%}
                     and
                   {% endif %}
-                  {% if grant.client.tos_uri %}
-                    <a target="_blank" href="{{ grant.client.tos_uri }}" class="text-accent">terms of service</a>.
+                  {% if client.tos_uri %}
+                    <a target="_blank" href="{{ client.tos_uri }}" class="text-accent">terms of service</a>.
                   {% endif %}
                 {% endif %}
               </p>

--- a/templates/pages/policy_violation.html
+++ b/templates/pages/policy_violation.html
@@ -24,11 +24,11 @@ limitations under the License.
         <p>This might be because of the client which authored the request, the currently logged in user, or the request itself.</p>
         <div class="rounded-lg bg-grey-25 dark:bg-grey-450 p-2 flex items-center">
           <div class="bg-white rounded w-16 h-16 overflow-hidden mx-auto">
-            {% if grant.client.logo_uri %}
-            <img class="w-16 h-16" src="{{ grant.client.logo_uri }}" />
+            {% if client.logo_uri %}
+            <img class="w-16 h-16" src="{{ client.logo_uri }}" />
             {% endif %}
           </div>
-          <h1 class="text-lg text-center font-medium flex-1"><a target="_blank" href="{{ grant.client.client_uri }}" class="text-accent">{{ grant.client.client_name | default(value=grant.client.client_id) }}</a></h1>
+          <h1 class="text-lg text-center font-medium flex-1"><a target="_blank" href="{{ client.client_uri }}" class="text-accent">{{ client.client_name | default(value=client.client_id) }}</a></h1>
         </div>
 
         <div class="rounded-lg bg-grey-25 dark:bg-grey-450 p-2 flex items-center">


### PR DESCRIPTION
It previously relied on the client being in the authorization grant,
which is not the case anymore. This commit also adds a test to ensure
we're not breaking this template in the future.

Fixes https://sentry.tools.element.io/organizations/element/issues/60523/
