### PR TITLE
Update Rust to 1.69.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -182,8 +182,8 @@ jobs:
 
       - name: Install toolchain
         run: |
-          rustup toolchain install 1.67.0
-          rustup default 1.67.0
+          rustup toolchain install 1.69.0
+          rustup default 1.69.0
           rustup component add clippy
 
       - name: Setup OPA

--- a/crates/handlers/src/compat/login_sso_complete.rs
+++ b/crates/handlers/src/compat/login_sso_complete.rs
@@ -188,7 +188,7 @@ pub async fn post(
             existing_params,
             login_token: &login.login_token,
         };
-        let query = serde_urlencoded::to_string(&params)?;
+        let query = serde_urlencoded::to_string(params)?;
         redirect_uri.set_query(Some(&query));
         redirect_uri
     };

--- a/crates/handlers/src/test_utils.rs
+++ b/crates/handlers/src/test_utils.rs
@@ -42,8 +42,11 @@ use crate::{
     MatrixHomeserver,
 };
 
+// This might fail if it's not the first time it's being called, which is fine,
+// so we ignore the result
+#[allow(unused_must_use)]
 pub(crate) fn init_tracing() {
-    let _ = tracing_subscriber::fmt()
+    tracing_subscriber::fmt()
         .with_max_level(tracing::Level::INFO)
         .with_test_writer()
         .try_init();

--- a/crates/storage-pg/src/compat/mod.rs
+++ b/crates/storage-pg/src/compat/mod.rs
@@ -46,8 +46,6 @@ mod tests {
 
     #[sqlx::test(migrator = "crate::MIGRATOR")]
     async fn test_session_repository(pool: PgPool) {
-        const FIRST_TOKEN: &str = "first_access_token";
-        const SECOND_TOKEN: &str = "second_access_token";
         let mut rng = ChaChaRng::seed_from_u64(42);
         let clock = MockClock::default();
         let mut repo = PgRepository::from_pool(&pool).await.unwrap();

--- a/crates/tasks/src/lib.rs
+++ b/crates/tasks/src/lib.rs
@@ -82,11 +82,9 @@ impl State {
         &self.mailer
     }
 
+    // This is fine for now, we may move that to a trait at some point.
+    #[allow(clippy::unused_self, clippy::disallowed_methods)]
     pub fn rng(&self) -> rand_chacha::ChaChaRng {
-        let _ = self;
-
-        // This is fine.
-        #[allow(clippy::disallowed_methods)]
         rand_chacha::ChaChaRng::from_rng(rand::thread_rng()).expect("failed to seed rng")
     }
 


### PR DESCRIPTION
This bumps the Rust version in the Clippy stage, so it also fixes a bunch of Clippy lints.

It also bumps the Rust version in the Docker image, and fixes a bunch of things in the Dockerfile