### PR TITLE
Allow deserialisation of VerifiedClientMetadata for client restoration.

### DIFF
--- a/crates/oauth2-types/src/registration/mod.rs
+++ b/crates/oauth2-types/src/registration/mod.rs
@@ -777,7 +777,7 @@ impl ClientMetadata {
 /// ```
 ///
 /// [OpenID Connect Dynamic Client Registration Spec 1.0]: https://openid.net/specs/openid-connect-registration-1_0.html#ClientMetadata
-#[derive(Serialize, Debug, PartialEq, Eq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 #[serde(into = "ClientMetadataSerdeHelper")]
 pub struct VerifiedClientMetadata {
     inner: ClientMetadata,


### PR DESCRIPTION
In order to call [`set_registered_client_data`](https://github.com/matrix-org/matrix-rust-sdk/blob/e1d5fd80c2453f928207b592162b2f726da3a293/crates/matrix-sdk/src/oidc.rs#L314) in the Rust SDK on a restored client, the `VerifiedClientMetadata` needs to be deserialised too. As I understand it `ClientCredentials` is ok without as we can serialise just the `client_id` and create new credentials from it like so `ClientCredentials::None { client_id }`