### PR TITLE
Setup GraphQL mutations to add and verify email addresses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3262,6 +3262,7 @@ dependencies = [
  "mas-data-model",
  "mas-storage",
  "oauth2-types",
+ "rand_chacha 0.3.1",
  "serde",
  "thiserror",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3258,11 +3258,11 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-graphql",
+ "async-trait",
  "chrono",
  "mas-data-model",
  "mas-storage",
  "oauth2-types",
- "rand_chacha 0.3.1",
  "serde",
  "thiserror",
  "tokio",

--- a/crates/cli/src/commands/server.rs
+++ b/crates/cli/src/commands/server.rs
@@ -122,7 +122,7 @@ impl Options {
             watch_templates(&templates).await?;
         }
 
-        let graphql_schema = mas_handlers::graphql_schema();
+        let graphql_schema = mas_handlers::graphql_schema(&pool);
 
         // Maximum 50 outgoing HTTP requests at a time
         let http_client_factory = HttpClientFactory::new(50);

--- a/crates/data-model/src/users.rs
+++ b/crates/data-model/src/users.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::ops::Deref;
+
 use chrono::{DateTime, Duration, Utc};
 use rand::{Rng, SeedableRng};
 use serde::Serialize;
@@ -131,6 +133,13 @@ pub enum UserEmailVerificationState {
     Valid,
 }
 
+impl UserEmailVerificationState {
+    #[must_use]
+    pub fn is_valid(&self) -> bool {
+        matches!(self, Self::Valid)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct UserEmailVerification {
     pub id: Ulid,
@@ -138,6 +147,14 @@ pub struct UserEmailVerification {
     pub code: String,
     pub created_at: DateTime<Utc>,
     pub state: UserEmailVerificationState,
+}
+
+impl Deref for UserEmailVerification {
+    type Target = UserEmailVerificationState;
+
+    fn deref(&self) -> &Self::Target {
+        &self.state
+    }
 }
 
 impl UserEmailVerification {

--- a/crates/graphql/Cargo.toml
+++ b/crates/graphql/Cargo.toml
@@ -8,14 +8,14 @@ license = "Apache-2.0"
 [dependencies]
 anyhow = "1.0.70"
 async-graphql = { version = "5.0.7", features = ["chrono", "url"] }
+async-trait = "0.1.51"
 chrono = "0.4.24"
 serde = { version = "1.0.160", features = ["derive"] }
-tokio = { version = "1.27.0", features = ["sync"] }
 thiserror = "1.0.40"
+tokio = { version = "1.27.0", features = ["sync"] }
 tracing = "0.1.37"
 ulid = "1.0.0"
 url = "2.3.1"
-rand_chacha = "0.3.1"
 
 oauth2-types = { path = "../oauth2-types" }
 mas-data-model = { path = "../data-model" }

--- a/crates/graphql/Cargo.toml
+++ b/crates/graphql/Cargo.toml
@@ -15,6 +15,7 @@ thiserror = "1.0.40"
 tracing = "0.1.37"
 ulid = "1.0.0"
 url = "2.3.1"
+rand_chacha = "0.3.1"
 
 oauth2-types = { path = "../oauth2-types" }
 mas-data-model = { path = "../data-model" }

--- a/crates/graphql/src/lib.rs
+++ b/crates/graphql/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 The Matrix.org Foundation C.I.C.
+// Copyright 2022-2023 The Matrix.org Foundation C.I.C.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -26,269 +26,26 @@
     clippy::unused_async
 )]
 
-use async_graphql::{
-    connection::{query, Connection, Edge, OpaqueCursor},
-    Context, Description, EmptyMutation, EmptySubscription, ID,
-};
-use mas_storage::{
-    oauth2::OAuth2ClientRepository,
-    upstream_oauth2::{UpstreamOAuthLinkRepository, UpstreamOAuthProviderRepository},
-    user::{BrowserSessionRepository, UserEmailRepository},
-    BoxRepository, Pagination,
-};
-use model::CreationEvent;
-use tokio::sync::Mutex;
-
-use self::model::{
-    BrowserSession, Cursor, Node, NodeCursor, NodeType, OAuth2Client, UpstreamOAuth2Link,
-    UpstreamOAuth2Provider, User, UserEmail,
-};
+use async_graphql::EmptySubscription;
 
 mod model;
 mod mutations;
+mod query;
+mod state;
 
-pub type Schema = async_graphql::Schema<RootQuery, EmptyMutation, EmptySubscription>;
-pub type SchemaBuilder = async_graphql::SchemaBuilder<RootQuery, EmptyMutation, EmptySubscription>;
+pub use self::{
+    model::{CreationEvent, Node},
+    mutations::RootMutations,
+    query::RootQuery,
+    state::{BoxState, State},
+};
+
+pub type Schema = async_graphql::Schema<RootQuery, RootMutations, EmptySubscription>;
+pub type SchemaBuilder = async_graphql::SchemaBuilder<RootQuery, RootMutations, EmptySubscription>;
 
 #[must_use]
 pub fn schema_builder() -> SchemaBuilder {
-    async_graphql::Schema::build(RootQuery::new(), EmptyMutation, EmptySubscription)
+    async_graphql::Schema::build(RootQuery::new(), RootMutations::new(), EmptySubscription)
         .register_output_type::<Node>()
         .register_output_type::<CreationEvent>()
-}
-
-/// The query root of the GraphQL interface.
-#[derive(Default, Description)]
-pub struct RootQuery {
-    _private: (),
-}
-
-impl RootQuery {
-    #[must_use]
-    pub fn new() -> Self {
-        Self::default()
-    }
-}
-
-#[async_graphql::Object(use_type_description)]
-impl RootQuery {
-    /// Get the current logged in browser session
-    async fn current_browser_session(
-        &self,
-        ctx: &Context<'_>,
-    ) -> Result<Option<BrowserSession>, async_graphql::Error> {
-        let session = ctx.data_opt::<mas_data_model::BrowserSession>().cloned();
-        Ok(session.map(BrowserSession::from))
-    }
-
-    /// Get the current logged in user
-    async fn current_user(&self, ctx: &Context<'_>) -> Result<Option<User>, async_graphql::Error> {
-        let session = ctx.data_opt::<mas_data_model::BrowserSession>().cloned();
-        Ok(session.map(User::from))
-    }
-
-    /// Fetch an OAuth 2.0 client by its ID.
-    async fn oauth2_client(
-        &self,
-        ctx: &Context<'_>,
-        id: ID,
-    ) -> Result<Option<OAuth2Client>, async_graphql::Error> {
-        let id = NodeType::OAuth2Client.extract_ulid(&id)?;
-        let mut repo = ctx.data::<Mutex<BoxRepository>>()?.lock().await;
-
-        let client = repo.oauth2_client().lookup(id).await?;
-
-        Ok(client.map(OAuth2Client))
-    }
-
-    /// Fetch a user by its ID.
-    async fn user(&self, ctx: &Context<'_>, id: ID) -> Result<Option<User>, async_graphql::Error> {
-        let id = NodeType::User.extract_ulid(&id)?;
-        let session = ctx.data_opt::<mas_data_model::BrowserSession>().cloned();
-
-        let Some(session) = session else { return Ok(None) };
-        let current_user = session.user;
-
-        if current_user.id == id {
-            Ok(Some(User(current_user)))
-        } else {
-            Ok(None)
-        }
-    }
-
-    /// Fetch a browser session by its ID.
-    async fn browser_session(
-        &self,
-        ctx: &Context<'_>,
-        id: ID,
-    ) -> Result<Option<BrowserSession>, async_graphql::Error> {
-        let id = NodeType::BrowserSession.extract_ulid(&id)?;
-        let session = ctx.data_opt::<mas_data_model::BrowserSession>().cloned();
-        let mut repo = ctx.data::<Mutex<BoxRepository>>()?.lock().await;
-
-        let Some(session) = session else { return Ok(None) };
-        let current_user = session.user;
-
-        let browser_session = repo.browser_session().lookup(id).await?;
-
-        let ret = browser_session.and_then(|browser_session| {
-            if browser_session.user.id == current_user.id {
-                Some(BrowserSession(browser_session))
-            } else {
-                None
-            }
-        });
-
-        Ok(ret)
-    }
-
-    /// Fetch a user email by its ID.
-    async fn user_email(
-        &self,
-        ctx: &Context<'_>,
-        id: ID,
-    ) -> Result<Option<UserEmail>, async_graphql::Error> {
-        let id = NodeType::UserEmail.extract_ulid(&id)?;
-        let session = ctx.data_opt::<mas_data_model::BrowserSession>().cloned();
-        let mut repo = ctx.data::<Mutex<BoxRepository>>()?.lock().await;
-
-        let Some(session) = session else { return Ok(None) };
-        let current_user = session.user;
-
-        let user_email = repo
-            .user_email()
-            .lookup(id)
-            .await?
-            .filter(|e| e.user_id == current_user.id);
-
-        Ok(user_email.map(UserEmail))
-    }
-
-    /// Fetch an upstream OAuth 2.0 link by its ID.
-    async fn upstream_oauth2_link(
-        &self,
-        ctx: &Context<'_>,
-        id: ID,
-    ) -> Result<Option<UpstreamOAuth2Link>, async_graphql::Error> {
-        let id = NodeType::UpstreamOAuth2Link.extract_ulid(&id)?;
-        let session = ctx.data_opt::<mas_data_model::BrowserSession>().cloned();
-        let mut repo = ctx.data::<Mutex<BoxRepository>>()?.lock().await;
-
-        let Some(session) = session else { return Ok(None) };
-        let current_user = session.user;
-
-        let link = repo.upstream_oauth_link().lookup(id).await?;
-
-        // Ensure that the link belongs to the current user
-        let link = link.filter(|link| link.user_id == Some(current_user.id));
-
-        Ok(link.map(UpstreamOAuth2Link::new))
-    }
-
-    /// Fetch an upstream OAuth 2.0 provider by its ID.
-    async fn upstream_oauth2_provider(
-        &self,
-        ctx: &Context<'_>,
-        id: ID,
-    ) -> Result<Option<UpstreamOAuth2Provider>, async_graphql::Error> {
-        let id = NodeType::UpstreamOAuth2Provider.extract_ulid(&id)?;
-        let mut repo = ctx.data::<Mutex<BoxRepository>>()?.lock().await;
-
-        let provider = repo.upstream_oauth_provider().lookup(id).await?;
-
-        Ok(provider.map(UpstreamOAuth2Provider::new))
-    }
-
-    /// Get a list of upstream OAuth 2.0 providers.
-    async fn upstream_oauth2_providers(
-        &self,
-        ctx: &Context<'_>,
-
-        #[graphql(desc = "Returns the elements in the list that come after the cursor.")]
-        after: Option<String>,
-        #[graphql(desc = "Returns the elements in the list that come before the cursor.")]
-        before: Option<String>,
-        #[graphql(desc = "Returns the first *n* elements from the list.")] first: Option<i32>,
-        #[graphql(desc = "Returns the last *n* elements from the list.")] last: Option<i32>,
-    ) -> Result<Connection<Cursor, UpstreamOAuth2Provider>, async_graphql::Error> {
-        let mut repo = ctx.data::<Mutex<BoxRepository>>()?.lock().await;
-
-        query(
-            after,
-            before,
-            first,
-            last,
-            |after, before, first, last| async move {
-                let after_id = after
-                    .map(|x: OpaqueCursor<NodeCursor>| {
-                        x.extract_for_type(NodeType::UpstreamOAuth2Provider)
-                    })
-                    .transpose()?;
-                let before_id = before
-                    .map(|x: OpaqueCursor<NodeCursor>| {
-                        x.extract_for_type(NodeType::UpstreamOAuth2Provider)
-                    })
-                    .transpose()?;
-                let pagination = Pagination::try_new(before_id, after_id, first, last)?;
-
-                let page = repo
-                    .upstream_oauth_provider()
-                    .list_paginated(pagination)
-                    .await?;
-
-                let mut connection = Connection::new(page.has_previous_page, page.has_next_page);
-                connection.edges.extend(page.edges.into_iter().map(|p| {
-                    Edge::new(
-                        OpaqueCursor(NodeCursor(NodeType::UpstreamOAuth2Provider, p.id)),
-                        UpstreamOAuth2Provider::new(p),
-                    )
-                }));
-
-                Ok::<_, async_graphql::Error>(connection)
-            },
-        )
-        .await
-    }
-
-    /// Fetches an object given its ID.
-    async fn node(&self, ctx: &Context<'_>, id: ID) -> Result<Option<Node>, async_graphql::Error> {
-        let (node_type, _id) = NodeType::from_id(&id)?;
-
-        let ret = match node_type {
-            // TODO
-            NodeType::Authentication
-            | NodeType::CompatSession
-            | NodeType::CompatSsoLogin
-            | NodeType::OAuth2Session => None,
-
-            NodeType::UpstreamOAuth2Provider => self
-                .upstream_oauth2_provider(ctx, id)
-                .await?
-                .map(|c| Node::UpstreamOAuth2Provider(Box::new(c))),
-
-            NodeType::UpstreamOAuth2Link => self
-                .upstream_oauth2_link(ctx, id)
-                .await?
-                .map(|c| Node::UpstreamOAuth2Link(Box::new(c))),
-
-            NodeType::OAuth2Client => self
-                .oauth2_client(ctx, id)
-                .await?
-                .map(|c| Node::OAuth2Client(Box::new(c))),
-
-            NodeType::UserEmail => self
-                .user_email(ctx, id)
-                .await?
-                .map(|e| Node::UserEmail(Box::new(e))),
-
-            NodeType::BrowserSession => self
-                .browser_session(ctx, id)
-                .await?
-                .map(|s| Node::BrowserSession(Box::new(s))),
-
-            NodeType::User => self.user(ctx, id).await?.map(|u| Node::User(Box::new(u))),
-        };
-
-        Ok(ret)
-    }
 }

--- a/crates/graphql/src/lib.rs
+++ b/crates/graphql/src/lib.rs
@@ -36,17 +36,17 @@ mod state;
 
 pub use self::{
     model::{CreationEvent, Node},
-    mutations::RootMutations,
-    query::RootQuery,
+    mutations::Mutation,
+    query::Query,
     state::{BoxState, State},
 };
 
-pub type Schema = async_graphql::Schema<RootQuery, RootMutations, EmptySubscription>;
-pub type SchemaBuilder = async_graphql::SchemaBuilder<RootQuery, RootMutations, EmptySubscription>;
+pub type Schema = async_graphql::Schema<Query, Mutation, EmptySubscription>;
+pub type SchemaBuilder = async_graphql::SchemaBuilder<Query, Mutation, EmptySubscription>;
 
 #[must_use]
 pub fn schema_builder() -> SchemaBuilder {
-    async_graphql::Schema::build(RootQuery::new(), RootMutations::new(), EmptySubscription)
+    async_graphql::Schema::build(Query::new(), Mutation::new(), EmptySubscription)
         .register_output_type::<Node>()
         .register_output_type::<CreationEvent>()
 }

--- a/crates/graphql/src/lib.rs
+++ b/crates/graphql/src/lib.rs
@@ -45,6 +45,7 @@ use self::model::{
 };
 
 mod model;
+mod mutations;
 
 pub type Schema = async_graphql::Schema<RootQuery, EmptyMutation, EmptySubscription>;
 pub type SchemaBuilder = async_graphql::SchemaBuilder<RootQuery, EmptyMutation, EmptySubscription>;

--- a/crates/graphql/src/model/mod.rs
+++ b/crates/graphql/src/model/mod.rs
@@ -22,6 +22,7 @@ mod node;
 mod oauth;
 mod upstream_oauth;
 mod users;
+mod viewer;
 
 pub use self::{
     browser_sessions::{Authentication, BrowserSession},
@@ -31,6 +32,7 @@ pub use self::{
     oauth::{OAuth2Client, OAuth2Consent, OAuth2Session},
     upstream_oauth::{UpstreamOAuth2Link, UpstreamOAuth2Provider},
     users::{User, UserEmail},
+    viewer::{Anonymous, Viewer, ViewerSession},
 };
 
 /// An object with a creation date.

--- a/crates/graphql/src/model/node.rs
+++ b/crates/graphql/src/model/node.rs
@@ -18,8 +18,8 @@ use thiserror::Error;
 use ulid::Ulid;
 
 use super::{
-    Authentication, BrowserSession, CompatSession, CompatSsoLogin, OAuth2Client, OAuth2Session,
-    UpstreamOAuth2Link, UpstreamOAuth2Provider, User, UserEmail,
+    Anonymous, Authentication, BrowserSession, CompatSession, CompatSsoLogin, OAuth2Client,
+    OAuth2Session, UpstreamOAuth2Link, UpstreamOAuth2Provider, User, UserEmail,
 };
 
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -116,6 +116,7 @@ impl NodeType {
 #[derive(Interface)]
 #[graphql(field(name = "id", desc = "ID of the object.", type = "ID"))]
 pub enum Node {
+    Anonymous(Box<Anonymous>),
     Authentication(Box<Authentication>),
     BrowserSession(Box<BrowserSession>),
     CompatSession(Box<CompatSession>),

--- a/crates/graphql/src/model/viewer/anonymous.rs
+++ b/crates/graphql/src/model/viewer/anonymous.rs
@@ -1,0 +1,26 @@
+// Copyright 2023 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use async_graphql::{Object, ID};
+
+/// An anonymous viewer
+#[derive(Default, Clone, Copy)]
+pub struct Anonymous;
+
+#[Object]
+impl Anonymous {
+    pub async fn id(&self) -> ID {
+        "anonymous".into()
+    }
+}

--- a/crates/graphql/src/model/viewer/mod.rs
+++ b/crates/graphql/src/model/viewer/mod.rs
@@ -1,0 +1,54 @@
+// Copyright 2023 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use async_graphql::Union;
+
+use crate::model::{BrowserSession, User};
+
+mod anonymous;
+pub use self::anonymous::Anonymous;
+
+/// Represents the current viewer
+#[derive(Union)]
+pub enum Viewer {
+    User(User),
+    Anonymous(Anonymous),
+}
+
+impl Viewer {
+    pub fn user(user: mas_data_model::User) -> Self {
+        Self::User(User(user))
+    }
+
+    pub fn anonymous() -> Self {
+        Self::Anonymous(Anonymous)
+    }
+}
+
+/// Represents the current viewer's session
+#[derive(Union)]
+pub enum ViewerSession {
+    BrowserSession(BrowserSession),
+    Anonymous(Anonymous),
+}
+
+impl ViewerSession {
+    pub fn browser_session(session: mas_data_model::BrowserSession) -> Self {
+        Self::BrowserSession(BrowserSession(session))
+    }
+
+    pub fn anonymous() -> Self {
+        Self::Anonymous(Anonymous)
+    }
+}

--- a/crates/graphql/src/mutations.rs
+++ b/crates/graphql/src/mutations.rs
@@ -1,0 +1,68 @@
+// Copyright 2023 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use async_graphql::{Context, Object, ID};
+use mas_storage::{
+    job::{JobRepositoryExt, VerifyEmailJob},
+    user::UserEmailRepository,
+    BoxClock, BoxRepository, BoxRng, RepositoryAccess, SystemClock,
+};
+use rand_chacha::{rand_core::SeedableRng, ChaChaRng};
+use tokio::sync::Mutex;
+
+use crate::model::{NodeType, UserEmail};
+
+struct RootMutations;
+
+fn clock_and_rng() -> (BoxClock, BoxRng) {
+    // XXX: this should be moved somewhere else
+    let clock = SystemClock::default();
+    let rng = ChaChaRng::from_entropy();
+    (Box::new(clock), Box::new(rng))
+}
+
+#[Object]
+impl RootMutations {
+    async fn add_email(
+        &self,
+        ctx: &Context<'_>,
+        email: String,
+        user_id: ID,
+    ) -> Result<UserEmail, async_graphql::Error> {
+        let id = NodeType::User.extract_ulid(&user_id)?;
+        let session = ctx.data_opt::<mas_data_model::BrowserSession>().cloned();
+        let (clock, mut rng) = clock_and_rng();
+        let mut repo = ctx.data::<Mutex<BoxRepository>>()?.lock().await;
+
+        let Some(session) = session else {
+            return Err(async_graphql::Error::new("Unauthorized"));
+        };
+
+        if session.user.id != id {
+            return Err(async_graphql::Error::new("Unauthorized"));
+        }
+
+        let user_email = repo
+            .user_email()
+            .add(&mut rng, &clock, &session.user, email)
+            .await?;
+
+        repo.job()
+            .schedule_job(VerifyEmailJob::new(&user_email))
+            .await?;
+        // TODO: how do we save the transaction here?
+
+        Ok(UserEmail(user_email))
+    }
+}

--- a/crates/graphql/src/mutations/mod.rs
+++ b/crates/graphql/src/mutations/mod.rs
@@ -1,0 +1,28 @@
+// Copyright 2023 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod user_email;
+
+use async_graphql::MergedObject;
+
+/// The mutations root of the GraphQL interface.
+#[derive(Default, MergedObject)]
+pub struct RootMutations(user_email::UserEmailMutations);
+
+impl RootMutations {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+}

--- a/crates/graphql/src/mutations/mod.rs
+++ b/crates/graphql/src/mutations/mod.rs
@@ -18,9 +18,9 @@ use async_graphql::MergedObject;
 
 /// The mutations root of the GraphQL interface.
 #[derive(Default, MergedObject)]
-pub struct RootMutations(user_email::UserEmailMutations);
+pub struct Mutation(user_email::UserEmailMutations);
 
-impl RootMutations {
+impl Mutation {
     #[must_use]
     pub fn new() -> Self {
         Self::default()

--- a/crates/graphql/src/mutations/user_email.rs
+++ b/crates/graphql/src/mutations/user_email.rs
@@ -13,11 +13,15 @@
 // limitations under the License.
 
 use anyhow::Context as _;
-use async_graphql::{Context, InputObject, Object, ID};
-use mas_storage::job::{JobRepositoryExt, ProvisionUserJob, VerifyEmailJob};
+use async_graphql::{Context, Description, Enum, InputObject, Object, ID};
+use mas_storage::{
+    job::{JobRepositoryExt, ProvisionUserJob, VerifyEmailJob},
+    user::UserRepository,
+    RepositoryAccess,
+};
 
 use crate::{
-    model::{NodeType, UserEmail},
+    model::{NodeType, User, UserEmail},
     state::ContextExt,
 };
 
@@ -35,11 +39,121 @@ struct AddEmailInput {
     user_id: ID,
 }
 
+/// The status of the `addEmail` mutation
+#[derive(Enum, Copy, Clone, Eq, PartialEq)]
+pub enum AddEmailStatus {
+    /// The email address was added
+    Added,
+    /// The email address already exists
+    Exists,
+}
+
+/// The payload of the `addEmail` mutation
+#[derive(Description)]
+enum AddEmailPayload {
+    Added(mas_data_model::UserEmail),
+    Exists(mas_data_model::UserEmail),
+}
+
+#[Object(use_type_description)]
+impl AddEmailPayload {
+    /// Status of the operation
+    async fn status(&self) -> AddEmailStatus {
+        match self {
+            AddEmailPayload::Added(_) => AddEmailStatus::Added,
+            AddEmailPayload::Exists(_) => AddEmailStatus::Exists,
+        }
+    }
+
+    /// The email address that was added
+    async fn email(&self) -> UserEmail {
+        match self {
+            AddEmailPayload::Added(email) | AddEmailPayload::Exists(email) => {
+                UserEmail(email.clone())
+            }
+        }
+    }
+
+    /// The user to whom the email address was added
+    async fn user(&self, ctx: &Context<'_>) -> Result<User, async_graphql::Error> {
+        let state = ctx.state();
+        let mut repo = state.repository().await?;
+
+        let user_id = match self {
+            AddEmailPayload::Added(email) | AddEmailPayload::Exists(email) => email.user_id,
+        };
+
+        let user = repo
+            .user()
+            .lookup(user_id)
+            .await?
+            .context("User not found")?;
+
+        Ok(User(user))
+    }
+}
+
 /// The input for the `sendVerificationEmail` mutation
 #[derive(InputObject)]
 struct SendVerificationEmailInput {
     /// The ID of the email address to verify
     user_email_id: ID,
+}
+
+/// The status of the `sendVerificationEmail` mutation
+#[derive(Enum, Copy, Clone, Eq, PartialEq)]
+enum SendVerificationEmailStatus {
+    /// The verification email was sent
+    Sent,
+    /// The email address is already verified
+    AlreadyVerified,
+}
+
+/// The payload of the `sendVerificationEmail` mutation
+#[derive(Description)]
+enum SendVerificationEmailPayload {
+    Sent(mas_data_model::UserEmail),
+    AlreadyVerified(mas_data_model::UserEmail),
+}
+
+#[Object(use_type_description)]
+impl SendVerificationEmailPayload {
+    /// Status of the operation
+    async fn status(&self) -> SendVerificationEmailStatus {
+        match self {
+            SendVerificationEmailPayload::Sent(_) => SendVerificationEmailStatus::Sent,
+            SendVerificationEmailPayload::AlreadyVerified(_) => {
+                SendVerificationEmailStatus::AlreadyVerified
+            }
+        }
+    }
+
+    /// The email address to which the verification email was sent
+    async fn email(&self) -> UserEmail {
+        match self {
+            SendVerificationEmailPayload::Sent(email)
+            | SendVerificationEmailPayload::AlreadyVerified(email) => UserEmail(email.clone()),
+        }
+    }
+
+    /// The user to whom the email address belongs
+    async fn user(&self, ctx: &Context<'_>) -> Result<User, async_graphql::Error> {
+        let state = ctx.state();
+        let mut repo = state.repository().await?;
+
+        let user_id = match self {
+            SendVerificationEmailPayload::Sent(email)
+            | SendVerificationEmailPayload::AlreadyVerified(email) => email.user_id,
+        };
+
+        let user = repo
+            .user()
+            .lookup(user_id)
+            .await?
+            .context("User not found")?;
+
+        Ok(User(user))
+    }
 }
 
 /// The input for the `verifyEmail` mutation
@@ -51,6 +165,68 @@ struct VerifyEmailInput {
     code: String,
 }
 
+/// The status of the `verifyEmail` mutation
+#[derive(Enum, Copy, Clone, Eq, PartialEq)]
+enum VerifyEmailStatus {
+    /// The email address was just verified
+    Verified,
+    /// The email address was already verified before
+    AlreadyVerified,
+    /// The verification code is invalid
+    InvalidCode,
+}
+
+/// The payload of the `verifyEmail` mutation
+#[derive(Description)]
+enum VerifyEmailPayload {
+    Verified(mas_data_model::UserEmail),
+    AlreadyVerified(mas_data_model::UserEmail),
+    InvalidCode,
+}
+
+#[Object(use_type_description)]
+impl VerifyEmailPayload {
+    /// Status of the operation
+    async fn status(&self) -> VerifyEmailStatus {
+        match self {
+            VerifyEmailPayload::Verified(_) => VerifyEmailStatus::Verified,
+            VerifyEmailPayload::AlreadyVerified(_) => VerifyEmailStatus::AlreadyVerified,
+            VerifyEmailPayload::InvalidCode => VerifyEmailStatus::InvalidCode,
+        }
+    }
+
+    /// The email address that was verified
+    async fn email(&self) -> Option<UserEmail> {
+        match self {
+            VerifyEmailPayload::Verified(email) | VerifyEmailPayload::AlreadyVerified(email) => {
+                Some(UserEmail(email.clone()))
+            }
+            VerifyEmailPayload::InvalidCode => None,
+        }
+    }
+
+    /// The user to whom the email address belongs
+    async fn user(&self, ctx: &Context<'_>) -> Result<Option<User>, async_graphql::Error> {
+        let state = ctx.state();
+        let mut repo = state.repository().await?;
+
+        let user_id = match self {
+            VerifyEmailPayload::Verified(email) | VerifyEmailPayload::AlreadyVerified(email) => {
+                email.user_id
+            }
+            VerifyEmailPayload::InvalidCode => return Ok(None),
+        };
+
+        let user = repo
+            .user()
+            .lookup(user_id)
+            .await?
+            .context("User not found")?;
+
+        Ok(Some(User(user)))
+    }
+}
+
 #[Object]
 impl UserEmailMutations {
     /// Add an email address to the specified user
@@ -58,7 +234,7 @@ impl UserEmailMutations {
         &self,
         ctx: &Context<'_>,
         input: AddEmailInput,
-    ) -> Result<UserEmail, async_graphql::Error> {
+    ) -> Result<AddEmailPayload, async_graphql::Error> {
         let state = ctx.state();
         let id = NodeType::User.extract_ulid(&input.user_id)?;
         let requester = ctx.requester();
@@ -75,15 +251,18 @@ impl UserEmailMutations {
         // duplicated in mas_handlers
         // Find an existing email address
         let existing_user_email = repo.user_email().find(user, &input.email).await?;
-        let user_email = if let Some(user_email) = existing_user_email {
-            user_email
+        let (added, user_email) = if let Some(user_email) = existing_user_email {
+            (false, user_email)
         } else {
             let clock = state.clock();
             let mut rng = state.rng();
 
-            repo.user_email()
+            let user_email = repo
+                .user_email()
                 .add(&mut rng, &clock, user, input.email)
-                .await?
+                .await?;
+
+            (true, user_email)
         };
 
         // Schedule a job to verify the email address if needed
@@ -95,7 +274,12 @@ impl UserEmailMutations {
 
         repo.save().await?;
 
-        Ok(UserEmail(user_email))
+        let payload = if added {
+            AddEmailPayload::Added(user_email)
+        } else {
+            AddEmailPayload::Exists(user_email)
+        };
+        Ok(payload)
     }
 
     /// Send a verification code for an email address
@@ -103,7 +287,7 @@ impl UserEmailMutations {
         &self,
         ctx: &Context<'_>,
         input: SendVerificationEmailInput,
-    ) -> Result<UserEmail, async_graphql::Error> {
+    ) -> Result<SendVerificationEmailPayload, async_graphql::Error> {
         let state = ctx.state();
         let user_email_id = NodeType::UserEmail.extract_ulid(&input.user_email_id)?;
         let requester = ctx.requester();
@@ -122,7 +306,8 @@ impl UserEmailMutations {
         }
 
         // Schedule a job to verify the email address if needed
-        if user_email.confirmed_at.is_none() {
+        let needs_verification = user_email.confirmed_at.is_none();
+        if needs_verification {
             repo.job()
                 .schedule_job(VerifyEmailJob::new(&user_email))
                 .await?;
@@ -130,7 +315,12 @@ impl UserEmailMutations {
 
         repo.save().await?;
 
-        Ok(UserEmail(user_email))
+        let payload = if needs_verification {
+            SendVerificationEmailPayload::Sent(user_email)
+        } else {
+            SendVerificationEmailPayload::AlreadyVerified(user_email)
+        };
+        Ok(payload)
     }
 
     /// Submit a verification code for an email address
@@ -138,7 +328,7 @@ impl UserEmailMutations {
         &self,
         ctx: &Context<'_>,
         input: VerifyEmailInput,
-    ) -> Result<UserEmail, async_graphql::Error> {
+    ) -> Result<VerifyEmailPayload, async_graphql::Error> {
         let state = ctx.state();
         let user_email_id = NodeType::UserEmail.extract_ulid(&input.user_email_id)?;
         let requester = ctx.requester();
@@ -161,7 +351,7 @@ impl UserEmailMutations {
         if user_email.confirmed_at.is_some() {
             // Just return the email address if it's already verified
             // XXX: should we return an error instead?
-            return Ok(UserEmail(user_email));
+            return Ok(VerifyEmailPayload::AlreadyVerified(user_email));
         }
 
         // XXX: this logic should be extracted somewhere else, since most of it is
@@ -172,13 +362,12 @@ impl UserEmailMutations {
             .user_email()
             .find_verification_code(&clock, &user_email, &input.code)
             .await?
-            .context("Invalid verification code")?;
+            .filter(|v| v.is_valid());
 
-        if verification.is_valid() {
-            return Err(async_graphql::Error::new("Invalid verification code"));
-        }
+        let Some(verification) = verification else {
+            return Ok(VerifyEmailPayload::InvalidCode);
+        };
 
-        // TODO: display nice errors if the code was already consumed or expired
         repo.user_email()
             .consume_verification_code(&clock, verification)
             .await?;
@@ -197,6 +386,6 @@ impl UserEmailMutations {
 
         repo.save().await?;
 
-        Ok(UserEmail(user_email))
+        Ok(VerifyEmailPayload::Verified(user_email))
     }
 }

--- a/crates/graphql/src/query.rs
+++ b/crates/graphql/src/query.rs
@@ -1,0 +1,281 @@
+// Copyright 2023 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use async_graphql::{
+    connection::{query, Connection, Edge, OpaqueCursor},
+    Context, Description, Object, ID,
+};
+use mas_storage::Pagination;
+
+use crate::{
+    model::{
+        BrowserSession, Cursor, Node, NodeCursor, NodeType, OAuth2Client, UpstreamOAuth2Link,
+        UpstreamOAuth2Provider, User, UserEmail,
+    },
+    state::ContextExt,
+};
+
+/// The query root of the GraphQL interface.
+#[derive(Default, Description)]
+pub struct RootQuery {
+    _private: (),
+}
+
+impl RootQuery {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[Object(use_type_description)]
+impl RootQuery {
+    /// Get the current logged in browser session
+    async fn current_browser_session(
+        &self,
+        ctx: &Context<'_>,
+    ) -> Result<Option<BrowserSession>, async_graphql::Error> {
+        let session = ctx.session().cloned();
+        Ok(session.map(BrowserSession::from))
+    }
+
+    /// Get the current logged in user
+    async fn current_user(&self, ctx: &Context<'_>) -> Result<Option<User>, async_graphql::Error> {
+        let session = ctx.session().cloned();
+        Ok(session.map(User::from))
+    }
+
+    /// Fetch an OAuth 2.0 client by its ID.
+    async fn oauth2_client(
+        &self,
+        ctx: &Context<'_>,
+        id: ID,
+    ) -> Result<Option<OAuth2Client>, async_graphql::Error> {
+        let state = ctx.state();
+        let id = NodeType::OAuth2Client.extract_ulid(&id)?;
+
+        let mut repo = state.repository().await?;
+        let client = repo.oauth2_client().lookup(id).await?;
+        repo.cancel().await?;
+
+        Ok(client.map(OAuth2Client))
+    }
+
+    /// Fetch a user by its ID.
+    async fn user(&self, ctx: &Context<'_>, id: ID) -> Result<Option<User>, async_graphql::Error> {
+        let id = NodeType::User.extract_ulid(&id)?;
+
+        let session = ctx.session().cloned();
+
+        let Some(session) = session else { return Ok(None) };
+        let current_user = session.user;
+
+        if current_user.id == id {
+            Ok(Some(User(current_user)))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Fetch a browser session by its ID.
+    async fn browser_session(
+        &self,
+        ctx: &Context<'_>,
+        id: ID,
+    ) -> Result<Option<BrowserSession>, async_graphql::Error> {
+        let state = ctx.state();
+        let id = NodeType::BrowserSession.extract_ulid(&id)?;
+
+        let session = ctx.session().cloned();
+        let mut repo = state.repository().await?;
+
+        let Some(session) = session else { return Ok(None) };
+        let current_user = session.user;
+
+        let browser_session = repo.browser_session().lookup(id).await?;
+
+        repo.cancel().await?;
+
+        let ret = browser_session.and_then(|browser_session| {
+            if browser_session.user.id == current_user.id {
+                Some(BrowserSession(browser_session))
+            } else {
+                None
+            }
+        });
+
+        Ok(ret)
+    }
+
+    /// Fetch a user email by its ID.
+    async fn user_email(
+        &self,
+        ctx: &Context<'_>,
+        id: ID,
+    ) -> Result<Option<UserEmail>, async_graphql::Error> {
+        let state = ctx.state();
+        let id = NodeType::UserEmail.extract_ulid(&id)?;
+
+        let session = ctx.session().cloned();
+        let mut repo = state.repository().await?;
+
+        let Some(session) = session else { return Ok(None) };
+        let current_user = session.user;
+
+        let user_email = repo
+            .user_email()
+            .lookup(id)
+            .await?
+            .filter(|e| e.user_id == current_user.id);
+
+        repo.cancel().await?;
+
+        Ok(user_email.map(UserEmail))
+    }
+
+    /// Fetch an upstream OAuth 2.0 link by its ID.
+    async fn upstream_oauth2_link(
+        &self,
+        ctx: &Context<'_>,
+        id: ID,
+    ) -> Result<Option<UpstreamOAuth2Link>, async_graphql::Error> {
+        let state = ctx.state();
+        let id = NodeType::UpstreamOAuth2Link.extract_ulid(&id)?;
+
+        let session = ctx.session().cloned();
+        let mut repo = state.repository().await?;
+
+        let Some(session) = session else { return Ok(None) };
+        let current_user = session.user;
+
+        let link = repo.upstream_oauth_link().lookup(id).await?;
+
+        // Ensure that the link belongs to the current user
+        let link = link.filter(|link| link.user_id == Some(current_user.id));
+
+        Ok(link.map(UpstreamOAuth2Link::new))
+    }
+
+    /// Fetch an upstream OAuth 2.0 provider by its ID.
+    async fn upstream_oauth2_provider(
+        &self,
+        ctx: &Context<'_>,
+        id: ID,
+    ) -> Result<Option<UpstreamOAuth2Provider>, async_graphql::Error> {
+        let state = ctx.state();
+        let id = NodeType::UpstreamOAuth2Provider.extract_ulid(&id)?;
+
+        let mut repo = state.repository().await?;
+        let provider = repo.upstream_oauth_provider().lookup(id).await?;
+        repo.cancel().await?;
+
+        Ok(provider.map(UpstreamOAuth2Provider::new))
+    }
+
+    /// Get a list of upstream OAuth 2.0 providers.
+    async fn upstream_oauth2_providers(
+        &self,
+        ctx: &Context<'_>,
+
+        #[graphql(desc = "Returns the elements in the list that come after the cursor.")]
+        after: Option<String>,
+        #[graphql(desc = "Returns the elements in the list that come before the cursor.")]
+        before: Option<String>,
+        #[graphql(desc = "Returns the first *n* elements from the list.")] first: Option<i32>,
+        #[graphql(desc = "Returns the last *n* elements from the list.")] last: Option<i32>,
+    ) -> Result<Connection<Cursor, UpstreamOAuth2Provider>, async_graphql::Error> {
+        let state = ctx.state();
+        let mut repo = state.repository().await?;
+
+        query(
+            after,
+            before,
+            first,
+            last,
+            |after, before, first, last| async move {
+                let after_id = after
+                    .map(|x: OpaqueCursor<NodeCursor>| {
+                        x.extract_for_type(NodeType::UpstreamOAuth2Provider)
+                    })
+                    .transpose()?;
+                let before_id = before
+                    .map(|x: OpaqueCursor<NodeCursor>| {
+                        x.extract_for_type(NodeType::UpstreamOAuth2Provider)
+                    })
+                    .transpose()?;
+                let pagination = Pagination::try_new(before_id, after_id, first, last)?;
+
+                let page = repo
+                    .upstream_oauth_provider()
+                    .list_paginated(pagination)
+                    .await?;
+
+                repo.cancel().await?;
+
+                let mut connection = Connection::new(page.has_previous_page, page.has_next_page);
+                connection.edges.extend(page.edges.into_iter().map(|p| {
+                    Edge::new(
+                        OpaqueCursor(NodeCursor(NodeType::UpstreamOAuth2Provider, p.id)),
+                        UpstreamOAuth2Provider::new(p),
+                    )
+                }));
+
+                Ok::<_, async_graphql::Error>(connection)
+            },
+        )
+        .await
+    }
+
+    /// Fetches an object given its ID.
+    async fn node(&self, ctx: &Context<'_>, id: ID) -> Result<Option<Node>, async_graphql::Error> {
+        let (node_type, _id) = NodeType::from_id(&id)?;
+
+        let ret = match node_type {
+            // TODO
+            NodeType::Authentication
+            | NodeType::CompatSession
+            | NodeType::CompatSsoLogin
+            | NodeType::OAuth2Session => None,
+
+            NodeType::UpstreamOAuth2Provider => self
+                .upstream_oauth2_provider(ctx, id)
+                .await?
+                .map(|c| Node::UpstreamOAuth2Provider(Box::new(c))),
+
+            NodeType::UpstreamOAuth2Link => self
+                .upstream_oauth2_link(ctx, id)
+                .await?
+                .map(|c| Node::UpstreamOAuth2Link(Box::new(c))),
+
+            NodeType::OAuth2Client => self
+                .oauth2_client(ctx, id)
+                .await?
+                .map(|c| Node::OAuth2Client(Box::new(c))),
+
+            NodeType::UserEmail => self
+                .user_email(ctx, id)
+                .await?
+                .map(|e| Node::UserEmail(Box::new(e))),
+
+            NodeType::BrowserSession => self
+                .browser_session(ctx, id)
+                .await?
+                .map(|s| Node::BrowserSession(Box::new(s))),
+
+            NodeType::User => self.user(ctx, id).await?.map(|u| Node::User(Box::new(u))),
+        };
+
+        Ok(ret)
+    }
+}

--- a/crates/graphql/src/query/mod.rs
+++ b/crates/graphql/src/query/mod.rs
@@ -26,9 +26,9 @@ use self::{upstream_oauth::UpstreamOAuthQuery, viewer::ViewerQuery};
 
 /// The query root of the GraphQL interface.
 #[derive(Default, MergedObject)]
-pub struct RootQuery(BaseQuery, UpstreamOAuthQuery, ViewerQuery);
+pub struct Query(BaseQuery, UpstreamOAuthQuery, ViewerQuery);
 
-impl RootQuery {
+impl Query {
     #[must_use]
     pub fn new() -> Self {
         Self::default()

--- a/crates/graphql/src/query/upstream_oauth.rs
+++ b/crates/graphql/src/query/upstream_oauth.rs
@@ -1,0 +1,121 @@
+// Copyright 2023 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use async_graphql::{
+    connection::{query, Connection, Edge, OpaqueCursor},
+    Context, Object, ID,
+};
+use mas_storage::Pagination;
+
+use crate::{
+    model::{Cursor, NodeCursor, NodeType, UpstreamOAuth2Link, UpstreamOAuth2Provider},
+    state::ContextExt,
+};
+
+#[derive(Default)]
+pub struct UpstreamOAuthQuery;
+
+#[Object]
+impl UpstreamOAuthQuery {
+    /// Fetch an upstream OAuth 2.0 link by its ID.
+    pub async fn upstream_oauth2_link(
+        &self,
+        ctx: &Context<'_>,
+        id: ID,
+    ) -> Result<Option<UpstreamOAuth2Link>, async_graphql::Error> {
+        let state = ctx.state();
+        let id = NodeType::UpstreamOAuth2Link.extract_ulid(&id)?;
+        let requester = ctx.requester();
+
+        let Some(current_user) = requester.user() else { return Ok(None) };
+        let mut repo = state.repository().await?;
+
+        let link = repo.upstream_oauth_link().lookup(id).await?;
+
+        // Ensure that the link belongs to the current user
+        let link = link.filter(|link| link.user_id == Some(current_user.id));
+
+        Ok(link.map(UpstreamOAuth2Link::new))
+    }
+
+    /// Fetch an upstream OAuth 2.0 provider by its ID.
+    pub async fn upstream_oauth2_provider(
+        &self,
+        ctx: &Context<'_>,
+        id: ID,
+    ) -> Result<Option<UpstreamOAuth2Provider>, async_graphql::Error> {
+        let state = ctx.state();
+        let id = NodeType::UpstreamOAuth2Provider.extract_ulid(&id)?;
+
+        let mut repo = state.repository().await?;
+        let provider = repo.upstream_oauth_provider().lookup(id).await?;
+        repo.cancel().await?;
+
+        Ok(provider.map(UpstreamOAuth2Provider::new))
+    }
+
+    /// Get a list of upstream OAuth 2.0 providers.
+    async fn upstream_oauth2_providers(
+        &self,
+        ctx: &Context<'_>,
+
+        #[graphql(desc = "Returns the elements in the list that come after the cursor.")]
+        after: Option<String>,
+        #[graphql(desc = "Returns the elements in the list that come before the cursor.")]
+        before: Option<String>,
+        #[graphql(desc = "Returns the first *n* elements from the list.")] first: Option<i32>,
+        #[graphql(desc = "Returns the last *n* elements from the list.")] last: Option<i32>,
+    ) -> Result<Connection<Cursor, UpstreamOAuth2Provider>, async_graphql::Error> {
+        let state = ctx.state();
+        let mut repo = state.repository().await?;
+
+        query(
+            after,
+            before,
+            first,
+            last,
+            |after, before, first, last| async move {
+                let after_id = after
+                    .map(|x: OpaqueCursor<NodeCursor>| {
+                        x.extract_for_type(NodeType::UpstreamOAuth2Provider)
+                    })
+                    .transpose()?;
+                let before_id = before
+                    .map(|x: OpaqueCursor<NodeCursor>| {
+                        x.extract_for_type(NodeType::UpstreamOAuth2Provider)
+                    })
+                    .transpose()?;
+                let pagination = Pagination::try_new(before_id, after_id, first, last)?;
+
+                let page = repo
+                    .upstream_oauth_provider()
+                    .list_paginated(pagination)
+                    .await?;
+
+                repo.cancel().await?;
+
+                let mut connection = Connection::new(page.has_previous_page, page.has_next_page);
+                connection.edges.extend(page.edges.into_iter().map(|p| {
+                    Edge::new(
+                        OpaqueCursor(NodeCursor(NodeType::UpstreamOAuth2Provider, p.id)),
+                        UpstreamOAuth2Provider::new(p),
+                    )
+                }));
+
+                Ok::<_, async_graphql::Error>(connection)
+            },
+        )
+        .await
+    }
+}

--- a/crates/graphql/src/query/viewer.rs
+++ b/crates/graphql/src/query/viewer.rs
@@ -1,0 +1,47 @@
+// Copyright 2023 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use async_graphql::{Context, Object};
+
+use crate::{
+    model::{Viewer, ViewerSession},
+    state::ContextExt,
+    Requester,
+};
+
+#[derive(Default)]
+pub struct ViewerQuery;
+
+#[Object]
+impl ViewerQuery {
+    /// Get the viewer
+    async fn viewer(&self, ctx: &Context<'_>) -> Viewer {
+        let requester = ctx.requester();
+
+        match requester {
+            Requester::BrowserSession(session) => Viewer::user(session.user.clone()),
+            Requester::Anonymous => Viewer::anonymous(),
+        }
+    }
+
+    /// Get the viewer's session
+    async fn viewer_session(&self, ctx: &Context<'_>) -> ViewerSession {
+        let requester = ctx.requester();
+
+        match requester {
+            Requester::BrowserSession(session) => ViewerSession::browser_session(session.clone()),
+            Requester::Anonymous => ViewerSession::anonymous(),
+        }
+    }
+}

--- a/crates/graphql/src/state.rs
+++ b/crates/graphql/src/state.rs
@@ -1,0 +1,41 @@
+// Copyright 2023 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use mas_data_model::BrowserSession;
+use mas_storage::{BoxClock, BoxRepository, BoxRng, RepositoryError};
+
+#[async_trait::async_trait]
+pub trait State {
+    async fn repository(&self) -> Result<BoxRepository, RepositoryError>;
+    fn clock(&self) -> BoxClock;
+    fn rng(&self) -> BoxRng;
+}
+
+pub type BoxState = Box<dyn State + Send + Sync + 'static>;
+
+pub trait ContextExt {
+    fn state(&self) -> &BoxState;
+
+    fn session(&self) -> Option<&BrowserSession>;
+}
+
+impl ContextExt for async_graphql::Context<'_> {
+    fn state(&self) -> &BoxState {
+        self.data_unchecked::<BoxState>()
+    }
+
+    fn session(&self) -> Option<&BrowserSession> {
+        self.data_opt()
+    }
+}

--- a/crates/graphql/src/state.rs
+++ b/crates/graphql/src/state.rs
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use mas_data_model::BrowserSession;
 use mas_storage::{BoxClock, BoxRepository, BoxRng, RepositoryError};
+
+use crate::Requester;
 
 #[async_trait::async_trait]
 pub trait State {
@@ -27,15 +28,15 @@ pub type BoxState = Box<dyn State + Send + Sync + 'static>;
 pub trait ContextExt {
     fn state(&self) -> &BoxState;
 
-    fn session(&self) -> Option<&BrowserSession>;
+    fn requester(&self) -> &Requester;
 }
 
 impl ContextExt for async_graphql::Context<'_> {
     fn state(&self) -> &BoxState {
-        self.data_unchecked::<BoxState>()
+        self.data_unchecked()
     }
 
-    fn session(&self) -> Option<&BrowserSession> {
-        self.data_opt()
+    fn requester(&self) -> &Requester {
+        self.data_unchecked()
     }
 }

--- a/crates/handlers/src/test_utils.rs
+++ b/crates/handlers/src/test_utils.rs
@@ -105,7 +105,7 @@ impl TestState {
 
         let policy_factory = Arc::new(policy_factory);
 
-        let graphql_schema = graphql_schema();
+        let graphql_schema = graphql_schema(&pool);
 
         let http_client_factory = HttpClientFactory::new(10);
 

--- a/crates/handlers/src/views/account/emails/verify.rs
+++ b/crates/handlers/src/views/account/emails/verify.rs
@@ -118,6 +118,9 @@ pub(crate) async fn post(
         .filter(|u| u.user_id == session.user.id)
         .context("Could not find user email")?;
 
+    // XXX: this logic should be extracted somewhere else, since most of it is
+    // duplicated in mas_graphql
+
     let verification = repo
         .user_email()
         .find_verification_code(&clock, &user_email, &form.code)

--- a/frontend/.eslintrc.cjs
+++ b/frontend/.eslintrc.cjs
@@ -51,6 +51,10 @@ module.exports = {
         "plugin:prettier/recommended",
       ],
       rules: {
+        "@graphql-eslint/input-name": [
+          "error",
+          { checkInputType: true, caseSensitiveInputType: false },
+        ],
         "@graphql-eslint/relay-edge-types": [
           "error",
           {
@@ -64,9 +68,9 @@ module.exports = {
           "error",
           {
             exceptions: {
-              // The '*Connection', '*Edge' and 'PageInfo' types don't have IDs
+              // The '*Connection', '*Edge', '*Payload' and 'PageInfo' types don't have IDs
               types: ["PageInfo"],
-              suffixes: ["Connection", "Edge"],
+              suffixes: ["Connection", "Edge", "Payload"],
             },
           },
         ],

--- a/frontend/schema.graphql
+++ b/frontend/schema.graphql
@@ -12,6 +12,10 @@ input AddEmailInput {
   userId: ID!
 }
 
+type Anonymous implements Node {
+  id: ID!
+}
+
 """
 An authentication records when a user enter their credential in a browser
 session.
@@ -331,10 +335,11 @@ type RootQuery {
   Get the current logged in browser session
   """
   currentBrowserSession: BrowserSession
+    @deprecated(reason: "Use `viewerSession` instead.")
   """
   Get the current logged in user
   """
-  currentUser: User
+  currentUser: User @deprecated(reason: "Use `viewer` instead.")
   """
   Fetch an OAuth 2.0 client by its ID.
   """
@@ -351,6 +356,10 @@ type RootQuery {
   Fetch a user email by its ID.
   """
   userEmail(id: ID!): UserEmail
+  """
+  Fetches an object given its ID.
+  """
+  node(id: ID!): Node
   """
   Fetch an upstream OAuth 2.0 link by its ID.
   """
@@ -369,9 +378,13 @@ type RootQuery {
     last: Int
   ): UpstreamOAuth2ProviderConnection!
   """
-  Fetches an object given its ID.
+  Get the viewer
   """
-  node(id: ID!): Node
+  viewer: Viewer!
+  """
+  Get the viewer's session
+  """
+  viewerSession: ViewerSession!
 }
 
 """
@@ -621,6 +634,16 @@ input VerifyEmailInput {
   """
   code: String!
 }
+
+"""
+Represents the current viewer
+"""
+union Viewer = User | Anonymous
+
+"""
+Represents the current viewer's session
+"""
+union ViewerSession = BrowserSession | Anonymous
 
 schema {
   query: RootQuery

--- a/frontend/schema.graphql
+++ b/frontend/schema.graphql
@@ -1,4 +1,18 @@
 """
+The input for the `addEmail` mutation
+"""
+input AddEmailInput {
+  """
+  The email address to add
+  """
+  email: String!
+  """
+  The ID of the user to add the email address to
+  """
+  userId: ID!
+}
+
+"""
 An authentication records when a user enter their credential in a browser
 session.
 """
@@ -298,15 +312,15 @@ type RootMutations {
   """
   Add an email address to the specified user
   """
-  addEmail(email: String!, userId: ID!): UserEmail!
+  addEmail(input: AddEmailInput!): UserEmail!
   """
   Send a verification code for an email address
   """
-  sendVerificationEmail(userEmailId: ID!): UserEmail!
+  sendVerificationEmail(input: SendVerificationEmailInput!): UserEmail!
   """
   Submit a verification code for an email address
   """
-  verifyEmail(userEmailId: ID!, code: String!): UserEmail!
+  verifyEmail(input: VerifyEmailInput!): UserEmail!
 }
 
 """
@@ -358,6 +372,16 @@ type RootQuery {
   Fetches an object given its ID.
   """
   node(id: ID!): Node
+}
+
+"""
+The input for the `sendVerificationEmail` mutation
+"""
+input SendVerificationEmailInput {
+  """
+  The ID of the email address to verify
+  """
+  userEmailId: ID!
 }
 
 type UpstreamOAuth2Link implements Node & CreationEvent {
@@ -582,6 +606,20 @@ type UserEmailEdge {
   The item at the end of the edge
   """
   node: UserEmail!
+}
+
+"""
+The input for the `verifyEmail` mutation
+"""
+input VerifyEmailInput {
+  """
+  The ID of the email address to verify
+  """
+  userEmailId: ID!
+  """
+  The verification code
+  """
+  code: String!
 }
 
 schema {

--- a/frontend/schema.graphql
+++ b/frontend/schema.graphql
@@ -292,6 +292,24 @@ type PageInfo {
 }
 
 """
+The mutations root of the GraphQL interface.
+"""
+type RootMutations {
+  """
+  Add an email address to the specified user
+  """
+  addEmail(email: String!, userId: ID!): UserEmail!
+  """
+  Send a verification code for an email address
+  """
+  sendVerificationEmail(userEmailId: ID!): UserEmail!
+  """
+  Submit a verification code for an email address
+  """
+  verifyEmail(userEmailId: ID!, code: String!): UserEmail!
+}
+
+"""
 The query root of the GraphQL interface.
 """
 type RootQuery {
@@ -568,4 +586,5 @@ type UserEmailEdge {
 
 schema {
   query: RootQuery
+  mutation: RootMutations
 }

--- a/frontend/schema.graphql
+++ b/frontend/schema.graphql
@@ -12,6 +12,38 @@ input AddEmailInput {
   userId: ID!
 }
 
+"""
+The payload of the `addEmail` mutation
+"""
+type AddEmailPayload {
+  """
+  Status of the operation
+  """
+  status: AddEmailStatus!
+  """
+  The email address that was added
+  """
+  email: UserEmail!
+  """
+  The user to whom the email address was added
+  """
+  user: User!
+}
+
+"""
+The status of the `addEmail` mutation
+"""
+enum AddEmailStatus {
+  """
+  The email address was added
+  """
+  ADDED
+  """
+  The email address already exists
+  """
+  EXISTS
+}
+
 type Anonymous implements Node {
   id: ID!
 }
@@ -188,6 +220,26 @@ The input/output is a string in RFC3339 format.
 scalar DateTime
 
 """
+The mutations root of the GraphQL interface.
+"""
+type Mutation {
+  """
+  Add an email address to the specified user
+  """
+  addEmail(input: AddEmailInput!): AddEmailPayload!
+  """
+  Send a verification code for an email address
+  """
+  sendVerificationEmail(
+    input: SendVerificationEmailInput!
+  ): SendVerificationEmailPayload!
+  """
+  Submit a verification code for an email address
+  """
+  verifyEmail(input: VerifyEmailInput!): VerifyEmailPayload!
+}
+
+"""
 An object with an ID.
 """
 interface Node {
@@ -310,27 +362,9 @@ type PageInfo {
 }
 
 """
-The mutations root of the GraphQL interface.
-"""
-type RootMutations {
-  """
-  Add an email address to the specified user
-  """
-  addEmail(input: AddEmailInput!): UserEmail!
-  """
-  Send a verification code for an email address
-  """
-  sendVerificationEmail(input: SendVerificationEmailInput!): UserEmail!
-  """
-  Submit a verification code for an email address
-  """
-  verifyEmail(input: VerifyEmailInput!): UserEmail!
-}
-
-"""
 The query root of the GraphQL interface.
 """
-type RootQuery {
+type Query {
   """
   Get the current logged in browser session
   """
@@ -395,6 +429,38 @@ input SendVerificationEmailInput {
   The ID of the email address to verify
   """
   userEmailId: ID!
+}
+
+"""
+The payload of the `sendVerificationEmail` mutation
+"""
+type SendVerificationEmailPayload {
+  """
+  Status of the operation
+  """
+  status: SendVerificationEmailStatus!
+  """
+  The email address to which the verification email was sent
+  """
+  email: UserEmail!
+  """
+  The user to whom the email address belongs
+  """
+  user: User!
+}
+
+"""
+The status of the `sendVerificationEmail` mutation
+"""
+enum SendVerificationEmailStatus {
+  """
+  The verification email was sent
+  """
+  SENT
+  """
+  The email address is already verified
+  """
+  ALREADY_VERIFIED
 }
 
 type UpstreamOAuth2Link implements Node & CreationEvent {
@@ -636,6 +702,42 @@ input VerifyEmailInput {
 }
 
 """
+The payload of the `verifyEmail` mutation
+"""
+type VerifyEmailPayload {
+  """
+  Status of the operation
+  """
+  status: VerifyEmailStatus!
+  """
+  The email address that was verified
+  """
+  email: UserEmail
+  """
+  The user to whom the email address belongs
+  """
+  user: User
+}
+
+"""
+The status of the `verifyEmail` mutation
+"""
+enum VerifyEmailStatus {
+  """
+  The email address was just verified
+  """
+  VERIFIED
+  """
+  The email address was already verified before
+  """
+  ALREADY_VERIFIED
+  """
+  The verification code is invalid
+  """
+  INVALID_CODE
+}
+
+"""
 Represents the current viewer
 """
 union Viewer = User | Anonymous
@@ -646,6 +748,6 @@ Represents the current viewer's session
 union ViewerSession = BrowserSession | Anonymous
 
 schema {
-  query: RootQuery
-  mutation: RootMutations
+  query: Query
+  mutation: Mutation
 }

--- a/frontend/src/gql/gql.ts
+++ b/frontend/src/gql/gql.ts
@@ -20,7 +20,7 @@ const documents = {
     "\n  fragment OAuth2Session_session on Oauth2Session {\n    id\n    scope\n    client {\n      id\n      clientId\n      clientName\n      clientUri\n    }\n  }\n": types.OAuth2Session_SessionFragmentDoc,
     "\n  fragment OAuth2SessionList_user on User {\n    oauth2Sessions(first: $count, after: $cursor) {\n      edges {\n        cursor\n        node {\n          id\n          ...OAuth2Session_session\n        }\n      }\n    }\n  }\n": types.OAuth2SessionList_UserFragmentDoc,
     "\n  query BrowserSessionQuery($id: ID!) {\n    browserSession(id: $id) {\n      id\n      createdAt\n      lastAuthentication {\n        id\n        createdAt\n      }\n      user {\n        id\n        username\n      }\n    }\n  }\n": types.BrowserSessionQueryDocument,
-    "\n  query HomeQuery($count: Int!, $cursor: String) {\n    currentBrowserSession {\n      id\n      user {\n        id\n        username\n\n        ...CompatSsoLoginList_user\n        ...BrowserSessionList_user\n        ...OAuth2SessionList_user\n      }\n    }\n  }\n": types.HomeQueryDocument,
+    "\n  query HomeQuery($count: Int!, $cursor: String) {\n    # eslint-disable-next-line @graphql-eslint/no-deprecated\n    currentBrowserSession {\n      id\n      user {\n        id\n        username\n\n        ...CompatSsoLoginList_user\n        ...BrowserSessionList_user\n        ...OAuth2SessionList_user\n      }\n    }\n  }\n": types.HomeQueryDocument,
     "\n  query OAuth2ClientQuery($id: ID!) {\n    oauth2Client(id: $id) {\n      id\n      clientId\n      clientName\n      clientUri\n      tosUri\n      policyUri\n      redirectUris\n    }\n  }\n": types.OAuth2ClientQueryDocument,
 };
 
@@ -69,7 +69,7 @@ export function graphql(source: "\n  query BrowserSessionQuery($id: ID!) {\n    
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
-export function graphql(source: "\n  query HomeQuery($count: Int!, $cursor: String) {\n    currentBrowserSession {\n      id\n      user {\n        id\n        username\n\n        ...CompatSsoLoginList_user\n        ...BrowserSessionList_user\n        ...OAuth2SessionList_user\n      }\n    }\n  }\n"): (typeof documents)["\n  query HomeQuery($count: Int!, $cursor: String) {\n    currentBrowserSession {\n      id\n      user {\n        id\n        username\n\n        ...CompatSsoLoginList_user\n        ...BrowserSessionList_user\n        ...OAuth2SessionList_user\n      }\n    }\n  }\n"];
+export function graphql(source: "\n  query HomeQuery($count: Int!, $cursor: String) {\n    # eslint-disable-next-line @graphql-eslint/no-deprecated\n    currentBrowserSession {\n      id\n      user {\n        id\n        username\n\n        ...CompatSsoLoginList_user\n        ...BrowserSessionList_user\n        ...OAuth2SessionList_user\n      }\n    }\n  }\n"): (typeof documents)["\n  query HomeQuery($count: Int!, $cursor: String) {\n    # eslint-disable-next-line @graphql-eslint/no-deprecated\n    currentBrowserSession {\n      id\n      user {\n        id\n        username\n\n        ...CompatSsoLoginList_user\n        ...BrowserSessionList_user\n        ...OAuth2SessionList_user\n      }\n    }\n  }\n"];
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */

--- a/frontend/src/gql/graphql.ts
+++ b/frontend/src/gql/graphql.ts
@@ -30,6 +30,11 @@ export type AddEmailInput = {
   userId: Scalars['ID'];
 };
 
+export type Anonymous = Node & {
+  __typename?: 'Anonymous';
+  id: Scalars['ID'];
+};
+
 /**
  * An authentication records when a user enter their credential in a browser
  * session.
@@ -249,9 +254,15 @@ export type RootQuery = {
   __typename?: 'RootQuery';
   /** Fetch a browser session by its ID. */
   browserSession?: Maybe<BrowserSession>;
-  /** Get the current logged in browser session */
+  /**
+   * Get the current logged in browser session
+   * @deprecated Use `viewerSession` instead.
+   */
   currentBrowserSession?: Maybe<BrowserSession>;
-  /** Get the current logged in user */
+  /**
+   * Get the current logged in user
+   * @deprecated Use `viewer` instead.
+   */
   currentUser?: Maybe<User>;
   /** Fetches an object given its ID. */
   node?: Maybe<Node>;
@@ -267,6 +278,10 @@ export type RootQuery = {
   user?: Maybe<User>;
   /** Fetch a user email by its ID. */
   userEmail?: Maybe<UserEmail>;
+  /** Get the viewer */
+  viewer: Viewer;
+  /** Get the viewer's session */
+  viewerSession: ViewerSession;
 };
 
 
@@ -500,6 +515,12 @@ export type VerifyEmailInput = {
   /** The ID of the email address to verify */
   userEmailId: Scalars['ID'];
 };
+
+/** Represents the current viewer */
+export type Viewer = Anonymous | User;
+
+/** Represents the current viewer's session */
+export type ViewerSession = Anonymous | BrowserSession;
 
 export type BrowserSession_SessionFragment = { __typename?: 'BrowserSession', id: string, createdAt: any, lastAuthentication?: { __typename?: 'Authentication', id: string, createdAt: any } | null } & { ' $fragmentName'?: 'BrowserSession_SessionFragment' };
 

--- a/frontend/src/gql/graphql.ts
+++ b/frontend/src/gql/graphql.ts
@@ -22,6 +22,14 @@ export type Scalars = {
   Url: any;
 };
 
+/** The input for the `addEmail` mutation */
+export type AddEmailInput = {
+  /** The email address to add */
+  email: Scalars['String'];
+  /** The ID of the user to add the email address to */
+  userId: Scalars['ID'];
+};
+
 /**
  * An authentication records when a user enter their credential in a browser
  * session.
@@ -221,21 +229,19 @@ export type RootMutations = {
 
 /** The mutations root of the GraphQL interface. */
 export type RootMutationsAddEmailArgs = {
-  email: Scalars['String'];
-  userId: Scalars['ID'];
+  input: AddEmailInput;
 };
 
 
 /** The mutations root of the GraphQL interface. */
 export type RootMutationsSendVerificationEmailArgs = {
-  userEmailId: Scalars['ID'];
+  input: SendVerificationEmailInput;
 };
 
 
 /** The mutations root of the GraphQL interface. */
 export type RootMutationsVerifyEmailArgs = {
-  code: Scalars['String'];
-  userEmailId: Scalars['ID'];
+  input: VerifyEmailInput;
 };
 
 /** The query root of the GraphQL interface. */
@@ -312,6 +318,12 @@ export type RootQueryUserArgs = {
 /** The query root of the GraphQL interface. */
 export type RootQueryUserEmailArgs = {
   id: Scalars['ID'];
+};
+
+/** The input for the `sendVerificationEmail` mutation */
+export type SendVerificationEmailInput = {
+  /** The ID of the email address to verify */
+  userEmailId: Scalars['ID'];
 };
 
 export type UpstreamOAuth2Link = CreationEvent & Node & {
@@ -479,6 +491,14 @@ export type UserEmailEdge = {
   cursor: Scalars['String'];
   /** The item at the end of the edge */
   node: UserEmail;
+};
+
+/** The input for the `verifyEmail` mutation */
+export type VerifyEmailInput = {
+  /** The verification code */
+  code: Scalars['String'];
+  /** The ID of the email address to verify */
+  userEmailId: Scalars['ID'];
 };
 
 export type BrowserSession_SessionFragment = { __typename?: 'BrowserSession', id: string, createdAt: any, lastAuthentication?: { __typename?: 'Authentication', id: string, createdAt: any } | null } & { ' $fragmentName'?: 'BrowserSession_SessionFragment' };

--- a/frontend/src/gql/graphql.ts
+++ b/frontend/src/gql/graphql.ts
@@ -207,6 +207,37 @@ export type PageInfo = {
   startCursor?: Maybe<Scalars['String']>;
 };
 
+/** The mutations root of the GraphQL interface. */
+export type RootMutations = {
+  __typename?: 'RootMutations';
+  /** Add an email address to the specified user */
+  addEmail: UserEmail;
+  /** Send a verification code for an email address */
+  sendVerificationEmail: UserEmail;
+  /** Submit a verification code for an email address */
+  verifyEmail: UserEmail;
+};
+
+
+/** The mutations root of the GraphQL interface. */
+export type RootMutationsAddEmailArgs = {
+  email: Scalars['String'];
+  userId: Scalars['ID'];
+};
+
+
+/** The mutations root of the GraphQL interface. */
+export type RootMutationsSendVerificationEmailArgs = {
+  userEmailId: Scalars['ID'];
+};
+
+
+/** The mutations root of the GraphQL interface. */
+export type RootMutationsVerifyEmailArgs = {
+  code: Scalars['String'];
+  userEmailId: Scalars['ID'];
+};
+
 /** The query root of the GraphQL interface. */
 export type RootQuery = {
   __typename?: 'RootQuery';

--- a/frontend/src/gql/graphql.ts
+++ b/frontend/src/gql/graphql.ts
@@ -30,6 +30,25 @@ export type AddEmailInput = {
   userId: Scalars['ID'];
 };
 
+/** The payload of the `addEmail` mutation */
+export type AddEmailPayload = {
+  __typename?: 'AddEmailPayload';
+  /** The email address that was added */
+  email: UserEmail;
+  /** Status of the operation */
+  status: AddEmailStatus;
+  /** The user to whom the email address was added */
+  user: User;
+};
+
+/** The status of the `addEmail` mutation */
+export enum AddEmailStatus {
+  /** The email address was added */
+  Added = 'ADDED',
+  /** The email address already exists */
+  Exists = 'EXISTS'
+}
+
 export type Anonymous = Node & {
   __typename?: 'Anonymous';
   id: Scalars['ID'];
@@ -145,6 +164,35 @@ export type CreationEvent = {
   createdAt: Scalars['DateTime'];
 };
 
+/** The mutations root of the GraphQL interface. */
+export type Mutation = {
+  __typename?: 'Mutation';
+  /** Add an email address to the specified user */
+  addEmail: AddEmailPayload;
+  /** Send a verification code for an email address */
+  sendVerificationEmail: SendVerificationEmailPayload;
+  /** Submit a verification code for an email address */
+  verifyEmail: VerifyEmailPayload;
+};
+
+
+/** The mutations root of the GraphQL interface. */
+export type MutationAddEmailArgs = {
+  input: AddEmailInput;
+};
+
+
+/** The mutations root of the GraphQL interface. */
+export type MutationSendVerificationEmailArgs = {
+  input: SendVerificationEmailInput;
+};
+
+
+/** The mutations root of the GraphQL interface. */
+export type MutationVerifyEmailArgs = {
+  input: VerifyEmailInput;
+};
+
 /** An object with an ID. */
 export type Node = {
   /** ID of the object. */
@@ -220,38 +268,9 @@ export type PageInfo = {
   startCursor?: Maybe<Scalars['String']>;
 };
 
-/** The mutations root of the GraphQL interface. */
-export type RootMutations = {
-  __typename?: 'RootMutations';
-  /** Add an email address to the specified user */
-  addEmail: UserEmail;
-  /** Send a verification code for an email address */
-  sendVerificationEmail: UserEmail;
-  /** Submit a verification code for an email address */
-  verifyEmail: UserEmail;
-};
-
-
-/** The mutations root of the GraphQL interface. */
-export type RootMutationsAddEmailArgs = {
-  input: AddEmailInput;
-};
-
-
-/** The mutations root of the GraphQL interface. */
-export type RootMutationsSendVerificationEmailArgs = {
-  input: SendVerificationEmailInput;
-};
-
-
-/** The mutations root of the GraphQL interface. */
-export type RootMutationsVerifyEmailArgs = {
-  input: VerifyEmailInput;
-};
-
 /** The query root of the GraphQL interface. */
-export type RootQuery = {
-  __typename?: 'RootQuery';
+export type Query = {
+  __typename?: 'Query';
   /** Fetch a browser session by its ID. */
   browserSession?: Maybe<BrowserSession>;
   /**
@@ -286,37 +305,37 @@ export type RootQuery = {
 
 
 /** The query root of the GraphQL interface. */
-export type RootQueryBrowserSessionArgs = {
+export type QueryBrowserSessionArgs = {
   id: Scalars['ID'];
 };
 
 
 /** The query root of the GraphQL interface. */
-export type RootQueryNodeArgs = {
+export type QueryNodeArgs = {
   id: Scalars['ID'];
 };
 
 
 /** The query root of the GraphQL interface. */
-export type RootQueryOauth2ClientArgs = {
+export type QueryOauth2ClientArgs = {
   id: Scalars['ID'];
 };
 
 
 /** The query root of the GraphQL interface. */
-export type RootQueryUpstreamOauth2LinkArgs = {
+export type QueryUpstreamOauth2LinkArgs = {
   id: Scalars['ID'];
 };
 
 
 /** The query root of the GraphQL interface. */
-export type RootQueryUpstreamOauth2ProviderArgs = {
+export type QueryUpstreamOauth2ProviderArgs = {
   id: Scalars['ID'];
 };
 
 
 /** The query root of the GraphQL interface. */
-export type RootQueryUpstreamOauth2ProvidersArgs = {
+export type QueryUpstreamOauth2ProvidersArgs = {
   after?: InputMaybe<Scalars['String']>;
   before?: InputMaybe<Scalars['String']>;
   first?: InputMaybe<Scalars['Int']>;
@@ -325,13 +344,13 @@ export type RootQueryUpstreamOauth2ProvidersArgs = {
 
 
 /** The query root of the GraphQL interface. */
-export type RootQueryUserArgs = {
+export type QueryUserArgs = {
   id: Scalars['ID'];
 };
 
 
 /** The query root of the GraphQL interface. */
-export type RootQueryUserEmailArgs = {
+export type QueryUserEmailArgs = {
   id: Scalars['ID'];
 };
 
@@ -340,6 +359,25 @@ export type SendVerificationEmailInput = {
   /** The ID of the email address to verify */
   userEmailId: Scalars['ID'];
 };
+
+/** The payload of the `sendVerificationEmail` mutation */
+export type SendVerificationEmailPayload = {
+  __typename?: 'SendVerificationEmailPayload';
+  /** The email address to which the verification email was sent */
+  email: UserEmail;
+  /** Status of the operation */
+  status: SendVerificationEmailStatus;
+  /** The user to whom the email address belongs */
+  user: User;
+};
+
+/** The status of the `sendVerificationEmail` mutation */
+export enum SendVerificationEmailStatus {
+  /** The email address is already verified */
+  AlreadyVerified = 'ALREADY_VERIFIED',
+  /** The verification email was sent */
+  Sent = 'SENT'
+}
 
 export type UpstreamOAuth2Link = CreationEvent & Node & {
   __typename?: 'UpstreamOAuth2Link';
@@ -516,6 +554,27 @@ export type VerifyEmailInput = {
   userEmailId: Scalars['ID'];
 };
 
+/** The payload of the `verifyEmail` mutation */
+export type VerifyEmailPayload = {
+  __typename?: 'VerifyEmailPayload';
+  /** The email address that was verified */
+  email?: Maybe<UserEmail>;
+  /** Status of the operation */
+  status: VerifyEmailStatus;
+  /** The user to whom the email address belongs */
+  user?: Maybe<User>;
+};
+
+/** The status of the `verifyEmail` mutation */
+export enum VerifyEmailStatus {
+  /** The email address was already verified before */
+  AlreadyVerified = 'ALREADY_VERIFIED',
+  /** The verification code is invalid */
+  InvalidCode = 'INVALID_CODE',
+  /** The email address was just verified */
+  Verified = 'VERIFIED'
+}
+
 /** Represents the current viewer */
 export type Viewer = Anonymous | User;
 
@@ -548,7 +607,7 @@ export type BrowserSessionQueryQueryVariables = Exact<{
 }>;
 
 
-export type BrowserSessionQueryQuery = { __typename?: 'RootQuery', browserSession?: { __typename?: 'BrowserSession', id: string, createdAt: any, lastAuthentication?: { __typename?: 'Authentication', id: string, createdAt: any } | null, user: { __typename?: 'User', id: string, username: string } } | null };
+export type BrowserSessionQueryQuery = { __typename?: 'Query', browserSession?: { __typename?: 'BrowserSession', id: string, createdAt: any, lastAuthentication?: { __typename?: 'Authentication', id: string, createdAt: any } | null, user: { __typename?: 'User', id: string, username: string } } | null };
 
 export type HomeQueryQueryVariables = Exact<{
   count: Scalars['Int'];
@@ -556,7 +615,7 @@ export type HomeQueryQueryVariables = Exact<{
 }>;
 
 
-export type HomeQueryQuery = { __typename?: 'RootQuery', currentBrowserSession?: { __typename?: 'BrowserSession', id: string, user: (
+export type HomeQueryQuery = { __typename?: 'Query', currentBrowserSession?: { __typename?: 'BrowserSession', id: string, user: (
       { __typename?: 'User', id: string, username: string }
       & { ' $fragmentRefs'?: { 'CompatSsoLoginList_UserFragment': CompatSsoLoginList_UserFragment;'BrowserSessionList_UserFragment': BrowserSessionList_UserFragment;'OAuth2SessionList_UserFragment': OAuth2SessionList_UserFragment } }
     ) } | null };
@@ -566,7 +625,7 @@ export type OAuth2ClientQueryQueryVariables = Exact<{
 }>;
 
 
-export type OAuth2ClientQueryQuery = { __typename?: 'RootQuery', oauth2Client?: { __typename?: 'Oauth2Client', id: string, clientId: string, clientName?: string | null, clientUri?: any | null, tosUri?: any | null, policyUri?: any | null, redirectUris: Array<any> } | null };
+export type OAuth2ClientQueryQuery = { __typename?: 'Query', oauth2Client?: { __typename?: 'Oauth2Client', id: string, clientId: string, clientName?: string | null, clientUri?: any | null, tosUri?: any | null, policyUri?: any | null, redirectUris: Array<any> } | null };
 
 export const BrowserSession_SessionFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"BrowserSession_session"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"BrowserSession"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"createdAt"}},{"kind":"Field","name":{"kind":"Name","value":"lastAuthentication"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"createdAt"}}]}}]}}]} as unknown as DocumentNode<BrowserSession_SessionFragment, unknown>;
 export const BrowserSessionList_UserFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"BrowserSessionList_user"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"User"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"browserSessions"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"first"},"value":{"kind":"Variable","name":{"kind":"Name","value":"count"}}},{"kind":"Argument","name":{"kind":"Name","value":"after"},"value":{"kind":"Variable","name":{"kind":"Name","value":"cursor"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"edges"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"cursor"}},{"kind":"Field","name":{"kind":"Name","value":"node"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"FragmentSpread","name":{"kind":"Name","value":"BrowserSession_session"}}]}}]}}]}}]}},{"kind":"FragmentDefinition","name":{"kind":"Name","value":"BrowserSession_session"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"BrowserSession"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"createdAt"}},{"kind":"Field","name":{"kind":"Name","value":"lastAuthentication"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"createdAt"}}]}}]}}]} as unknown as DocumentNode<BrowserSessionList_UserFragment, unknown>;

--- a/frontend/src/gql/schema.ts
+++ b/frontend/src/gql/schema.ts
@@ -4,7 +4,9 @@ export default {
     queryType: {
       name: "RootQuery",
     },
-    mutationType: null,
+    mutationType: {
+      name: "RootMutations",
+    },
     subscriptionType: null,
     types: [
       {
@@ -796,6 +798,102 @@ export default {
               name: "Any",
             },
             args: [],
+          },
+        ],
+        interfaces: [],
+      },
+      {
+        kind: "OBJECT",
+        name: "RootMutations",
+        fields: [
+          {
+            name: "addEmail",
+            type: {
+              kind: "NON_NULL",
+              ofType: {
+                kind: "OBJECT",
+                name: "UserEmail",
+                ofType: null,
+              },
+            },
+            args: [
+              {
+                name: "email",
+                type: {
+                  kind: "NON_NULL",
+                  ofType: {
+                    kind: "SCALAR",
+                    name: "Any",
+                  },
+                },
+              },
+              {
+                name: "userId",
+                type: {
+                  kind: "NON_NULL",
+                  ofType: {
+                    kind: "SCALAR",
+                    name: "Any",
+                  },
+                },
+              },
+            ],
+          },
+          {
+            name: "sendVerificationEmail",
+            type: {
+              kind: "NON_NULL",
+              ofType: {
+                kind: "OBJECT",
+                name: "UserEmail",
+                ofType: null,
+              },
+            },
+            args: [
+              {
+                name: "userEmailId",
+                type: {
+                  kind: "NON_NULL",
+                  ofType: {
+                    kind: "SCALAR",
+                    name: "Any",
+                  },
+                },
+              },
+            ],
+          },
+          {
+            name: "verifyEmail",
+            type: {
+              kind: "NON_NULL",
+              ofType: {
+                kind: "OBJECT",
+                name: "UserEmail",
+                ofType: null,
+              },
+            },
+            args: [
+              {
+                name: "code",
+                type: {
+                  kind: "NON_NULL",
+                  ofType: {
+                    kind: "SCALAR",
+                    name: "Any",
+                  },
+                },
+              },
+              {
+                name: "userEmailId",
+                type: {
+                  kind: "NON_NULL",
+                  ofType: {
+                    kind: "SCALAR",
+                    name: "Any",
+                  },
+                },
+              },
+            ],
           },
         ],
         interfaces: [],

--- a/frontend/src/gql/schema.ts
+++ b/frontend/src/gql/schema.ts
@@ -2,13 +2,55 @@ import { IntrospectionQuery } from "graphql";
 export default {
   __schema: {
     queryType: {
-      name: "RootQuery",
+      name: "Query",
     },
     mutationType: {
-      name: "RootMutations",
+      name: "Mutation",
     },
     subscriptionType: null,
     types: [
+      {
+        kind: "OBJECT",
+        name: "AddEmailPayload",
+        fields: [
+          {
+            name: "email",
+            type: {
+              kind: "NON_NULL",
+              ofType: {
+                kind: "OBJECT",
+                name: "UserEmail",
+                ofType: null,
+              },
+            },
+            args: [],
+          },
+          {
+            name: "status",
+            type: {
+              kind: "NON_NULL",
+              ofType: {
+                kind: "SCALAR",
+                name: "Any",
+              },
+            },
+            args: [],
+          },
+          {
+            name: "user",
+            type: {
+              kind: "NON_NULL",
+              ofType: {
+                kind: "OBJECT",
+                name: "User",
+                ofType: null,
+              },
+            },
+            args: [],
+          },
+        ],
+        interfaces: [],
+      },
       {
         kind: "OBJECT",
         name: "Anonymous",
@@ -483,6 +525,82 @@ export default {
         ],
       },
       {
+        kind: "OBJECT",
+        name: "Mutation",
+        fields: [
+          {
+            name: "addEmail",
+            type: {
+              kind: "NON_NULL",
+              ofType: {
+                kind: "OBJECT",
+                name: "AddEmailPayload",
+                ofType: null,
+              },
+            },
+            args: [
+              {
+                name: "input",
+                type: {
+                  kind: "NON_NULL",
+                  ofType: {
+                    kind: "SCALAR",
+                    name: "Any",
+                  },
+                },
+              },
+            ],
+          },
+          {
+            name: "sendVerificationEmail",
+            type: {
+              kind: "NON_NULL",
+              ofType: {
+                kind: "OBJECT",
+                name: "SendVerificationEmailPayload",
+                ofType: null,
+              },
+            },
+            args: [
+              {
+                name: "input",
+                type: {
+                  kind: "NON_NULL",
+                  ofType: {
+                    kind: "SCALAR",
+                    name: "Any",
+                  },
+                },
+              },
+            ],
+          },
+          {
+            name: "verifyEmail",
+            type: {
+              kind: "NON_NULL",
+              ofType: {
+                kind: "OBJECT",
+                name: "VerifyEmailPayload",
+                ofType: null,
+              },
+            },
+            args: [
+              {
+                name: "input",
+                type: {
+                  kind: "NON_NULL",
+                  ofType: {
+                    kind: "SCALAR",
+                    name: "Any",
+                  },
+                },
+              },
+            ],
+          },
+        ],
+        interfaces: [],
+      },
+      {
         kind: "INTERFACE",
         name: "Node",
         fields: [
@@ -831,83 +949,7 @@ export default {
       },
       {
         kind: "OBJECT",
-        name: "RootMutations",
-        fields: [
-          {
-            name: "addEmail",
-            type: {
-              kind: "NON_NULL",
-              ofType: {
-                kind: "OBJECT",
-                name: "UserEmail",
-                ofType: null,
-              },
-            },
-            args: [
-              {
-                name: "input",
-                type: {
-                  kind: "NON_NULL",
-                  ofType: {
-                    kind: "SCALAR",
-                    name: "Any",
-                  },
-                },
-              },
-            ],
-          },
-          {
-            name: "sendVerificationEmail",
-            type: {
-              kind: "NON_NULL",
-              ofType: {
-                kind: "OBJECT",
-                name: "UserEmail",
-                ofType: null,
-              },
-            },
-            args: [
-              {
-                name: "input",
-                type: {
-                  kind: "NON_NULL",
-                  ofType: {
-                    kind: "SCALAR",
-                    name: "Any",
-                  },
-                },
-              },
-            ],
-          },
-          {
-            name: "verifyEmail",
-            type: {
-              kind: "NON_NULL",
-              ofType: {
-                kind: "OBJECT",
-                name: "UserEmail",
-                ofType: null,
-              },
-            },
-            args: [
-              {
-                name: "input",
-                type: {
-                  kind: "NON_NULL",
-                  ofType: {
-                    kind: "SCALAR",
-                    name: "Any",
-                  },
-                },
-              },
-            ],
-          },
-        ],
-        interfaces: [],
-      },
-      {
-        kind: "OBJECT",
-        name: "RootQuery",
+        name: "Query",
         fields: [
           {
             name: "browserSession",
@@ -1127,6 +1169,48 @@ export default {
               ofType: {
                 kind: "UNION",
                 name: "ViewerSession",
+                ofType: null,
+              },
+            },
+            args: [],
+          },
+        ],
+        interfaces: [],
+      },
+      {
+        kind: "OBJECT",
+        name: "SendVerificationEmailPayload",
+        fields: [
+          {
+            name: "email",
+            type: {
+              kind: "NON_NULL",
+              ofType: {
+                kind: "OBJECT",
+                name: "UserEmail",
+                ofType: null,
+              },
+            },
+            args: [],
+          },
+          {
+            name: "status",
+            type: {
+              kind: "NON_NULL",
+              ofType: {
+                kind: "SCALAR",
+                name: "Any",
+              },
+            },
+            args: [],
+          },
+          {
+            name: "user",
+            type: {
+              kind: "NON_NULL",
+              ofType: {
+                kind: "OBJECT",
+                name: "User",
                 ofType: null,
               },
             },
@@ -1830,6 +1914,42 @@ export default {
                 name: "UserEmail",
                 ofType: null,
               },
+            },
+            args: [],
+          },
+        ],
+        interfaces: [],
+      },
+      {
+        kind: "OBJECT",
+        name: "VerifyEmailPayload",
+        fields: [
+          {
+            name: "email",
+            type: {
+              kind: "OBJECT",
+              name: "UserEmail",
+              ofType: null,
+            },
+            args: [],
+          },
+          {
+            name: "status",
+            type: {
+              kind: "NON_NULL",
+              ofType: {
+                kind: "SCALAR",
+                name: "Any",
+              },
+            },
+            args: [],
+          },
+          {
+            name: "user",
+            type: {
+              kind: "OBJECT",
+              name: "User",
+              ofType: null,
             },
             args: [],
           },

--- a/frontend/src/gql/schema.ts
+++ b/frontend/src/gql/schema.ts
@@ -11,6 +11,29 @@ export default {
     types: [
       {
         kind: "OBJECT",
+        name: "Anonymous",
+        fields: [
+          {
+            name: "id",
+            type: {
+              kind: "NON_NULL",
+              ofType: {
+                kind: "SCALAR",
+                name: "Any",
+              },
+            },
+            args: [],
+          },
+        ],
+        interfaces: [
+          {
+            kind: "INTERFACE",
+            name: "Node",
+          },
+        ],
+      },
+      {
+        kind: "OBJECT",
         name: "Authentication",
         fields: [
           {
@@ -477,6 +500,10 @@ export default {
         ],
         interfaces: [],
         possibleTypes: [
+          {
+            kind: "OBJECT",
+            name: "Anonymous",
+          },
           {
             kind: "OBJECT",
             name: "Authentication",
@@ -1080,6 +1107,30 @@ export default {
                 },
               },
             ],
+          },
+          {
+            name: "viewer",
+            type: {
+              kind: "NON_NULL",
+              ofType: {
+                kind: "UNION",
+                name: "Viewer",
+                ofType: null,
+              },
+            },
+            args: [],
+          },
+          {
+            name: "viewerSession",
+            type: {
+              kind: "NON_NULL",
+              ofType: {
+                kind: "UNION",
+                name: "ViewerSession",
+                ofType: null,
+              },
+            },
+            args: [],
           },
         ],
         interfaces: [],
@@ -1784,6 +1835,34 @@ export default {
           },
         ],
         interfaces: [],
+      },
+      {
+        kind: "UNION",
+        name: "Viewer",
+        possibleTypes: [
+          {
+            kind: "OBJECT",
+            name: "Anonymous",
+          },
+          {
+            kind: "OBJECT",
+            name: "User",
+          },
+        ],
+      },
+      {
+        kind: "UNION",
+        name: "ViewerSession",
+        possibleTypes: [
+          {
+            kind: "OBJECT",
+            name: "Anonymous",
+          },
+          {
+            kind: "OBJECT",
+            name: "BrowserSession",
+          },
+        ],
       },
       {
         kind: "SCALAR",

--- a/frontend/src/gql/schema.ts
+++ b/frontend/src/gql/schema.ts
@@ -818,17 +818,7 @@ export default {
             },
             args: [
               {
-                name: "email",
-                type: {
-                  kind: "NON_NULL",
-                  ofType: {
-                    kind: "SCALAR",
-                    name: "Any",
-                  },
-                },
-              },
-              {
-                name: "userId",
+                name: "input",
                 type: {
                   kind: "NON_NULL",
                   ofType: {
@@ -851,7 +841,7 @@ export default {
             },
             args: [
               {
-                name: "userEmailId",
+                name: "input",
                 type: {
                   kind: "NON_NULL",
                   ofType: {
@@ -874,17 +864,7 @@ export default {
             },
             args: [
               {
-                name: "code",
-                type: {
-                  kind: "NON_NULL",
-                  ofType: {
-                    kind: "SCALAR",
-                    name: "Any",
-                  },
-                },
-              },
-              {
-                name: "userEmailId",
+                name: "input",
                 type: {
                   kind: "NON_NULL",
                   ofType: {

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -23,6 +23,7 @@ import { graphql } from "../gql";
 
 const QUERY = graphql(/* GraphQL */ `
   query HomeQuery($count: Int!, $cursor: String) {
+    # eslint-disable-next-line @graphql-eslint/no-deprecated
     currentBrowserSession {
       id
       user {


### PR DESCRIPTION
This adds 3 mutations, to add email addresses, send a verification email, and verify them.
