### PR TITLE
oidc-client: Derive `Clone` for `ClientCredentials`

### DIFF
--- a/crates/oidc-client/src/types/client_credentials.rs
+++ b/crates/oidc-client/src/types/client_credentials.rs
@@ -108,6 +108,7 @@ impl JwtSigningMethod {
 
 /// The credentials obtained during registration, to authenticate a client on
 /// endpoints that require it.
+#[derive(Clone)]
 pub enum ClientCredentials {
     /// No client authentication is used.
     ///


### PR DESCRIPTION
It was the initial purpose of #760, but it was lost when I reverted the initial commit…