### PR TITLE
Fix the default listener configuration

### DIFF
--- a/crates/config/src/sections/http.rs
+++ b/crates/config/src/sections/http.rs
@@ -358,8 +358,9 @@ impl Default for HttpConfig {
                     resources: vec![Resource::Health],
                     tls: None,
                     proxy_protocol: false,
-                    binds: vec![BindConfig::Address {
-                        address: "localhost:8081".into(),
+                    binds: vec![BindConfig::Listen {
+                        host: Some("localhost".to_owned()),
+                        port: 8081,
                     }],
                 },
             ],

--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -97,7 +97,8 @@
           {
             "binds": [
               {
-                "address": "localhost:8081"
+                "host": "localhost",
+                "port": 8081
               }
             ],
             "name": "internal",


### PR DESCRIPTION
The default listener configuration used `localhost:8081` as address, which would not go through hostname resolution.
This is now fixed by instead using separately configured `host` and `port` options.
