### PR TITLE
Add tests for the Matrix compatibility login API

### DIFF
--- a/crates/data-model/src/compat/device.rs
+++ b/crates/data-model/src/compat/device.rs
@@ -17,12 +17,12 @@ use rand::{
     distributions::{Alphanumeric, DistString},
     RngCore,
 };
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 static DEVICE_ID_LENGTH: usize = 10;
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct Device {
     id: String,


### PR DESCRIPTION
This adds tests for the `/_matrix/client/v3/login` endpoint.

cc @tadzik if you want to review