### PR TITLE
Build rustdoc with a stable toolchain in CI

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -24,8 +24,8 @@ jobs:
 
       - name: Install Rust toolchain
         run: |
-          rustup toolchain install nightly
-          rustup default nightly
+          rustup toolchain install stable
+          rustup default stable
 
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2
@@ -50,6 +50,9 @@ jobs:
         run: mdbook build
 
       - name: Build rustdoc
+        env:
+          # This is required to be able use to use the unstable `-Zrustdoc-map` flag
+          RUSTC_BOOTSTRAP: "1"
         run: cargo doc -Zrustdoc-map --workspace --lib --no-deps
 
       - name: Build storybook


### PR DESCRIPTION
We used a nightly toolchain to be able to use the unstable `-Zrustdoc-map` flag. Unfortunately, we're currently have an ICE when building the docs, so this switches back to a stable toolchain, but with the `RUSTC_BOOTSTRAP` flag, which allows us to use unstable flags.