### PR TITLE
Remove explicit generics from tasks layers

### DIFF
--- a/crates/tasks/src/database.rs
+++ b/crates/tasks/src/database.rs
@@ -78,7 +78,7 @@ pub(crate) fn register(
     let worker = WorkerBuilder::new(worker_name)
         .stream(CronStream::new(schedule).timer(TokioTimer).to_stream())
         .layer(state.inject())
-        .layer(metrics_layer::<CleanupExpiredTokensJob>())
+        .layer(metrics_layer())
         .build_fn(cleanup_expired_tokens);
 
     monitor.register(worker)

--- a/crates/tasks/src/email.rs
+++ b/crates/tasks/src/email.rs
@@ -101,8 +101,8 @@ pub(crate) fn register(
     let worker_name = format!("{job}-{suffix}", job = VerifyEmailJob::NAME);
     let worker = WorkerBuilder::new(worker_name)
         .layer(state.inject())
-        .layer(trace_layer::<VerifyEmailJob>())
-        .layer(metrics_layer::<JobWithSpanContext<VerifyEmailJob>>())
+        .layer(trace_layer())
+        .layer(metrics_layer())
         .with_storage(storage)
         .build_fn(verify_email);
     monitor.register(worker)

--- a/crates/tasks/src/matrix.rs
+++ b/crates/tasks/src/matrix.rs
@@ -322,7 +322,7 @@ pub(crate) fn register(
     let provision_user_worker = WorkerBuilder::new(worker_name)
         .layer(state.inject())
         .layer(trace_layer())
-        .layer(metrics_layer::<JobWithSpanContext<ProvisionUserJob>>())
+        .layer(metrics_layer())
         .with_storage(storage)
         .build_fn(provision_user);
 
@@ -331,7 +331,7 @@ pub(crate) fn register(
     let provision_device_worker = WorkerBuilder::new(worker_name)
         .layer(state.inject())
         .layer(trace_layer())
-        .layer(metrics_layer::<JobWithSpanContext<ProvisionDeviceJob>>())
+        .layer(metrics_layer())
         .with_storage(storage)
         .build_fn(provision_device);
 
@@ -340,7 +340,7 @@ pub(crate) fn register(
     let delete_device_worker = WorkerBuilder::new(worker_name)
         .layer(state.inject())
         .layer(trace_layer())
-        .layer(metrics_layer::<JobWithSpanContext<DeleteDeviceJob>>())
+        .layer(metrics_layer())
         .with_storage(storage)
         .build_fn(delete_device);
 

--- a/crates/tower/src/utils.rs
+++ b/crates/tower/src/utils.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use opentelemetry::{KeyValue, Value};
+use tower::{Layer, Service};
 
 /// A simple static key-value pair.
 #[derive(Clone, Debug)]
@@ -31,3 +32,67 @@ where
 /// make or enrich spans.
 #[derive(Clone, Debug)]
 pub struct FnWrapper<F>(pub F);
+
+/// A no-op layer that has the request type bound.
+#[derive(Clone, Copy, Debug)]
+pub struct IdentityLayer<R> {
+    _request: std::marker::PhantomData<R>,
+}
+
+impl<R> Default for IdentityLayer<R> {
+    fn default() -> Self {
+        Self {
+            _request: std::marker::PhantomData,
+        }
+    }
+}
+
+/// A no-op service that has the request type bound.
+#[derive(Clone, Copy, Debug)]
+pub struct IdentityService<R, S> {
+    _request: std::marker::PhantomData<R>,
+    inner: S,
+}
+
+impl<R, S> Default for IdentityService<R, S>
+where
+    S: Default,
+{
+    fn default() -> Self {
+        Self {
+            _request: std::marker::PhantomData,
+            inner: S::default(),
+        }
+    }
+}
+
+impl<R, S> Layer<S> for IdentityLayer<R> {
+    type Service = IdentityService<R, S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        IdentityService {
+            _request: std::marker::PhantomData,
+            inner,
+        }
+    }
+}
+
+impl<S, R> Service<R> for IdentityService<R, S>
+where
+    S: Service<R>,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = S::Future;
+
+    fn poll_ready(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: R) -> Self::Future {
+        self.inner.call(req)
+    }
+}


### PR DESCRIPTION
This defines an IdentityLayer<R> which is used to bind the request type
on the service, which helps with type inference.
