### PR TITLE
Import upstream OIDC claims on registration

### DIFF
--- a/crates/cli/src/commands/config.rs
+++ b/crates/cli/src/commands/config.rs
@@ -15,7 +15,7 @@
 use std::collections::HashSet;
 
 use clap::Parser;
-use mas_config::{ConfigurationSection, RootConfig};
+use mas_config::{ConfigurationSection, RootConfig, SyncConfig};
 use mas_storage::{
     upstream_oauth2::UpstreamOAuthProviderRepository, Repository, RepositoryAccess, SystemClock,
 };
@@ -142,7 +142,7 @@ async fn sync(root: &super::Options, prune: bool, dry_run: bool) -> anyhow::Resu
     let mut rng = rand_chacha::ChaChaRng::from_entropy();
     let clock = SystemClock::default();
 
-    let config: RootConfig = root.load_config()?;
+    let config: SyncConfig = root.load_config()?;
     let encrypter = config.secrets.encrypter();
     let pool = database_from_config(&config.database).await?;
     let mut repo = PgRepository::from_pool(&pool).await?.boxed();

--- a/crates/cli/src/commands/database.rs
+++ b/crates/cli/src/commands/database.rs
@@ -33,7 +33,7 @@ enum Subcommand {
 }
 
 impl Options {
-    pub async fn run(&self, root: &super::Options) -> anyhow::Result<()> {
+    pub async fn run(self, root: &super::Options) -> anyhow::Result<()> {
         let _span = info_span!("cli.database.migrate").entered();
         let config: DatabaseConfig = root.load_config()?;
         let pool = database_from_config(&config).await?;

--- a/crates/cli/src/commands/manage.rs
+++ b/crates/cli/src/commands/manage.rs
@@ -13,22 +13,17 @@
 // limitations under the License.
 
 use anyhow::Context;
-use clap::{Parser, ValueEnum};
-use mas_config::{DatabaseConfig, PasswordsConfig, RootConfig};
-use mas_data_model::{Device, TokenType, UpstreamOAuthProviderClaimsImports};
-use mas_iana::{jose::JsonWebSignatureAlg, oauth::OAuthClientAuthenticationMethod};
-use mas_router::UrlBuilder;
+use clap::Parser;
+use mas_config::{DatabaseConfig, PasswordsConfig};
+use mas_data_model::{Device, TokenType};
 use mas_storage::{
     compat::{CompatAccessTokenRepository, CompatSessionRepository},
-    oauth2::OAuth2ClientRepository,
-    upstream_oauth2::UpstreamOAuthProviderRepository,
     user::{UserEmailRepository, UserPasswordRepository, UserRepository},
     Repository, RepositoryAccess, SystemClock,
 };
 use mas_storage_pg::PgRepository;
-use oauth2_types::scope::Scope;
 use rand::SeedableRng;
-use tracing::{info, info_span, warn};
+use tracing::{info, info_span};
 
 use crate::util::{database_from_config, password_manager_from_config};
 
@@ -38,152 +33,13 @@ pub(super) struct Options {
     subcommand: Subcommand,
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
-enum AuthenticationMethod {
-    /// Client doesn't use any authentication
-    None,
-
-    /// Client sends its `client_secret` in the request body
-    ClientSecretPost,
-
-    /// Client sends its `client_secret` in the authorization header
-    ClientSecretBasic,
-
-    /// Client uses its `client_secret` to sign a client assertion JWT
-    ClientSecretJwt,
-
-    /// Client uses its private keys to sign a client assertion JWT
-    PrivateKeyJwt,
-}
-
-impl AuthenticationMethod {
-    fn requires_client_secret(self) -> bool {
-        matches!(
-            self,
-            Self::ClientSecretJwt | Self::ClientSecretPost | Self::ClientSecretBasic
-        )
-    }
-}
-
-impl From<AuthenticationMethod> for OAuthClientAuthenticationMethod {
-    fn from(val: AuthenticationMethod) -> Self {
-        (&val).into()
-    }
-}
-
-impl From<&AuthenticationMethod> for OAuthClientAuthenticationMethod {
-    fn from(val: &AuthenticationMethod) -> Self {
-        match val {
-            AuthenticationMethod::None => OAuthClientAuthenticationMethod::None,
-            AuthenticationMethod::ClientSecretPost => {
-                OAuthClientAuthenticationMethod::ClientSecretPost
-            }
-            AuthenticationMethod::ClientSecretBasic => {
-                OAuthClientAuthenticationMethod::ClientSecretBasic
-            }
-            AuthenticationMethod::ClientSecretJwt => {
-                OAuthClientAuthenticationMethod::ClientSecretJwt
-            }
-            AuthenticationMethod::PrivateKeyJwt => OAuthClientAuthenticationMethod::PrivateKeyJwt,
-        }
-    }
-}
-
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
-enum SigningAlgorithm {
-    #[value(name = "HS256")]
-    HS256,
-    #[value(name = "HS384")]
-    HS384,
-    #[value(name = "HS512")]
-    HS512,
-    #[value(name = "RS256")]
-    RS256,
-    #[value(name = "RS384")]
-    RS384,
-    #[value(name = "RS512")]
-    RS512,
-    #[value(name = "PS256")]
-    PS256,
-    #[value(name = "PS384")]
-    PS384,
-    #[value(name = "PS512")]
-    PS512,
-    #[value(name = "ES256")]
-    ES256,
-    #[value(name = "ES384")]
-    ES384,
-    #[value(name = "ES256K")]
-    ES256K,
-}
-
-impl From<SigningAlgorithm> for JsonWebSignatureAlg {
-    fn from(val: SigningAlgorithm) -> Self {
-        (&val).into()
-    }
-}
-
-impl From<&SigningAlgorithm> for JsonWebSignatureAlg {
-    fn from(val: &SigningAlgorithm) -> Self {
-        match val {
-            SigningAlgorithm::HS256 => Self::Hs256,
-            SigningAlgorithm::HS384 => Self::Hs384,
-            SigningAlgorithm::HS512 => Self::Hs512,
-            SigningAlgorithm::RS256 => Self::Rs256,
-            SigningAlgorithm::RS384 => Self::Rs384,
-            SigningAlgorithm::RS512 => Self::Rs512,
-            SigningAlgorithm::PS256 => Self::Ps256,
-            SigningAlgorithm::PS384 => Self::Ps384,
-            SigningAlgorithm::PS512 => Self::Ps512,
-            SigningAlgorithm::ES256 => Self::Es256,
-            SigningAlgorithm::ES384 => Self::Es384,
-            SigningAlgorithm::ES256K => Self::Es256K,
-        }
-    }
-}
-
 #[derive(Parser, Debug)]
 enum Subcommand {
     /// Mark email address as verified
     VerifyEmail { username: String, email: String },
 
-    /// Import clients from config
-    ImportClients {
-        /// Update existing clients
-        #[arg(long)]
-        update: bool,
-    },
-
     /// Set a user password
     SetPassword { username: String, password: String },
-
-    /// Add an OAuth 2.0 upstream
-    #[command(name = "add-oauth-upstream")]
-    AddOAuthUpstream {
-        /// Issuer URL
-        issuer: String,
-
-        /// Scope to ask for when authorizing with this upstream.
-        ///
-        /// This should include at least the `openid` scope.
-        scope: Scope,
-
-        /// Client authentication method used when using the token endpoint.
-        #[arg(value_enum)]
-        token_endpoint_auth_method: AuthenticationMethod,
-
-        /// Client ID
-        client_id: String,
-
-        /// JWT signing algorithm used when authenticating for the token
-        /// endpoint.
-        #[arg(long, value_enum)]
-        signing_alg: Option<SigningAlgorithm>,
-
-        /// Client Secret
-        #[arg(long)]
-        client_secret: Option<String>,
-    },
 
     /// Issue a compatibility token
     IssueCompatibilityToken {
@@ -267,128 +123,6 @@ impl Options {
 
                 repo.save().await?;
                 info!(?email, "Email marked as verified");
-
-                Ok(())
-            }
-
-            SC::ImportClients { update } => {
-                let _span = info_span!("cli.manage.import_clients").entered();
-
-                let config: RootConfig = root.load_config()?;
-                let pool = database_from_config(&config.database).await?;
-                let encrypter = config.secrets.encrypter();
-
-                let mut repo = PgRepository::from_pool(&pool).await?.boxed();
-
-                for client in config.clients.iter() {
-                    let client_id = client.client_id;
-
-                    let existing = repo.oauth2_client().lookup(client_id).await?.is_some();
-                    if !update && existing {
-                        warn!(%client_id, "Skipping already imported client. Run with --update to update existing clients.");
-                        continue;
-                    }
-
-                    if existing {
-                        info!(%client_id, "Updating client");
-                    } else {
-                        info!(%client_id, "Importing client");
-                    }
-
-                    let client_secret = client.client_secret();
-                    let client_auth_method = client.client_auth_method();
-                    let jwks = client.jwks();
-                    let jwks_uri = client.jwks_uri();
-
-                    // TODO: should be moved somewhere else
-                    let encrypted_client_secret = client_secret
-                        .map(|client_secret| encrypter.encrypt_to_string(client_secret.as_bytes()))
-                        .transpose()?;
-
-                    repo.oauth2_client()
-                        .add_from_config(
-                            &mut rng,
-                            &clock,
-                            client_id,
-                            client_auth_method,
-                            encrypted_client_secret,
-                            jwks.cloned(),
-                            jwks_uri.cloned(),
-                            client.redirect_uris.clone(),
-                        )
-                        .await?;
-                }
-
-                repo.save().await?;
-
-                Ok(())
-            }
-
-            SC::AddOAuthUpstream {
-                issuer,
-                scope,
-                token_endpoint_auth_method,
-                client_id,
-                client_secret,
-                signing_alg,
-            } => {
-                let _span = info_span!(
-                    "cli.manage.add_oauth_upstream",
-                    upstream_oauth_provider.issuer = issuer,
-                    upstream_oauth_provider.client_id = client_id,
-                )
-                .entered();
-
-                let config: RootConfig = root.load_config()?;
-                let encrypter = config.secrets.encrypter();
-                let pool = database_from_config(&config.database).await?;
-                let url_builder = UrlBuilder::new(config.http.public_base);
-                let mut repo = PgRepository::from_pool(&pool).await?.boxed();
-
-                let requires_client_secret = token_endpoint_auth_method.requires_client_secret();
-
-                let token_endpoint_auth_method: OAuthClientAuthenticationMethod =
-                    token_endpoint_auth_method.into();
-
-                let token_endpoint_signing_alg: Option<JsonWebSignatureAlg> =
-                    signing_alg.as_ref().map(Into::into);
-
-                tracing::info!(%issuer, %scope, %token_endpoint_auth_method, %client_id, "Adding OAuth upstream");
-
-                if client_secret.is_none() && requires_client_secret {
-                    tracing::warn!("Token endpoint auth method requires a client secret, but none were provided");
-                }
-
-                let encrypted_client_secret = client_secret
-                    .as_deref()
-                    .map(|client_secret| encrypter.encrypt_to_string(client_secret.as_bytes()))
-                    .transpose()?;
-
-                let provider = repo
-                    .upstream_oauth_provider()
-                    .add(
-                        &mut rng,
-                        &clock,
-                        issuer,
-                        scope,
-                        token_endpoint_auth_method,
-                        token_endpoint_signing_alg,
-                        client_id,
-                        encrypted_client_secret,
-                        UpstreamOAuthProviderClaimsImports::default(),
-                    )
-                    .await?;
-
-                repo.save().await?;
-
-                let redirect_uri = url_builder.upstream_oauth_callback(provider.id);
-                let auth_uri = url_builder.upstream_oauth_authorize(provider.id);
-                tracing::info!(
-                    %provider.id,
-                    %provider.client_id,
-                    provider.redirect_uri = %redirect_uri,
-                    "Test authorization by going to {auth_uri}"
-                );
 
                 Ok(())
             }

--- a/crates/cli/src/commands/manage.rs
+++ b/crates/cli/src/commands/manage.rs
@@ -15,7 +15,7 @@
 use anyhow::Context;
 use clap::{Parser, ValueEnum};
 use mas_config::{DatabaseConfig, PasswordsConfig, RootConfig};
-use mas_data_model::{Device, TokenType};
+use mas_data_model::{Device, TokenType, UpstreamOAuthProviderClaimsImports};
 use mas_iana::{jose::JsonWebSignatureAlg, oauth::OAuthClientAuthenticationMethod};
 use mas_router::UrlBuilder;
 use mas_storage::{
@@ -375,6 +375,7 @@ impl Options {
                         token_endpoint_signing_alg,
                         client_id.clone(),
                         encrypted_client_secret,
+                        UpstreamOAuthProviderClaimsImports::default(),
                     )
                     .await?;
 

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -74,7 +74,7 @@ impl Options {
         }
     }
 
-    pub fn load_config<'de, T: ConfigurationSection<'de>>(&self) -> anyhow::Result<T> {
+    pub fn load_config<T: ConfigurationSection>(&self) -> anyhow::Result<T> {
         let configs = if self.config.is_empty() {
             // Read the MAS_CONFIG environment variable
             std::env::var("MAS_CONFIG")

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -60,17 +60,17 @@ pub struct Options {
 }
 
 impl Options {
-    pub async fn run(&self) -> anyhow::Result<()> {
+    pub async fn run(mut self) -> anyhow::Result<()> {
         use Subcommand as S;
-        match &self.subcommand {
-            Some(S::Config(c)) => c.run(self).await,
-            Some(S::Database(c)) => c.run(self).await,
-            Some(S::Server(c)) => c.run(self).await,
-            Some(S::Worker(c)) => c.run(self).await,
-            Some(S::Manage(c)) => c.run(self).await,
-            Some(S::Templates(c)) => c.run(self).await,
-            Some(S::Debug(c)) => c.run(self).await,
-            None => self::server::Options::default().run(self).await,
+        match self.subcommand.take() {
+            Some(S::Config(c)) => c.run(&self).await,
+            Some(S::Database(c)) => c.run(&self).await,
+            Some(S::Server(c)) => c.run(&self).await,
+            Some(S::Worker(c)) => c.run(&self).await,
+            Some(S::Manage(c)) => c.run(&self).await,
+            Some(S::Templates(c)) => c.run(&self).await,
+            Some(S::Debug(c)) => c.run(&self).await,
+            None => self::server::Options::default().run(&self).await,
         }
     }
 

--- a/crates/cli/src/commands/server.rs
+++ b/crates/cli/src/commands/server.rs
@@ -17,7 +17,7 @@ use std::{sync::Arc, time::Duration};
 use anyhow::Context;
 use clap::Parser;
 use itertools::Itertools;
-use mas_config::RootConfig;
+use mas_config::AppConfig;
 use mas_handlers::{AppState, HttpClientFactory, MatrixHomeserver};
 use mas_listener::{server::Server, shutdown::ShutdownStream};
 use mas_matrix_synapse::SynapseConnection;
@@ -54,7 +54,7 @@ impl Options {
     #[allow(clippy::too_many_lines)]
     pub async fn run(self, root: &super::Options) -> anyhow::Result<()> {
         let span = info_span!("cli.run.init").entered();
-        let config: RootConfig = root.load_config()?;
+        let config: AppConfig = root.load_config()?;
 
         // Connect to the database
         info!("Connecting to the database");

--- a/crates/cli/src/commands/server.rs
+++ b/crates/cli/src/commands/server.rs
@@ -52,7 +52,7 @@ pub(super) struct Options {
 
 impl Options {
     #[allow(clippy::too_many_lines)]
-    pub async fn run(&self, root: &super::Options) -> anyhow::Result<()> {
+    pub async fn run(self, root: &super::Options) -> anyhow::Result<()> {
         let span = info_span!("cli.run.init").entered();
         let config: RootConfig = root.load_config()?;
 

--- a/crates/cli/src/commands/templates.rs
+++ b/crates/cli/src/commands/templates.rs
@@ -35,9 +35,9 @@ enum Subcommand {
 }
 
 impl Options {
-    pub async fn run(&self, _root: &super::Options) -> anyhow::Result<()> {
+    pub async fn run(self, _root: &super::Options) -> anyhow::Result<()> {
         use Subcommand as SC;
-        match &self.subcommand {
+        match self.subcommand {
             SC::Check { path } => {
                 let _span = info_span!("cli.templates.check").entered();
 
@@ -45,7 +45,7 @@ impl Options {
                 // XXX: we should disallow SeedableRng::from_entropy
                 let mut rng = rand_chacha::ChaChaRng::from_entropy();
                 let url_builder = mas_router::UrlBuilder::new("https://example.com/".parse()?);
-                let templates = Templates::load(path.clone(), url_builder).await?;
+                let templates = Templates::load(path, url_builder).await?;
                 templates.check_render(clock.now(), &mut rng).await?;
 
                 Ok(())

--- a/crates/cli/src/commands/worker.rs
+++ b/crates/cli/src/commands/worker.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use clap::Parser;
-use mas_config::RootConfig;
+use mas_config::AppConfig;
 use mas_handlers::HttpClientFactory;
 use mas_matrix_synapse::SynapseConnection;
 use mas_router::UrlBuilder;
@@ -31,7 +31,7 @@ pub(super) struct Options {}
 impl Options {
     pub async fn run(self, root: &super::Options) -> anyhow::Result<()> {
         let span = info_span!("cli.worker.init").entered();
-        let config: RootConfig = root.load_config()?;
+        let config: AppConfig = root.load_config()?;
 
         // Connect to the database
         info!("Connecting to the database");

--- a/crates/cli/src/commands/worker.rs
+++ b/crates/cli/src/commands/worker.rs
@@ -29,7 +29,7 @@ use crate::util::{database_from_config, mailer_from_config, templates_from_confi
 pub(super) struct Options {}
 
 impl Options {
-    pub async fn run(&self, root: &super::Options) -> anyhow::Result<()> {
+    pub async fn run(self, root: &super::Options) -> anyhow::Result<()> {
         let span = info_span!("cli.worker.init").entered();
         let config: RootConfig = root.load_config()?;
 

--- a/crates/config/src/sections/clients.rs
+++ b/crates/config/src/sections/clients.rs
@@ -171,7 +171,7 @@ impl DerefMut for ClientsConfig {
 }
 
 #[async_trait]
-impl ConfigurationSection<'_> for ClientsConfig {
+impl ConfigurationSection for ClientsConfig {
     fn path() -> &'static str {
         "clients"
     }

--- a/crates/config/src/sections/clients.rs
+++ b/crates/config/src/sections/clients.rs
@@ -69,7 +69,7 @@ pub enum ClientAuthMethodConfig {
     },
 
     /// `client_secret_basic`: a `client_assertion` sent in the request body and
-    /// signed by an asymetric key
+    /// signed by an asymmetric key
     PrivateKeyJwt(JwksOrJwksUri),
 }
 

--- a/crates/config/src/sections/csrf.rs
+++ b/crates/config/src/sections/csrf.rs
@@ -43,7 +43,7 @@ impl Default for CsrfConfig {
 }
 
 #[async_trait]
-impl ConfigurationSection<'_> for CsrfConfig {
+impl ConfigurationSection for CsrfConfig {
     fn path() -> &'static str {
         "csrf"
     }

--- a/crates/config/src/sections/database.rs
+++ b/crates/config/src/sections/database.rs
@@ -145,7 +145,7 @@ pub struct DatabaseConfig {
 }
 
 #[async_trait]
-impl ConfigurationSection<'_> for DatabaseConfig {
+impl ConfigurationSection for DatabaseConfig {
     fn path() -> &'static str {
         "database"
     }

--- a/crates/config/src/sections/email.rs
+++ b/crates/config/src/sections/email.rs
@@ -124,7 +124,7 @@ impl Default for EmailConfig {
 }
 
 #[async_trait]
-impl ConfigurationSection<'_> for EmailConfig {
+impl ConfigurationSection for EmailConfig {
     fn path() -> &'static str {
         "email"
     }

--- a/crates/config/src/sections/http.rs
+++ b/crates/config/src/sections/http.rs
@@ -370,7 +370,7 @@ impl Default for HttpConfig {
 }
 
 #[async_trait]
-impl ConfigurationSection<'_> for HttpConfig {
+impl ConfigurationSection for HttpConfig {
     fn path() -> &'static str {
         "http"
     }

--- a/crates/config/src/sections/matrix.rs
+++ b/crates/config/src/sections/matrix.rs
@@ -49,7 +49,7 @@ pub struct MatrixConfig {
 }
 
 #[async_trait]
-impl ConfigurationSection<'_> for MatrixConfig {
+impl ConfigurationSection for MatrixConfig {
     fn path() -> &'static str {
         "matrix"
     }

--- a/crates/config/src/sections/mod.rs
+++ b/crates/config/src/sections/mod.rs
@@ -48,7 +48,10 @@ pub use self::{
         TelemetryConfig, TracingConfig, TracingExporterConfig,
     },
     templates::TemplatesConfig,
-    upstream_oauth2::UpstreamOAuth2Config,
+    upstream_oauth2::{
+        ClaimsImports as UpstreamOAuth2ClaimsImports, ImportAction as UpstreamOAuth2ImportAction,
+        ImportPreference as UpstreamOAuth2ImportPreference, UpstreamOAuth2Config,
+    },
 };
 use crate::util::ConfigurationSection;
 

--- a/crates/config/src/sections/mod.rs
+++ b/crates/config/src/sections/mod.rs
@@ -28,6 +28,7 @@ mod policy;
 mod secrets;
 mod telemetry;
 mod templates;
+mod upstream_oauth2;
 
 pub use self::{
     clients::{ClientAuthMethodConfig, ClientConfig, ClientsConfig},
@@ -47,6 +48,7 @@ pub use self::{
         TelemetryConfig, TracingConfig, TracingExporterConfig,
     },
     templates::TemplatesConfig,
+    upstream_oauth2::UpstreamOAuth2Config,
 };
 use crate::util::ConfigurationSection;
 
@@ -94,6 +96,10 @@ pub struct RootConfig {
     /// Configuration related to the OPA policies
     #[serde(default)]
     pub policy: PolicyConfig,
+
+    /// Configuration related to upstream OAuth providers
+    #[serde(default)]
+    pub upstream_oauth2: UpstreamOAuth2Config,
 }
 
 #[async_trait]
@@ -118,6 +124,7 @@ impl ConfigurationSection<'_> for RootConfig {
             secrets: SecretsConfig::generate(&mut rng).await?,
             matrix: MatrixConfig::generate(&mut rng).await?,
             policy: PolicyConfig::generate(&mut rng).await?,
+            upstream_oauth2: UpstreamOAuth2Config::generate(&mut rng).await?,
         })
     }
 
@@ -134,6 +141,7 @@ impl ConfigurationSection<'_> for RootConfig {
             secrets: SecretsConfig::test(),
             matrix: MatrixConfig::test(),
             policy: PolicyConfig::test(),
+            upstream_oauth2: UpstreamOAuth2Config::test(),
         }
     }
 }

--- a/crates/config/src/sections/mod.rs
+++ b/crates/config/src/sections/mod.rs
@@ -106,7 +106,7 @@ pub struct RootConfig {
 }
 
 #[async_trait]
-impl ConfigurationSection<'_> for RootConfig {
+impl ConfigurationSection for RootConfig {
     fn path() -> &'static str {
         ""
     }
@@ -144,6 +144,118 @@ impl ConfigurationSection<'_> for RootConfig {
             secrets: SecretsConfig::test(),
             matrix: MatrixConfig::test(),
             policy: PolicyConfig::test(),
+            upstream_oauth2: UpstreamOAuth2Config::test(),
+        }
+    }
+}
+
+/// Partial configuration actually used by the server
+#[allow(missing_docs)]
+#[derive(Debug, Deserialize, Serialize)]
+pub struct AppConfig {
+    #[serde(default)]
+    pub http: HttpConfig,
+
+    #[serde(default)]
+    pub database: DatabaseConfig,
+
+    #[serde(default)]
+    pub templates: TemplatesConfig,
+
+    #[serde(default)]
+    pub csrf: CsrfConfig,
+
+    #[serde(default)]
+    pub email: EmailConfig,
+
+    pub secrets: SecretsConfig,
+
+    #[serde(default)]
+    pub passwords: PasswordsConfig,
+
+    pub matrix: MatrixConfig,
+
+    #[serde(default)]
+    pub policy: PolicyConfig,
+}
+
+#[async_trait]
+impl ConfigurationSection for AppConfig {
+    fn path() -> &'static str {
+        ""
+    }
+
+    async fn generate<R>(mut rng: R) -> anyhow::Result<Self>
+    where
+        R: Rng + Send,
+    {
+        Ok(Self {
+            http: HttpConfig::generate(&mut rng).await?,
+            database: DatabaseConfig::generate(&mut rng).await?,
+            templates: TemplatesConfig::generate(&mut rng).await?,
+            csrf: CsrfConfig::generate(&mut rng).await?,
+            email: EmailConfig::generate(&mut rng).await?,
+            passwords: PasswordsConfig::generate(&mut rng).await?,
+            secrets: SecretsConfig::generate(&mut rng).await?,
+            matrix: MatrixConfig::generate(&mut rng).await?,
+            policy: PolicyConfig::generate(&mut rng).await?,
+        })
+    }
+
+    fn test() -> Self {
+        Self {
+            http: HttpConfig::test(),
+            database: DatabaseConfig::test(),
+            templates: TemplatesConfig::test(),
+            passwords: PasswordsConfig::test(),
+            csrf: CsrfConfig::test(),
+            email: EmailConfig::test(),
+            secrets: SecretsConfig::test(),
+            matrix: MatrixConfig::test(),
+            policy: PolicyConfig::test(),
+        }
+    }
+}
+
+/// Partial config used by the `mas-cli config sync` command
+#[allow(missing_docs)]
+#[derive(Debug, Deserialize, Serialize)]
+pub struct SyncConfig {
+    #[serde(default)]
+    pub database: DatabaseConfig,
+
+    pub secrets: SecretsConfig,
+
+    #[serde(default)]
+    pub clients: ClientsConfig,
+
+    #[serde(default)]
+    pub upstream_oauth2: UpstreamOAuth2Config,
+}
+
+#[async_trait]
+impl ConfigurationSection for SyncConfig {
+    fn path() -> &'static str {
+        ""
+    }
+
+    async fn generate<R>(mut rng: R) -> anyhow::Result<Self>
+    where
+        R: Rng + Send,
+    {
+        Ok(Self {
+            database: DatabaseConfig::generate(&mut rng).await?,
+            secrets: SecretsConfig::generate(&mut rng).await?,
+            clients: ClientsConfig::generate(&mut rng).await?,
+            upstream_oauth2: UpstreamOAuth2Config::generate(&mut rng).await?,
+        })
+    }
+
+    fn test() -> Self {
+        Self {
+            database: DatabaseConfig::test(),
+            secrets: SecretsConfig::test(),
+            clients: ClientsConfig::test(),
             upstream_oauth2: UpstreamOAuth2Config::test(),
         }
     }

--- a/crates/config/src/sections/passwords.rs
+++ b/crates/config/src/sections/passwords.rs
@@ -56,7 +56,7 @@ impl Default for PasswordsConfig {
 }
 
 #[async_trait]
-impl ConfigurationSection<'_> for PasswordsConfig {
+impl ConfigurationSection for PasswordsConfig {
     fn path() -> &'static str {
         "passwords"
     }

--- a/crates/config/src/sections/policy.rs
+++ b/crates/config/src/sections/policy.rs
@@ -82,7 +82,7 @@ impl Default for PolicyConfig {
 }
 
 #[async_trait]
-impl ConfigurationSection<'_> for PolicyConfig {
+impl ConfigurationSection for PolicyConfig {
     fn path() -> &'static str {
         "policy"
     }

--- a/crates/config/src/sections/secrets.rs
+++ b/crates/config/src/sections/secrets.rs
@@ -138,7 +138,7 @@ impl SecretsConfig {
 }
 
 #[async_trait]
-impl ConfigurationSection<'_> for SecretsConfig {
+impl ConfigurationSection for SecretsConfig {
     fn path() -> &'static str {
         "secrets"
     }

--- a/crates/config/src/sections/telemetry.rs
+++ b/crates/config/src/sections/telemetry.rs
@@ -287,7 +287,7 @@ pub struct TelemetryConfig {
 }
 
 #[async_trait]
-impl ConfigurationSection<'_> for TelemetryConfig {
+impl ConfigurationSection for TelemetryConfig {
     fn path() -> &'static str {
         "telemetry"
     }

--- a/crates/config/src/sections/templates.rs
+++ b/crates/config/src/sections/templates.rs
@@ -48,7 +48,7 @@ impl Default for TemplatesConfig {
 }
 
 #[async_trait]
-impl ConfigurationSection<'_> for TemplatesConfig {
+impl ConfigurationSection for TemplatesConfig {
     fn path() -> &'static str {
         "templates"
     }

--- a/crates/config/src/sections/upstream_oauth2.rs
+++ b/crates/config/src/sections/upstream_oauth2.rs
@@ -32,7 +32,7 @@ pub struct UpstreamOAuth2Config {
 }
 
 #[async_trait]
-impl<'a> ConfigurationSection<'a> for UpstreamOAuth2Config {
+impl ConfigurationSection for UpstreamOAuth2Config {
     fn path() -> &'static str {
         "upstream_oauth2"
     }

--- a/crates/config/src/sections/upstream_oauth2.rs
+++ b/crates/config/src/sections/upstream_oauth2.rs
@@ -1,0 +1,144 @@
+// Copyright 2023 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use async_trait::async_trait;
+use rand::Rng;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
+use ulid::Ulid;
+
+use crate::ConfigurationSection;
+
+/// Upstream OAuth 2.0 providers configuration
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Default)]
+pub struct UpstreamOAuth2Config {
+    /// List of OAuth 2.0 providers
+    pub providers: Vec<Provider>,
+}
+
+#[async_trait]
+impl<'a> ConfigurationSection<'a> for UpstreamOAuth2Config {
+    fn path() -> &'static str {
+        "upstream_oauth2"
+    }
+
+    async fn generate<R>(_rng: R) -> anyhow::Result<Self>
+    where
+        R: Rng + Send,
+    {
+        Ok(Self::default())
+    }
+
+    fn test() -> Self {
+        Self::default()
+    }
+}
+
+/// Authentication methods used against the OAuth 2.0 provider
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "token_endpoint_auth_method", rename_all = "snake_case")]
+pub enum TokenAuthMethod {
+    /// `none`: No authentication
+    None,
+
+    /// `client_secret_basic`: `client_id` and `client_secret` used as basic
+    /// authorization credentials
+    ClientSecretBasic { client_secret: String },
+
+    /// `client_secret_post`: `client_id` and `client_secret` sent in the
+    /// request body
+    ClientSecretPost { client_secret: String },
+
+    /// `client_secret_basic`: a `client_assertion` sent in the request body and
+    /// signed using the `client_secret`
+    ClientSecretJwt {
+        client_secret: String,
+        token_endpoint_auth_signing_alg: Option<String>,
+    },
+
+    /// `client_secret_basic`: a `client_assertion` sent in the request body and
+    /// signed by an asymmetric key
+    PrivateKeyJwt {
+        token_endpoint_auth_signing_alg: Option<String>,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum ImportAction {
+    /// Ignore the claim
+    #[default]
+    Ignore,
+
+    /// Suggest the claim value, but allow the user to change it
+    Suggest,
+
+    /// Force the claim value, but don't fail if it is missing
+    Force,
+
+    /// Force the claim value, and fail if it is missing
+    Require,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default, JsonSchema)]
+pub struct ImportPreference {
+    /// How to handle the claim
+    #[serde(default)]
+    pub action: ImportAction,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default, JsonSchema)]
+pub struct ClaimsImports {
+    /// Import the localpart of the MXID based on the `preferred_username` claim
+    #[serde(default)]
+    pub localpart: Option<ImportPreference>,
+
+    /// Import the displayname of the user based on the `name` claim
+    #[serde(default)]
+    pub displayname: Option<ImportPreference>,
+
+    /// Import the email address of the user based on the `email` and
+    /// `email_verified` claims
+    #[serde(default)]
+    pub email: Option<ImportPreference>,
+}
+
+#[skip_serializing_none]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct Provider {
+    /// An internal unique identifier for this provider
+    #[schemars(
+        with = "String",
+        regex(pattern = r"^[0123456789ABCDEFGHJKMNPQRSTVWXYZ]{26}$"),
+        description = "A ULID as per https://github.com/ulid/spec"
+    )]
+    pub id: Ulid,
+
+    /// The OIDC issuer URL
+    pub issuer: String,
+
+    /// The client ID to use when authenticating with the provider
+    pub client_id: String,
+
+    /// The scopes to request from the provider
+    pub scope: String,
+
+    #[serde(flatten)]
+    pub token_auth_method: TokenAuthMethod,
+
+    /// How claims should be imported from the `id_token` provided by the
+    /// provider
+    pub claims_imports: ClaimsImports,
+}

--- a/crates/config/src/util.rs
+++ b/crates/config/src/util.rs
@@ -21,12 +21,12 @@ use figment::{
     Figment, Profile,
 };
 use rand::Rng;
-use serde::{Deserialize, Serialize};
+use serde::{de::DeserializeOwned, Serialize};
 
 #[async_trait]
 /// Trait implemented by all configuration section to help loading specific part
 /// of the config and generate the sample config.
-pub trait ConfigurationSection<'a>: Sized + Deserialize<'a> + Serialize {
+pub trait ConfigurationSection: Sized + DeserializeOwned + Serialize {
     /// Specify where this section should live relative to the root.
     fn path() -> &'static str;
 
@@ -39,7 +39,7 @@ pub trait ConfigurationSection<'a>: Sized + Deserialize<'a> + Serialize {
     /// variables.
     ///
     /// This is what backs the `config generate` subcommand, allowing to
-    /// programatically generate a configuration file, e.g.
+    /// programmatically generate a configuration file, e.g.
     ///
     /// ```sh
     /// export MAS_OAUTH2_ISSUER=https://example.com/

--- a/crates/data-model/src/lib.rs
+++ b/crates/data-model/src/lib.rs
@@ -47,7 +47,8 @@ pub use self::{
     },
     upstream_oauth2::{
         UpstreamOAuthAuthorizationSession, UpstreamOAuthAuthorizationSessionState,
-        UpstreamOAuthLink, UpstreamOAuthProvider,
+        UpstreamOAuthLink, UpstreamOAuthProvider, UpstreamOAuthProviderClaimsImports,
+        UpstreamOAuthProviderImportPreference,
     },
     users::{
         Authentication, BrowserSession, Password, User, UserEmail, UserEmailVerification,

--- a/crates/data-model/src/lib.rs
+++ b/crates/data-model/src/lib.rs
@@ -48,7 +48,7 @@ pub use self::{
     upstream_oauth2::{
         UpstreamOAuthAuthorizationSession, UpstreamOAuthAuthorizationSessionState,
         UpstreamOAuthLink, UpstreamOAuthProvider, UpstreamOAuthProviderClaimsImports,
-        UpstreamOAuthProviderImportPreference,
+        UpstreamOAuthProviderImportAction, UpstreamOAuthProviderImportPreference,
     },
     users::{
         Authentication, BrowserSession, Password, User, UserEmail, UserEmailVerification,

--- a/crates/data-model/src/upstream_oauth2/mod.rs
+++ b/crates/data-model/src/upstream_oauth2/mod.rs
@@ -18,6 +18,9 @@ mod session;
 
 pub use self::{
     link::UpstreamOAuthLink,
-    provider::UpstreamOAuthProvider,
+    provider::{
+        ClaimsImports as UpstreamOAuthProviderClaimsImports,
+        ImportPreference as UpstreamOAuthProviderImportPreference, UpstreamOAuthProvider,
+    },
     session::{UpstreamOAuthAuthorizationSession, UpstreamOAuthAuthorizationSessionState},
 };

--- a/crates/data-model/src/upstream_oauth2/mod.rs
+++ b/crates/data-model/src/upstream_oauth2/mod.rs
@@ -20,6 +20,7 @@ pub use self::{
     link::UpstreamOAuthLink,
     provider::{
         ClaimsImports as UpstreamOAuthProviderClaimsImports,
+        ImportAction as UpstreamOAuthProviderImportAction,
         ImportPreference as UpstreamOAuthProviderImportPreference, UpstreamOAuthProvider,
     },
     session::{UpstreamOAuthAuthorizationSession, UpstreamOAuthAuthorizationSessionState},

--- a/crates/data-model/src/upstream_oauth2/provider.rs
+++ b/crates/data-model/src/upstream_oauth2/provider.rs
@@ -75,14 +75,17 @@ pub enum ImportAction {
 }
 
 impl ImportAction {
+    #[must_use]
     pub fn is_forced(&self) -> bool {
         matches!(self, Self::Force | Self::Require)
     }
 
+    #[must_use]
     pub fn ignore(&self) -> bool {
         matches!(self, Self::Ignore)
     }
 
+    #[must_use]
     pub fn is_required(&self) -> bool {
         matches!(self, Self::Require)
     }

--- a/crates/handlers/src/oauth2/registration.rs
+++ b/crates/handlers/src/oauth2/registration.rs
@@ -162,7 +162,7 @@ pub(crate) async fn post(
         ) => {
             // Let's generate a random client secret
             let client_secret = Alphanumeric.sample_string(&mut rng, 20);
-            let encrypted_client_secret = encrypter.encryt_to_string(client_secret.as_bytes())?;
+            let encrypted_client_secret = encrypter.encrypt_to_string(client_secret.as_bytes())?;
             (Some(client_secret), Some(encrypted_client_secret))
         }
         _ => (None, None),

--- a/crates/handlers/src/upstream_oauth2/cookie.rs
+++ b/crates/handlers/src/upstream_oauth2/cookie.rs
@@ -143,7 +143,9 @@ impl UpstreamSessions {
     ) -> Result<(Ulid, Option<&PostAuthAction>), UpstreamSessionNotFound> {
         self.0
             .iter()
-            .find(|p| p.link == Some(link_id))
+            .filter(|p| p.link == Some(link_id))
+            // Find the session with the highest ID, aka. the most recent one
+            .reduce(|a, b| if a.session > b.session { a } else { b })
             .map(|p| (p.session, p.post_auth_action.as_ref()))
             .ok_or(UpstreamSessionNotFound)
     }

--- a/crates/handlers/src/upstream_oauth2/link.rs
+++ b/crates/handlers/src/upstream_oauth2/link.rs
@@ -124,7 +124,7 @@ fn import_claim(
     name: &'static str,
     value: Option<String>,
     preference: &UpstreamOAuthProviderImportPreference,
-    mut run: impl FnMut(String, bool) -> (),
+    mut run: impl FnMut(String, bool),
 ) -> Result<(), RouteError> {
     // If this claim is ignored, we don't need to do anything.
     if preference.ignore() {

--- a/crates/handlers/src/views/login.rs
+++ b/crates/handlers/src/views/login.rs
@@ -284,6 +284,7 @@ mod test {
         header::{CONTENT_TYPE, LOCATION},
         Request, StatusCode,
     };
+    use mas_data_model::UpstreamOAuthProviderClaimsImports;
     use mas_iana::oauth::OAuthClientAuthenticationMethod;
     use mas_router::Route;
     use mas_storage::{upstream_oauth2::UpstreamOAuthProviderRepository, RepositoryAccess};
@@ -326,6 +327,7 @@ mod test {
                 None,
                 "first_client".into(),
                 None,
+                UpstreamOAuthProviderClaimsImports::default(),
             )
             .await
             .unwrap();
@@ -350,6 +352,7 @@ mod test {
                 None,
                 "second_client".into(),
                 None,
+                UpstreamOAuthProviderClaimsImports::default(),
             )
             .await
             .unwrap();

--- a/crates/keystore/src/encrypter.rs
+++ b/crates/keystore/src/encrypter.rs
@@ -81,7 +81,7 @@ impl Encrypter {
     /// # Errors
     ///
     /// Will return `Err` when the payload failed to encrypt
-    pub fn encryt_to_string(&self, decrypted: &[u8]) -> Result<String, aead::Error> {
+    pub fn encrypt_to_string(&self, decrypted: &[u8]) -> Result<String, aead::Error> {
         let nonce = rand::random();
         let encrypted = self.encrypt(&nonce, decrypted)?;
         let encrypted = [&nonce[..], &encrypted].concat();

--- a/crates/storage-pg/migrations/20230621140528_upstream_oauth_claims_imports.sql
+++ b/crates/storage-pg/migrations/20230621140528_upstream_oauth_claims_imports.sql
@@ -1,0 +1,19 @@
+-- Copyright 2023 The Matrix.org Foundation C.I.C.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+ALTER TABLE upstream_oauth_providers
+    ADD COLUMN claims_imports
+        JSONB
+        NOT NULL
+        DEFAULT '{}';

--- a/crates/storage-pg/migrations/20230626130338_oauth_clients_static.sql
+++ b/crates/storage-pg/migrations/20230626130338_oauth_clients_static.sql
@@ -1,0 +1,19 @@
+-- Copyright 2023 The Matrix.org Foundation C.I.C.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- This adds a flag to the OAuth 2.0 clients to indicate whether they are static (i.e. defined in config) or not.
+ALTER TABLE oauth2_clients
+    ADD COLUMN is_static
+        BOOLEAN NOT NULL
+        DEFAULT FALSE;

--- a/crates/storage-pg/sqlx-data.json
+++ b/crates/storage-pg/sqlx-data.json
@@ -1226,6 +1226,18 @@
     },
     "query": "\n                UPDATE upstream_oauth_links\n                SET user_id = $1\n                WHERE upstream_oauth_link_id = $2\n            "
   },
+  "82fec0e13755e7032457d94fe8d212c62f14c80a98b61d82965f1b93f841c014": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Left": [
+          "Uuid"
+        ]
+      }
+    },
+    "query": "\n                DELETE FROM upstream_oauth_authorization_sessions\n                WHERE upstream_oauth_provider_id = $1\n            "
+  },
   "836fb7567d84057fa7f1edaab834c21a158a5762fe220b6bfacd6576be6c613c": {
     "describe": {
       "columns": [
@@ -1379,6 +1391,18 @@
       }
     },
     "query": "\n                SELECT oauth2_client_id\n                     , encrypted_client_secret\n                     , ARRAY(\n                           SELECT redirect_uri\n                           FROM oauth2_client_redirect_uris r\n                           WHERE r.oauth2_client_id = c.oauth2_client_id\n                       ) AS \"redirect_uris!\"\n                     , grant_type_authorization_code\n                     , grant_type_refresh_token\n                     , client_name\n                     , logo_uri\n                     , client_uri\n                     , policy_uri\n                     , tos_uri\n                     , jwks_uri\n                     , jwks\n                     , id_token_signed_response_alg\n                     , userinfo_signed_response_alg\n                     , token_endpoint_auth_method\n                     , token_endpoint_auth_signing_alg\n                     , initiate_login_uri\n                FROM oauth2_clients c\n\n                WHERE oauth2_client_id = ANY($1::uuid[])\n            "
+  },
+  "8a32a39c43147dfd9dbd25ff04686c3cdbc52ea5689ce3454d15e8ed31756f38": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Left": [
+          "Uuid"
+        ]
+      }
+    },
+    "query": "\n                DELETE FROM upstream_oauth_links\n                WHERE upstream_oauth_provider_id = $1\n            "
   },
   "8a79c7c392dd930628caadec80c9b2645501475ab4feacbac59ca1bc52b16c3f": {
     "describe": {

--- a/crates/storage-pg/sqlx-data.json
+++ b/crates/storage-pg/sqlx-data.json
@@ -14,6 +14,18 @@
     },
     "query": "\n                UPDATE oauth2_authorization_grants\n                SET fulfilled_at = $2\n                  , oauth2_session_id = $3\n                WHERE oauth2_authorization_grant_id = $1\n            "
   },
+  "036e9e2cb7271782e48700fecd3fdd80f596ed433f37f2528c7edbdc88b13646": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Left": [
+          "Uuid"
+        ]
+      }
+    },
+    "query": "\n                    DELETE FROM oauth2_consents\n                    WHERE oauth2_client_id = $1\n                "
+  },
   "0469c1d3ad11fd96febacad33302709c870ead848d6920cdfdb18912d543488e": {
     "describe": {
       "columns": [
@@ -165,6 +177,18 @@
     },
     "query": "\n                SELECT user_email_confirmation_code_id\n                     , user_email_id\n                     , code\n                     , created_at\n                     , expires_at\n                     , consumed_at\n                FROM user_email_confirmation_codes\n                WHERE code = $1\n                  AND user_email_id = $2\n            "
   },
+  "1eb829460407fca22b717b88a1a0a9b7b920d807a4b6c235e1bee524cd73b266": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Left": [
+          "Uuid"
+        ]
+      }
+    },
+    "query": "\n                    DELETE FROM upstream_oauth_links\n                    WHERE upstream_oauth_provider_id = $1\n                "
+  },
   "1f6297fb323e9f2fbfa1c9e3225c0b3037c8c4714533a6240c62275332aa58dc": {
     "describe": {
       "columns": [],
@@ -189,6 +213,57 @@
       }
     },
     "query": "\n                UPDATE oauth2_access_tokens\n                SET revoked_at = $2\n                WHERE oauth2_access_token_id = $1\n            "
+  },
+  "2a0d8d70d21afa9a2c9c1c432853361bb85911c48f7db6c3873b0f5abf35940b": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Left": [
+          "Uuid"
+        ]
+      }
+    },
+    "query": "\n                    DELETE FROM oauth2_authorization_grants\n                    WHERE oauth2_client_id = $1\n                "
+  },
+  "2ee26886c56f04cd53d4c0968f5cf0963f92b6d15e6af0e69378a6447dee677c": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Left": [
+          "Uuid"
+        ]
+      }
+    },
+    "query": "\n                    DELETE FROM oauth2_access_tokens\n                    WHERE oauth2_session_id IN (\n                        SELECT oauth2_session_id\n                        FROM oauth2_sessions\n                        WHERE oauth2_client_id = $1\n                    )\n                "
+  },
+  "31cbbd841029812c6d3500cae04a8e9e5723e4749d339465492b68e072c3a802": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          "Text",
+          "Bool",
+          "Bool",
+          "Text",
+          "Text",
+          "Text",
+          "Text",
+          "Text",
+          "Text",
+          "Jsonb",
+          "Text",
+          "Text",
+          "Text",
+          "Text",
+          "Text"
+        ]
+      }
+    },
+    "query": "\n                INSERT INTO oauth2_clients\n                    ( oauth2_client_id\n                    , encrypted_client_secret\n                    , grant_type_authorization_code\n                    , grant_type_refresh_token\n                    , client_name\n                    , logo_uri\n                    , client_uri\n                    , policy_uri\n                    , tos_uri\n                    , jwks_uri\n                    , jwks\n                    , id_token_signed_response_alg\n                    , userinfo_signed_response_alg\n                    , token_endpoint_auth_method\n                    , token_endpoint_auth_signing_alg\n                    , initiate_login_uri\n                    , is_static\n                    )\n                VALUES\n                    ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, FALSE)\n            "
   },
   "3d66f3121b11ce923b9c60609b510a8ca899640e78cc8f5b03168622928ffe94": {
     "describe": {
@@ -706,6 +781,18 @@
     },
     "query": "\n                INSERT INTO oauth2_sessions\n                    ( oauth2_session_id\n                    , user_session_id\n                    , oauth2_client_id\n                    , scope\n                    , created_at\n                    )\n                VALUES ($1, $2, $3, $4, $5)\n            "
   },
+  "5b697dd7834d33ec55972d3ba43d25fe794bc0b69c5938275711faa7a80b811f": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Left": [
+          "Uuid"
+        ]
+      }
+    },
+    "query": "\n                    DELETE FROM oauth2_refresh_tokens\n                    WHERE oauth2_session_id IN (\n                        SELECT oauth2_session_id\n                        FROM oauth2_sessions\n                        WHERE oauth2_client_id = $1\n                    )\n                "
+  },
   "5f6b7e38ef9bc3b39deabba277d0255fb8cfb2adaa65f47b78a8fac11d8c91c3": {
     "describe": {
       "columns": [],
@@ -720,6 +807,18 @@
       }
     },
     "query": "\n                INSERT INTO upstream_oauth_links (\n                    upstream_oauth_link_id,\n                    upstream_oauth_provider_id,\n                    user_id,\n                    subject,\n                    created_at\n                ) VALUES ($1, $2, NULL, $3, $4)\n            "
+  },
+  "5fe1bb569d13a7d3ff22887b3fc5b76ff901c183b314f8ccb5018d70c516abf6": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Left": [
+          "Uuid"
+        ]
+      }
+    },
+    "query": "\n                DELETE FROM oauth2_clients\n                WHERE oauth2_client_id = $1\n            "
   },
   "6021c1b9e17b0b2e8b511888f8c6be00683ba0635a13eb7fcd403d3d4a3f90db": {
     "describe": {
@@ -912,6 +1011,24 @@
       }
     },
     "query": "\n                UPDATE upstream_oauth_authorization_sessions\n                SET consumed_at = $1\n                WHERE upstream_oauth_authorization_session_id = $2\n            "
+  },
+  "68c4cd463e4035ba8384f11818b7be602e2fbc34a5582f31f95b0cc5fa2aeb92": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          "Text",
+          "Bool",
+          "Bool",
+          "Text",
+          "Jsonb",
+          "Text"
+        ]
+      }
+    },
+    "query": "\n                INSERT INTO oauth2_clients\n                    ( oauth2_client_id\n                    , encrypted_client_secret\n                    , grant_type_authorization_code\n                    , grant_type_refresh_token\n                    , token_endpoint_auth_method\n                    , jwks\n                    , jwks_uri\n                    , is_static\n                    )\n                VALUES\n                    ($1, $2, $3, $4, $5, $6, $7, TRUE)\n                ON CONFLICT (oauth2_client_id)\n                DO\n                    UPDATE SET encrypted_client_secret = EXCLUDED.encrypted_client_secret\n                             , grant_type_authorization_code = EXCLUDED.grant_type_authorization_code\n                             , grant_type_refresh_token = EXCLUDED.grant_type_refresh_token\n                             , token_endpoint_auth_method = EXCLUDED.token_endpoint_auth_method\n                             , jwks = EXCLUDED.jwks\n                             , jwks_uri = EXCLUDED.jwks_uri\n                             , is_static = TRUE\n            "
   },
   "6a3b543ec53ce242866d1e84de26728e6dd275cae745f9c646e3824d859c5384": {
     "describe": {
@@ -1213,6 +1330,18 @@
     },
     "query": "\n                    INSERT INTO oauth2_client_redirect_uris\n                        (oauth2_client_redirect_uri_id, oauth2_client_id, redirect_uri)\n                    SELECT id, $2, redirect_uri\n                    FROM UNNEST($1::uuid[], $3::text[]) r(id, redirect_uri)\n                "
   },
+  "7cd0264707100f5b3cb2582f3f840bf66649742374e3643f1902ae69377fc9b6": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Left": [
+          "Uuid"
+        ]
+      }
+    },
+    "query": "\n                    DELETE FROM oauth2_client_redirect_uris\n                    WHERE oauth2_client_id = $1\n                "
+  },
   "7ce387b1b0aaf10e72adde667b19521b66eaafa51f73bf2f95e38b8f3b64a229": {
     "describe": {
       "columns": [],
@@ -1226,17 +1355,119 @@
     },
     "query": "\n                UPDATE upstream_oauth_links\n                SET user_id = $1\n                WHERE upstream_oauth_link_id = $2\n            "
   },
-  "82fec0e13755e7032457d94fe8d212c62f14c80a98b61d82965f1b93f841c014": {
+  "7e676491b077d4bc8a9cdb4a27ebf119d98cd35ebb52b1064fdb2d9eed78d0e8": {
     "describe": {
-      "columns": [],
-      "nullable": [],
+      "columns": [
+        {
+          "name": "oauth2_client_id",
+          "ordinal": 0,
+          "type_info": "Uuid"
+        },
+        {
+          "name": "encrypted_client_secret",
+          "ordinal": 1,
+          "type_info": "Text"
+        },
+        {
+          "name": "redirect_uris!",
+          "ordinal": 2,
+          "type_info": "TextArray"
+        },
+        {
+          "name": "grant_type_authorization_code",
+          "ordinal": 3,
+          "type_info": "Bool"
+        },
+        {
+          "name": "grant_type_refresh_token",
+          "ordinal": 4,
+          "type_info": "Bool"
+        },
+        {
+          "name": "client_name",
+          "ordinal": 5,
+          "type_info": "Text"
+        },
+        {
+          "name": "logo_uri",
+          "ordinal": 6,
+          "type_info": "Text"
+        },
+        {
+          "name": "client_uri",
+          "ordinal": 7,
+          "type_info": "Text"
+        },
+        {
+          "name": "policy_uri",
+          "ordinal": 8,
+          "type_info": "Text"
+        },
+        {
+          "name": "tos_uri",
+          "ordinal": 9,
+          "type_info": "Text"
+        },
+        {
+          "name": "jwks_uri",
+          "ordinal": 10,
+          "type_info": "Text"
+        },
+        {
+          "name": "jwks",
+          "ordinal": 11,
+          "type_info": "Jsonb"
+        },
+        {
+          "name": "id_token_signed_response_alg",
+          "ordinal": 12,
+          "type_info": "Text"
+        },
+        {
+          "name": "userinfo_signed_response_alg",
+          "ordinal": 13,
+          "type_info": "Text"
+        },
+        {
+          "name": "token_endpoint_auth_method",
+          "ordinal": 14,
+          "type_info": "Text"
+        },
+        {
+          "name": "token_endpoint_auth_signing_alg",
+          "ordinal": 15,
+          "type_info": "Text"
+        },
+        {
+          "name": "initiate_login_uri",
+          "ordinal": 16,
+          "type_info": "Text"
+        }
+      ],
+      "nullable": [
+        false,
+        true,
+        null,
+        false,
+        false,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true
+      ],
       "parameters": {
-        "Left": [
-          "Uuid"
-        ]
+        "Left": []
       }
     },
-    "query": "\n                DELETE FROM upstream_oauth_authorization_sessions\n                WHERE upstream_oauth_provider_id = $1\n            "
+    "query": "\n                SELECT oauth2_client_id\n                     , encrypted_client_secret\n                     , ARRAY(\n                           SELECT redirect_uri\n                           FROM oauth2_client_redirect_uris r\n                           WHERE r.oauth2_client_id = c.oauth2_client_id\n                       ) AS \"redirect_uris!\"\n                     , grant_type_authorization_code\n                     , grant_type_refresh_token\n                     , client_name\n                     , logo_uri\n                     , client_uri\n                     , policy_uri\n                     , tos_uri\n                     , jwks_uri\n                     , jwks\n                     , id_token_signed_response_alg\n                     , userinfo_signed_response_alg\n                     , token_endpoint_auth_method\n                     , token_endpoint_auth_signing_alg\n                     , initiate_login_uri\n                FROM oauth2_clients c\n                WHERE is_static = TRUE\n            "
   },
   "836fb7567d84057fa7f1edaab834c21a158a5762fe220b6bfacd6576be6c613c": {
     "describe": {
@@ -1392,7 +1623,7 @@
     },
     "query": "\n                SELECT oauth2_client_id\n                     , encrypted_client_secret\n                     , ARRAY(\n                           SELECT redirect_uri\n                           FROM oauth2_client_redirect_uris r\n                           WHERE r.oauth2_client_id = c.oauth2_client_id\n                       ) AS \"redirect_uris!\"\n                     , grant_type_authorization_code\n                     , grant_type_refresh_token\n                     , client_name\n                     , logo_uri\n                     , client_uri\n                     , policy_uri\n                     , tos_uri\n                     , jwks_uri\n                     , jwks\n                     , id_token_signed_response_alg\n                     , userinfo_signed_response_alg\n                     , token_endpoint_auth_method\n                     , token_endpoint_auth_signing_alg\n                     , initiate_login_uri\n                FROM oauth2_clients c\n\n                WHERE oauth2_client_id = ANY($1::uuid[])\n            "
   },
-  "8a32a39c43147dfd9dbd25ff04686c3cdbc52ea5689ce3454d15e8ed31756f38": {
+  "8acbdc892d44efb53529da1c2df65bea6b799a43cf4c9264a37d392847e6eff0": {
     "describe": {
       "columns": [],
       "nullable": [],
@@ -1402,25 +1633,7 @@
         ]
       }
     },
-    "query": "\n                DELETE FROM upstream_oauth_links\n                WHERE upstream_oauth_provider_id = $1\n            "
-  },
-  "8a79c7c392dd930628caadec80c9b2645501475ab4feacbac59ca1bc52b16c3f": {
-    "describe": {
-      "columns": [],
-      "nullable": [],
-      "parameters": {
-        "Left": [
-          "Uuid",
-          "Text",
-          "Bool",
-          "Bool",
-          "Text",
-          "Jsonb",
-          "Text"
-        ]
-      }
-    },
-    "query": "\n                INSERT INTO oauth2_clients\n                    ( oauth2_client_id\n                    , encrypted_client_secret\n                    , grant_type_authorization_code\n                    , grant_type_refresh_token\n                    , token_endpoint_auth_method\n                    , jwks\n                    , jwks_uri\n                    )\n                VALUES\n                    ($1, $2, $3, $4, $5, $6, $7)\n                ON CONFLICT (oauth2_client_id)\n                DO\n                    UPDATE SET encrypted_client_secret = EXCLUDED.encrypted_client_secret\n                             , grant_type_authorization_code = EXCLUDED.grant_type_authorization_code\n                             , grant_type_refresh_token = EXCLUDED.grant_type_refresh_token\n                             , token_endpoint_auth_method = EXCLUDED.token_endpoint_auth_method\n                             , jwks = EXCLUDED.jwks\n                             , jwks_uri = EXCLUDED.jwks_uri\n            "
+    "query": "\n                    DELETE FROM oauth2_sessions\n                    WHERE oauth2_client_id = $1\n                "
   },
   "8b7297c263336d70c2b647212b16f7ae39bc5cb1572e3a2dcfcd67f196a1fa39": {
     "describe": {
@@ -1918,6 +2131,18 @@
       }
     },
     "query": "\n                UPDATE upstream_oauth_authorization_sessions\n                SET upstream_oauth_link_id = $1,\n                    completed_at = $2,\n                    id_token = $3\n                WHERE upstream_oauth_authorization_session_id = $4\n            "
+  },
+  "b992283a9b43cbb8f86149f3f55cb47fb628dabd8fadc50e6a5772903f851e1c": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Left": [
+          "Uuid"
+        ]
+      }
+    },
+    "query": "\n                    DELETE FROM upstream_oauth_authorization_sessions\n                    WHERE upstream_oauth_provider_id = $1\n                "
   },
   "bbf62633c561706a762089bbab2f76a9ba3e2ed3539ef16accb601fb609c2ec9": {
     "describe": {
@@ -2515,32 +2740,5 @@
       }
     },
     "query": "\n                SELECT oauth2_session_id\n                     , user_session_id\n                     , oauth2_client_id\n                     , scope\n                     , created_at\n                     , finished_at\n                FROM oauth2_sessions\n\n                WHERE oauth2_session_id = $1\n            "
-  },
-  "f5edcd4c306ca8179cdf9d4aab59fbba971b54611c91345849920954dd8089b3": {
-    "describe": {
-      "columns": [],
-      "nullable": [],
-      "parameters": {
-        "Left": [
-          "Uuid",
-          "Text",
-          "Bool",
-          "Bool",
-          "Text",
-          "Text",
-          "Text",
-          "Text",
-          "Text",
-          "Text",
-          "Jsonb",
-          "Text",
-          "Text",
-          "Text",
-          "Text",
-          "Text"
-        ]
-      }
-    },
-    "query": "\n                INSERT INTO oauth2_clients\n                    ( oauth2_client_id\n                    , encrypted_client_secret\n                    , grant_type_authorization_code\n                    , grant_type_refresh_token\n                    , client_name\n                    , logo_uri\n                    , client_uri\n                    , policy_uri\n                    , tos_uri\n                    , jwks_uri\n                    , jwks\n                    , id_token_signed_response_alg\n                    , userinfo_signed_response_alg\n                    , token_endpoint_auth_method\n                    , token_endpoint_auth_signing_alg\n                    , initiate_login_uri\n                    )\n                VALUES\n                    ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)\n            "
   }
 }

--- a/crates/storage-pg/sqlx-data.json
+++ b/crates/storage-pg/sqlx-data.json
@@ -1447,6 +1447,18 @@
     },
     "query": "\n                INSERT INTO user_emails (user_email_id, user_id, email, created_at)\n                VALUES ($1, $2, $3, $4)\n            "
   },
+  "91a3ee5ad64a947b7807a590f6b014c6856229918b972b98946f98b75686ab6c": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Left": [
+          "Uuid"
+        ]
+      }
+    },
+    "query": "\n                DELETE FROM upstream_oauth_providers\n                WHERE upstream_oauth_provider_id = $1\n            "
+  },
   "921d77c194609615a7e9a6fd806e9cc17a7927e3e5deb58f3917ceeb9ab4dede": {
     "describe": {
       "columns": [],
@@ -2401,6 +2413,34 @@
       }
     },
     "query": "\n                SELECT oauth2_refresh_token_id\n                     , refresh_token\n                     , created_at\n                     , consumed_at\n                     , oauth2_access_token_id\n                     , oauth2_session_id\n                FROM oauth2_refresh_tokens\n\n                WHERE refresh_token = $1\n            "
+  },
+  "e7ce95415bb6b57cd601393c6abe5febfec2a963ce6eac7b099b761594b1dfaf": {
+    "describe": {
+      "columns": [
+        {
+          "name": "created_at",
+          "ordinal": 0,
+          "type_info": "Timestamptz"
+        }
+      ],
+      "nullable": [
+        false
+      ],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          "Text",
+          "Text",
+          "Text",
+          "Text",
+          "Text",
+          "Text",
+          "Timestamptz",
+          "Jsonb"
+        ]
+      }
+    },
+    "query": "\n                INSERT INTO upstream_oauth_providers (\n                    upstream_oauth_provider_id,\n                    issuer,\n                    scope,\n                    token_endpoint_auth_method,\n                    token_endpoint_signing_alg,\n                    client_id,\n                    encrypted_client_secret,\n                    created_at,\n                    claims_imports\n                ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)\n                ON CONFLICT (upstream_oauth_provider_id) \n                    DO UPDATE\n                    SET\n                        issuer = EXCLUDED.issuer,\n                        scope = EXCLUDED.scope,\n                        token_endpoint_auth_method = EXCLUDED.token_endpoint_auth_method,\n                        token_endpoint_signing_alg = EXCLUDED.token_endpoint_signing_alg,\n                        client_id = EXCLUDED.client_id,\n                        encrypted_client_secret = EXCLUDED.encrypted_client_secret,\n                        claims_imports = EXCLUDED.claims_imports\n                RETURNING created_at\n            "
   },
   "f0ace1af3775192a555c4ebb59b81183f359771f9f77e5fad759d38d872541d1": {
     "describe": {

--- a/crates/storage-pg/sqlx-data.json
+++ b/crates/storage-pg/sqlx-data.json
@@ -102,66 +102,6 @@
     },
     "query": "\n                SELECT user_id\n                     , username\n                     , primary_user_email_id\n                     , created_at\n                FROM users\n                WHERE user_id = $1\n            "
   },
-  "154e2e4488ff87e09163698750b56a43127cee4e1392785416a586d40a4d9b21": {
-    "describe": {
-      "columns": [
-        {
-          "name": "upstream_oauth_provider_id",
-          "ordinal": 0,
-          "type_info": "Uuid"
-        },
-        {
-          "name": "issuer",
-          "ordinal": 1,
-          "type_info": "Text"
-        },
-        {
-          "name": "scope",
-          "ordinal": 2,
-          "type_info": "Text"
-        },
-        {
-          "name": "client_id",
-          "ordinal": 3,
-          "type_info": "Text"
-        },
-        {
-          "name": "encrypted_client_secret",
-          "ordinal": 4,
-          "type_info": "Text"
-        },
-        {
-          "name": "token_endpoint_signing_alg",
-          "ordinal": 5,
-          "type_info": "Text"
-        },
-        {
-          "name": "token_endpoint_auth_method",
-          "ordinal": 6,
-          "type_info": "Text"
-        },
-        {
-          "name": "created_at",
-          "ordinal": 7,
-          "type_info": "Timestamptz"
-        }
-      ],
-      "nullable": [
-        false,
-        false,
-        false,
-        false,
-        true,
-        true,
-        false,
-        false
-      ],
-      "parameters": {
-        "Left": []
-      }
-    },
-    "query": "\n                SELECT\n                    upstream_oauth_provider_id,\n                    issuer,\n                    scope,\n                    client_id,\n                    encrypted_client_secret,\n                    token_endpoint_signing_alg,\n                    token_endpoint_auth_method,\n                    created_at\n                FROM upstream_oauth_providers\n            "
-  },
   "1a8701f5672de052bb766933f60b93249acc7237b996e8b93cd61b9f69c902ff": {
     "describe": {
       "columns": [],
@@ -224,25 +164,6 @@
       }
     },
     "query": "\n                SELECT user_email_confirmation_code_id\n                     , user_email_id\n                     , code\n                     , created_at\n                     , expires_at\n                     , consumed_at\n                FROM user_email_confirmation_codes\n                WHERE code = $1\n                  AND user_email_id = $2\n            "
-  },
-  "1ee5cecfafd4726a4ebc08da8a34c09178e6e1e072581c8fca9d3d76967792cb": {
-    "describe": {
-      "columns": [],
-      "nullable": [],
-      "parameters": {
-        "Left": [
-          "Uuid",
-          "Text",
-          "Text",
-          "Text",
-          "Text",
-          "Text",
-          "Text",
-          "Timestamptz"
-        ]
-      }
-    },
-    "query": "\n            INSERT INTO upstream_oauth_providers (\n                upstream_oauth_provider_id,\n                issuer,\n                scope,\n                token_endpoint_auth_method,\n                token_endpoint_signing_alg,\n                client_id,\n                encrypted_client_secret,\n                created_at\n            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)\n        "
   },
   "1f6297fb323e9f2fbfa1c9e3225c0b3037c8c4714533a6240c62275332aa58dc": {
     "describe": {
@@ -800,6 +721,26 @@
     },
     "query": "\n                INSERT INTO upstream_oauth_links (\n                    upstream_oauth_link_id,\n                    upstream_oauth_provider_id,\n                    user_id,\n                    subject,\n                    created_at\n                ) VALUES ($1, $2, NULL, $3, $4)\n            "
   },
+  "6021c1b9e17b0b2e8b511888f8c6be00683ba0635a13eb7fcd403d3d4a3f90db": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Left": [
+          "Uuid",
+          "Text",
+          "Text",
+          "Text",
+          "Text",
+          "Text",
+          "Text",
+          "Timestamptz",
+          "Jsonb"
+        ]
+      }
+    },
+    "query": "\n            INSERT INTO upstream_oauth_providers (\n                upstream_oauth_provider_id,\n                issuer,\n                scope,\n                token_endpoint_auth_method,\n                token_endpoint_signing_alg,\n                client_id,\n                encrypted_client_secret,\n                created_at,\n                claims_imports\n            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)\n        "
+  },
   "64e6ea47c2e877c1ebe4338d64d9ad8a6c1c777d1daea024b8ca2e7f0dd75b0f": {
     "describe": {
       "columns": [],
@@ -816,6 +757,74 @@
       }
     },
     "query": "\n                INSERT INTO upstream_oauth_authorization_sessions (\n                    upstream_oauth_authorization_session_id,\n                    upstream_oauth_provider_id,\n                    state,\n                    code_challenge_verifier,\n                    nonce,\n                    created_at,\n                    completed_at,\n                    consumed_at,\n                    id_token\n                ) VALUES ($1, $2, $3, $4, $5, $6, NULL, NULL, NULL)\n            "
+  },
+  "6733c54a8d9ed93a760f365a9362fdb0f77340d7a4df642a2942174aba2c6502": {
+    "describe": {
+      "columns": [
+        {
+          "name": "upstream_oauth_provider_id",
+          "ordinal": 0,
+          "type_info": "Uuid"
+        },
+        {
+          "name": "issuer",
+          "ordinal": 1,
+          "type_info": "Text"
+        },
+        {
+          "name": "scope",
+          "ordinal": 2,
+          "type_info": "Text"
+        },
+        {
+          "name": "client_id",
+          "ordinal": 3,
+          "type_info": "Text"
+        },
+        {
+          "name": "encrypted_client_secret",
+          "ordinal": 4,
+          "type_info": "Text"
+        },
+        {
+          "name": "token_endpoint_signing_alg",
+          "ordinal": 5,
+          "type_info": "Text"
+        },
+        {
+          "name": "token_endpoint_auth_method",
+          "ordinal": 6,
+          "type_info": "Text"
+        },
+        {
+          "name": "created_at",
+          "ordinal": 7,
+          "type_info": "Timestamptz"
+        },
+        {
+          "name": "claims_imports: Json<UpstreamOAuthProviderClaimsImports>",
+          "ordinal": 8,
+          "type_info": "Jsonb"
+        }
+      ],
+      "nullable": [
+        false,
+        false,
+        false,
+        false,
+        true,
+        true,
+        false,
+        false,
+        false
+      ],
+      "parameters": {
+        "Left": [
+          "Uuid"
+        ]
+      }
+    },
+    "query": "\n                SELECT\n                    upstream_oauth_provider_id,\n                    issuer,\n                    scope,\n                    client_id,\n                    encrypted_client_secret,\n                    token_endpoint_signing_alg,\n                    token_endpoint_auth_method,\n                    created_at,\n                    claims_imports as \"claims_imports: Json<UpstreamOAuthProviderClaimsImports>\"\n                FROM upstream_oauth_providers\n                WHERE upstream_oauth_provider_id = $1\n            "
   },
   "67ab838035946ddc15b43dd2f79d10b233d07e863b3a5c776c5db97cff263c8c": {
     "describe": {
@@ -1410,68 +1419,6 @@
     },
     "query": "\n                SELECT scope_token\n                FROM oauth2_consents\n                WHERE user_id = $1 AND oauth2_client_id = $2\n            "
   },
-  "8f7a9fb1f24c24f8dbc3c193df2a742c9ac730ab958587b67297de2d4b843863": {
-    "describe": {
-      "columns": [
-        {
-          "name": "upstream_oauth_provider_id",
-          "ordinal": 0,
-          "type_info": "Uuid"
-        },
-        {
-          "name": "issuer",
-          "ordinal": 1,
-          "type_info": "Text"
-        },
-        {
-          "name": "scope",
-          "ordinal": 2,
-          "type_info": "Text"
-        },
-        {
-          "name": "client_id",
-          "ordinal": 3,
-          "type_info": "Text"
-        },
-        {
-          "name": "encrypted_client_secret",
-          "ordinal": 4,
-          "type_info": "Text"
-        },
-        {
-          "name": "token_endpoint_signing_alg",
-          "ordinal": 5,
-          "type_info": "Text"
-        },
-        {
-          "name": "token_endpoint_auth_method",
-          "ordinal": 6,
-          "type_info": "Text"
-        },
-        {
-          "name": "created_at",
-          "ordinal": 7,
-          "type_info": "Timestamptz"
-        }
-      ],
-      "nullable": [
-        false,
-        false,
-        false,
-        false,
-        true,
-        true,
-        false,
-        false
-      ],
-      "parameters": {
-        "Left": [
-          "Uuid"
-        ]
-      }
-    },
-    "query": "\n                SELECT\n                    upstream_oauth_provider_id,\n                    issuer,\n                    scope,\n                    client_id,\n                    encrypted_client_secret,\n                    token_endpoint_signing_alg,\n                    token_endpoint_auth_method,\n                    created_at\n                FROM upstream_oauth_providers\n                WHERE upstream_oauth_provider_id = $1\n            "
-  },
   "90b5512c0c9dc3b3eb6500056cc72f9993216d9b553c2e33a7edec26ffb0fc59": {
     "describe": {
       "columns": [],
@@ -1716,6 +1663,72 @@
       }
     },
     "query": "\n                UPDATE compat_sessions cs\n                SET finished_at = $2\n                WHERE compat_session_id = $1\n            "
+  },
+  "af65441068530b68826561d4308e15923ba6c6882ded4860ebde4a7641359abb": {
+    "describe": {
+      "columns": [
+        {
+          "name": "upstream_oauth_provider_id",
+          "ordinal": 0,
+          "type_info": "Uuid"
+        },
+        {
+          "name": "issuer",
+          "ordinal": 1,
+          "type_info": "Text"
+        },
+        {
+          "name": "scope",
+          "ordinal": 2,
+          "type_info": "Text"
+        },
+        {
+          "name": "client_id",
+          "ordinal": 3,
+          "type_info": "Text"
+        },
+        {
+          "name": "encrypted_client_secret",
+          "ordinal": 4,
+          "type_info": "Text"
+        },
+        {
+          "name": "token_endpoint_signing_alg",
+          "ordinal": 5,
+          "type_info": "Text"
+        },
+        {
+          "name": "token_endpoint_auth_method",
+          "ordinal": 6,
+          "type_info": "Text"
+        },
+        {
+          "name": "created_at",
+          "ordinal": 7,
+          "type_info": "Timestamptz"
+        },
+        {
+          "name": "claims_imports: Json<UpstreamOAuthProviderClaimsImports>",
+          "ordinal": 8,
+          "type_info": "Jsonb"
+        }
+      ],
+      "nullable": [
+        false,
+        false,
+        false,
+        false,
+        true,
+        true,
+        false,
+        false,
+        false
+      ],
+      "parameters": {
+        "Left": []
+      }
+    },
+    "query": "\n                SELECT\n                    upstream_oauth_provider_id,\n                    issuer,\n                    scope,\n                    client_id,\n                    encrypted_client_secret,\n                    token_endpoint_signing_alg,\n                    token_endpoint_auth_method,\n                    created_at,\n                    claims_imports as \"claims_imports: Json<UpstreamOAuthProviderClaimsImports>\"\n                FROM upstream_oauth_providers\n            "
   },
   "afa86e79e3de2a83265cb0db8549d378a2f11b2a27bbd86d60558318c87eb698": {
     "describe": {

--- a/crates/storage-pg/src/upstream_oauth2/mod.rs
+++ b/crates/storage-pg/src/upstream_oauth2/mod.rs
@@ -27,6 +27,7 @@ pub use self::{
 #[cfg(test)]
 mod tests {
     use chrono::Duration;
+    use mas_data_model::UpstreamOAuthProviderClaimsImports;
     use mas_storage::{
         clock::MockClock,
         upstream_oauth2::{
@@ -64,6 +65,7 @@ mod tests {
                 None,
                 "client-id".to_owned(),
                 None,
+                UpstreamOAuthProviderClaimsImports::default(),
             )
             .await
             .unwrap();
@@ -207,6 +209,7 @@ mod tests {
                     None,
                     client_id,
                     None,
+                    UpstreamOAuthProviderClaimsImports::default(),
                 )
                 .await
                 .unwrap();

--- a/crates/storage-pg/src/upstream_oauth2/mod.rs
+++ b/crates/storage-pg/src/upstream_oauth2/mod.rs
@@ -80,6 +80,12 @@ mod tests {
         assert_eq!(provider.issuer, "https://example.com/");
         assert_eq!(provider.client_id, "client-id");
 
+        // It should be in the list of all providers
+        let providers = repo.upstream_oauth_provider().all().await.unwrap();
+        assert_eq!(providers.len(), 1);
+        assert_eq!(providers[0].issuer, "https://example.com/");
+        assert_eq!(providers[0].client_id, "client-id");
+
         // Start a session
         let session = repo
             .upstream_oauth_session()
@@ -181,6 +187,11 @@ mod tests {
         assert_eq!(links.edges.len(), 1);
         assert_eq!(links.edges[0].id, link.id);
         assert_eq!(links.edges[0].user_id, Some(user.id));
+
+        // Try deleting the provider
+        repo.upstream_oauth_provider().delete(provider).await.unwrap();
+        let providers = repo.upstream_oauth_provider().all().await.unwrap();
+        assert!(providers.is_empty());
     }
 
     /// Test that the pagination works as expected in the upstream OAuth

--- a/crates/storage-pg/src/upstream_oauth2/mod.rs
+++ b/crates/storage-pg/src/upstream_oauth2/mod.rs
@@ -189,7 +189,10 @@ mod tests {
         assert_eq!(links.edges[0].user_id, Some(user.id));
 
         // Try deleting the provider
-        repo.upstream_oauth_provider().delete(provider).await.unwrap();
+        repo.upstream_oauth_provider()
+            .delete(provider)
+            .await
+            .unwrap();
         let providers = repo.upstream_oauth_provider().all().await.unwrap();
         assert!(providers.is_empty());
     }

--- a/crates/storage-pg/src/upstream_oauth2/provider.rs
+++ b/crates/storage-pg/src/upstream_oauth2/provider.rs
@@ -163,12 +163,11 @@ impl<'c> UpstreamOAuthProviderRepository for PgUpstreamOAuthProviderRepository<'
         token_endpoint_signing_alg: Option<JsonWebSignatureAlg>,
         client_id: String,
         encrypted_client_secret: Option<String>,
+        claims_imports: UpstreamOAuthProviderClaimsImports,
     ) -> Result<UpstreamOAuthProvider, Self::Error> {
         let created_at = clock.now();
         let id = Ulid::from_datetime_with_source(created_at.into(), rng);
         tracing::Span::current().record("upstream_oauth_provider.id", tracing::field::display(id));
-
-        let claims_imports = UpstreamOAuthProviderClaimsImports::default();
 
         sqlx::query!(
             r#"

--- a/crates/storage/src/job.rs
+++ b/crates/storage/src/job.rs
@@ -256,13 +256,30 @@ mod jobs {
     #[derive(Serialize, Deserialize, Debug, Clone)]
     pub struct ProvisionUserJob {
         user_id: Ulid,
+        set_display_name: Option<String>,
     }
 
     impl ProvisionUserJob {
         /// Create a new job to provision the user on the homeserver.
         #[must_use]
         pub fn new(user: &User) -> Self {
-            Self { user_id: user.id }
+            Self {
+                user_id: user.id,
+                set_display_name: None,
+            }
+        }
+
+        /// Set the display name of the user.
+        #[must_use]
+        pub fn set_display_name(mut self, display_name: String) -> Self {
+            self.set_display_name = Some(display_name);
+            self
+        }
+
+        /// Get the display name to be set.
+        #[must_use]
+        pub fn display_name_to_set(&self) -> Option<&str> {
+            self.set_display_name.as_deref()
         }
 
         /// The ID of the user to provision.

--- a/crates/storage/src/upstream_oauth2/provider.rs
+++ b/crates/storage/src/upstream_oauth2/provider.rs
@@ -78,6 +78,65 @@ pub trait UpstreamOAuthProviderRepository: Send + Sync {
         claims_imports: UpstreamOAuthProviderClaimsImports,
     ) -> Result<UpstreamOAuthProvider, Self::Error>;
 
+    /// Delete an upstream OAuth provider
+    ///
+    /// # Parameters
+    ///
+    /// * `provider`: The provider to delete
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Self::Error`] if the underlying repository fails
+    async fn delete(&mut self, provider: UpstreamOAuthProvider) -> Result<(), Self::Error> {
+        self.delete_by_id(provider.id).await
+    }
+
+    /// Delete an upstream OAuth provider by its ID
+    ///
+    /// # Parameters
+    ///
+    /// * `id`: The ID of the provider to delete
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Self::Error`] if the underlying repository fails
+    async fn delete_by_id(&mut self, id: Ulid) -> Result<(), Self::Error>;
+
+    /// Insert or update an upstream OAuth provider
+    ///
+    /// # Parameters
+    ///
+    /// * `clock`: The clock used to generate timestamps
+    /// * `id`: The ID of the provider to update
+    /// * `issuer`: The OIDC issuer of the provider
+    /// * `scope`: The scope to request during the authorization flow
+    /// * `token_endpoint_auth_method`: The token endpoint authentication method
+    /// * `token_endpoint_auth_signing_alg`: The JWT signing algorithm to use
+    ///   when then `client_secret_jwt` or `private_key_jwt` authentication
+    ///   methods are used
+    /// * `client_id`: The client ID to use when authenticating to the upstream
+    /// * `encrypted_client_secret`: The encrypted client secret to use when
+    ///   authenticating to the upstream
+    /// * `claims_imports`: How claims should be imported from the upstream
+    ///   provider
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Self::Error`] if the underlying repository fails
+    #[allow(clippy::too_many_arguments)]
+    async fn upsert(
+        &mut self,
+        clock: &dyn Clock,
+        id: Ulid,
+        issuer: String,
+        scope: Scope,
+        token_endpoint_auth_method: OAuthClientAuthenticationMethod,
+        token_endpoint_signing_alg: Option<JsonWebSignatureAlg>,
+        client_id: String,
+        encrypted_client_secret: Option<String>,
+        claims_imports: UpstreamOAuthProviderClaimsImports,
+    ) -> Result<UpstreamOAuthProvider, Self::Error>;
+
     /// Get a paginated list of upstream OAuth providers
     ///
     /// # Parameters
@@ -115,6 +174,23 @@ repository_impl!(UpstreamOAuthProviderRepository:
         encrypted_client_secret: Option<String>,
         claims_imports: UpstreamOAuthProviderClaimsImports
     ) -> Result<UpstreamOAuthProvider, Self::Error>;
+
+    async fn upsert(
+        &mut self,
+        clock: &dyn Clock,
+        id: Ulid,
+        issuer: String,
+        scope: Scope,
+        token_endpoint_auth_method: OAuthClientAuthenticationMethod,
+        token_endpoint_signing_alg: Option<JsonWebSignatureAlg>,
+        client_id: String,
+        encrypted_client_secret: Option<String>,
+        claims_imports: UpstreamOAuthProviderClaimsImports,
+    ) -> Result<UpstreamOAuthProvider, Self::Error>;
+
+    async fn delete(&mut self, provider: UpstreamOAuthProvider) -> Result<(), Self::Error>;
+
+    async fn delete_by_id(&mut self, id: Ulid) -> Result<(), Self::Error>;
 
     async fn list_paginated(
         &mut self,

--- a/crates/storage/src/upstream_oauth2/provider.rs
+++ b/crates/storage/src/upstream_oauth2/provider.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use async_trait::async_trait;
-use mas_data_model::UpstreamOAuthProvider;
+use mas_data_model::{UpstreamOAuthProvider, UpstreamOAuthProviderClaimsImports};
 use mas_iana::{jose::JsonWebSignatureAlg, oauth::OAuthClientAuthenticationMethod};
 use oauth2_types::scope::Scope;
 use rand_core::RngCore;
@@ -58,6 +58,8 @@ pub trait UpstreamOAuthProviderRepository: Send + Sync {
     /// * `client_id`: The client ID to use when authenticating to the upstream
     /// * `encrypted_client_secret`: The encrypted client secret to use when
     ///   authenticating to the upstream
+    /// * `claims_imports`: How claims should be imported from the upstream
+    ///   provider
     ///
     /// # Errors
     ///
@@ -73,6 +75,7 @@ pub trait UpstreamOAuthProviderRepository: Send + Sync {
         token_endpoint_signing_alg: Option<JsonWebSignatureAlg>,
         client_id: String,
         encrypted_client_secret: Option<String>,
+        claims_imports: UpstreamOAuthProviderClaimsImports,
     ) -> Result<UpstreamOAuthProvider, Self::Error>;
 
     /// Get a paginated list of upstream OAuth providers
@@ -109,7 +112,8 @@ repository_impl!(UpstreamOAuthProviderRepository:
         token_endpoint_auth_method: OAuthClientAuthenticationMethod,
         token_endpoint_signing_alg: Option<JsonWebSignatureAlg>,
         client_id: String,
-        encrypted_client_secret: Option<String>
+        encrypted_client_secret: Option<String>,
+        claims_imports: UpstreamOAuthProviderClaimsImports
     ) -> Result<UpstreamOAuthProvider, Self::Error>;
 
     async fn list_paginated(

--- a/crates/tasks/src/matrix.rs
+++ b/crates/tasks/src/matrix.rs
@@ -69,7 +69,12 @@ async fn provision_user(
 
     repo.cancel().await?;
 
-    let request = ProvisionRequest::new(mxid.clone(), user.sub.clone()).set_emails(emails);
+    let mut request = ProvisionRequest::new(mxid.clone(), user.sub.clone()).set_emails(emails);
+
+    if let Some(display_name) = job.display_name_to_set() {
+        request = request.set_displayname(display_name.to_owned());
+    }
+
     let created = matrix.provision_user(&request).await?;
 
     if created {

--- a/crates/templates/src/context.rs
+++ b/crates/templates/src/context.rs
@@ -856,6 +856,12 @@ impl TemplateContext for UpstreamSuggestLink {
 #[derive(Serialize)]
 pub struct UpstreamRegister {
     login_link: String,
+    suggested_localpart: Option<String>,
+    force_localpart: bool,
+    suggested_display_name: Option<String>,
+    force_display_name: bool,
+    suggested_email: Option<String>,
+    force_email: bool,
 }
 
 impl UpstreamRegister {
@@ -865,12 +871,38 @@ impl UpstreamRegister {
         Self::for_link_id(link.id)
     }
 
+    /// Set the suggested localpart
+    pub fn set_localpart(&mut self, localpart: String, force: bool) {
+        self.suggested_localpart = Some(localpart);
+        self.force_localpart = force;
+    }
+
+    /// Set the suggested display name
+    pub fn set_display_name(&mut self, display_name: String, force: bool) {
+        self.suggested_display_name = Some(display_name);
+        self.force_display_name = force;
+    }
+
+    /// Set the suggested email
+    pub fn set_email(&mut self, email: String, force: bool) {
+        self.suggested_email = Some(email);
+        self.force_email = force;
+    }
+
     fn for_link_id(id: Ulid) -> Self {
         let login_link = mas_router::Login::and_link_upstream(id)
             .relative_url()
             .into();
 
-        Self { login_link }
+        Self {
+            login_link,
+            suggested_localpart: None,
+            force_localpart: false,
+            suggested_display_name: None,
+            force_display_name: false,
+            suggested_email: None,
+            force_email: false,
+        }
     }
 }
 

--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -290,6 +290,7 @@
       ]
     },
     "ClaimsImports": {
+      "description": "How claims should be imported",
       "type": "object",
       "properties": {
         "displayname": {
@@ -802,6 +803,7 @@
       }
     },
     "ImportAction": {
+      "description": "How to handle a claim",
       "oneOf": [
         {
           "description": "Ignore the claim",
@@ -834,6 +836,7 @@
       ]
     },
     "ImportPreference": {
+      "description": "What should be done with a claim",
       "type": "object",
       "properties": {
         "action": {
@@ -1469,7 +1472,7 @@
               ]
             },
             "token_endpoint_auth_signing_alg": {
-              "type": "string"
+              "$ref": "#/definitions/JsonWebSignatureAlg"
             }
           }
         },
@@ -1487,7 +1490,7 @@
               ]
             },
             "token_endpoint_auth_signing_alg": {
-              "type": "string"
+              "$ref": "#/definitions/JsonWebSignatureAlg"
             }
           }
         }

--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -197,6 +197,17 @@
           "$ref": "#/definitions/TemplatesConfig"
         }
       ]
+    },
+    "upstream_oauth2": {
+      "description": "Configuration related to upstream OAuth providers",
+      "default": {
+        "providers": []
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/UpstreamOAuth2Config"
+        }
+      ]
     }
   },
   "definitions": {
@@ -278,6 +289,38 @@
         }
       ]
     },
+    "ClaimsImports": {
+      "type": "object",
+      "properties": {
+        "displayname": {
+          "description": "Import the displayname of the user based on the `name` claim",
+          "default": null,
+          "allOf": [
+            {
+              "$ref": "#/definitions/ImportPreference"
+            }
+          ]
+        },
+        "email": {
+          "description": "Import the email address of the user based on the `email` and `email_verified` claims",
+          "default": null,
+          "allOf": [
+            {
+              "$ref": "#/definitions/ImportPreference"
+            }
+          ]
+        },
+        "localpart": {
+          "description": "Import the localpart of the MXID based on the `preferred_username` claim",
+          "default": null,
+          "allOf": [
+            {
+              "$ref": "#/definitions/ImportPreference"
+            }
+          ]
+        }
+      }
+    },
     "ClientConfig": {
       "description": "An OAuth 2.0 client configuration",
       "type": "object",
@@ -358,7 +401,7 @@
           }
         },
         {
-          "description": "`client_secret_basic`: a `client_assertion` sent in the request body and signed by an asymetric key",
+          "description": "`client_secret_basic`: a `client_assertion` sent in the request body and signed by an asymmetric key",
           "type": "object",
           "oneOf": [
             {
@@ -755,6 +798,52 @@
           "description": "Public URL base from where the authentication service is reachable",
           "type": "string",
           "format": "uri"
+        }
+      }
+    },
+    "ImportAction": {
+      "oneOf": [
+        {
+          "description": "Ignore the claim",
+          "type": "string",
+          "enum": [
+            "ignore"
+          ]
+        },
+        {
+          "description": "Suggest the claim value, but allow the user to change it",
+          "type": "string",
+          "enum": [
+            "suggest"
+          ]
+        },
+        {
+          "description": "Force the claim value, but don't fail if it is missing",
+          "type": "string",
+          "enum": [
+            "force"
+          ]
+        },
+        {
+          "description": "Force the claim value, and fail if it is missing",
+          "type": "string",
+          "enum": [
+            "require"
+          ]
+        }
+      ]
+    },
+    "ImportPreference": {
+      "type": "object",
+      "properties": {
+        "action": {
+          "description": "How to handle the claim",
+          "default": "ignore",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ImportAction"
+            }
+          ]
         }
       }
     },
@@ -1305,6 +1394,139 @@
         }
       ]
     },
+    "Provider": {
+      "description": "Authentication methods used against the OAuth 2.0 provider",
+      "type": "object",
+      "oneOf": [
+        {
+          "description": "`none`: No authentication",
+          "type": "object",
+          "required": [
+            "token_endpoint_auth_method"
+          ],
+          "properties": {
+            "token_endpoint_auth_method": {
+              "type": "string",
+              "enum": [
+                "none"
+              ]
+            }
+          }
+        },
+        {
+          "description": "`client_secret_basic`: `client_id` and `client_secret` used as basic authorization credentials",
+          "type": "object",
+          "required": [
+            "client_secret",
+            "token_endpoint_auth_method"
+          ],
+          "properties": {
+            "client_secret": {
+              "type": "string"
+            },
+            "token_endpoint_auth_method": {
+              "type": "string",
+              "enum": [
+                "client_secret_basic"
+              ]
+            }
+          }
+        },
+        {
+          "description": "`client_secret_post`: `client_id` and `client_secret` sent in the request body",
+          "type": "object",
+          "required": [
+            "client_secret",
+            "token_endpoint_auth_method"
+          ],
+          "properties": {
+            "client_secret": {
+              "type": "string"
+            },
+            "token_endpoint_auth_method": {
+              "type": "string",
+              "enum": [
+                "client_secret_post"
+              ]
+            }
+          }
+        },
+        {
+          "description": "`client_secret_basic`: a `client_assertion` sent in the request body and signed using the `client_secret`",
+          "type": "object",
+          "required": [
+            "client_secret",
+            "token_endpoint_auth_method"
+          ],
+          "properties": {
+            "client_secret": {
+              "type": "string"
+            },
+            "token_endpoint_auth_method": {
+              "type": "string",
+              "enum": [
+                "client_secret_jwt"
+              ]
+            },
+            "token_endpoint_auth_signing_alg": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "description": "`client_secret_basic`: a `client_assertion` sent in the request body and signed by an asymmetric key",
+          "type": "object",
+          "required": [
+            "token_endpoint_auth_method"
+          ],
+          "properties": {
+            "token_endpoint_auth_method": {
+              "type": "string",
+              "enum": [
+                "private_key_jwt"
+              ]
+            },
+            "token_endpoint_auth_signing_alg": {
+              "type": "string"
+            }
+          }
+        }
+      ],
+      "required": [
+        "claims_imports",
+        "client_id",
+        "id",
+        "issuer",
+        "scope"
+      ],
+      "properties": {
+        "claims_imports": {
+          "description": "How claims should be imported from the `id_token` provided by the provider",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ClaimsImports"
+            }
+          ]
+        },
+        "client_id": {
+          "description": "The client ID to use when authenticating with the provider",
+          "type": "string"
+        },
+        "id": {
+          "description": "A ULID as per https://github.com/ulid/spec",
+          "type": "string",
+          "pattern": "^[0123456789ABCDEFGHJKMNPQRSTVWXYZ]{26}$"
+        },
+        "issuer": {
+          "description": "The OIDC issuer URL",
+          "type": "string"
+        },
+        "scope": {
+          "description": "The scopes to request from the provider",
+          "type": "string"
+        }
+      }
+    },
     "Resource": {
       "description": "HTTP resources to mount",
       "oneOf": [
@@ -1785,6 +2007,22 @@
           ]
         }
       ]
+    },
+    "UpstreamOAuth2Config": {
+      "description": "Upstream OAuth 2.0 providers configuration",
+      "type": "object",
+      "required": [
+        "providers"
+      ],
+      "properties": {
+        "providers": {
+          "description": "List of OAuth 2.0 providers",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Provider"
+          }
+        }
+      }
     }
   }
 }

--- a/templates/components/button.html
+++ b/templates/components/button.html
@@ -50,14 +50,68 @@ limitations under the License.
   <a class="{{ self::outline_class() }} {{ class }}" href="{{ href }}">{{ text }}</a>
 {% endmacro %}
 
-{% macro button(text, name="", type="submit", class="", value="") %}
-  <button name="{{ name }}" value="{{ value }}" type="{{ type }}" class="{{ self::plain_class() }} {{ class }}">{{ text }}</button>
+{% macro button(
+  text,
+  name="",
+  type="submit",
+  class="",
+  value="",
+  disabled=False,
+  autocomplete=False,
+  autocorrect=False,
+  autocapitalize=False) %}
+  <button
+    name="{{ name }}"
+    value="{{ value }}"
+    type="{{ type }}"
+    {% if disabled %}disabled{% endif %}
+    class="{{ self::plain_class() }} {{ class }}"
+    {% if autocapitalize %}autocapitilize="{{ autocapitilize }}"{% endif %}
+    {% if autocomplete %}autocomplete="{{ autocomplete }}"{% endif %}
+    {% if autocorrect %}autocorrect="{{ autocorrect }}"{% endif %}
+  >{{ text }}</button>
 {% endmacro %}
 
-{% macro button_text(text, name="", type="submit", class="", value="") %}
-  <button name="{{ name }}" value="{{ value }}" type="{{ type }}" class="{{ self::text_class() }} {{ class }}">{{ text }}</button>
+{% macro button_text(
+  text,
+  name="",
+  type="submit",
+  class="",
+  value="",
+  disabled=False,
+  autocomplete=False,
+  autocorrect=False,
+  autocapitalize=False) %}
+  <button
+    name="{{ name }}"
+    value="{{ value }}"
+    type="{{ type }}"
+    {% if disabled %}disabled{% endif %}
+    class="{{ self::text_class() }} {{ class }}"
+    {% if autocapitalize %}autocapitilize="{{ autocapitilize }}"{% endif %}
+    {% if autocomplete %}autocomplete="{{ autocomplete }}"{% endif %}
+    {% if autocorrect %}autocorrect="{{ autocorrect }}"{% endif %}
+  >{{ text }}</button>
 {% endmacro %}
 
-{% macro button_outline(text, name="", type="submit", class="", value="") %}
-  <button name="{{ name }}" value="{{ value }}" type="{{ type }}" class="{{ self::outline_class() }} {{ class }}">{{ text }}</button>
+{% macro button_outline(
+  text,
+  name="",
+  type="submit",
+  class="",
+  value="",
+  disabled=False,
+  autocomplete=False,
+  autocorrect=False,
+  autocapitalize=False) %}
+  <button
+    name="{{ name }}"
+    value="{{ value }}"
+    type="{{ type }}"
+    {% if disabled %}disabled{% endif %}
+    {% if autocapitalize %}autocapitilize="{{ autocapitilize }}"{% endif %}
+    {% if autocomplete %}autocomplete="{{ autocomplete }}"{% endif %}
+    {% if autocorrect %}autocorrect="{{ autocorrect }}"{% endif %}
+    class="{{ self::outline_class() }} {{ class }}"
+  >{{ text }}</button>
 {% endmacro %}

--- a/templates/pages/upstream_oauth2/do_register.html
+++ b/templates/pages/upstream_oauth2/do_register.html
@@ -26,7 +26,35 @@ limitations under the License.
 
         <input type="hidden" name="csrf" value="{{ csrf_token }}" />
         <input type="hidden" name="action" value="register" />
-        {{ field::input(label="Username", name="username", autocomplete="username", autocorrect="off", autocapitalize="none") }}
+        {{ field::input(label="Username", name="username", autocomplete="username", autocorrect="off", autocapitalize="none", disabled=force_localpart, value=suggested_localpart) }}
+
+        {% if suggested_email %}
+          <div class="rounded-lg bg-grey-25 dark:bg-grey-450 p-4">
+            <div class="font-medium">
+              {% if force_email %}
+                Will import the following email address
+              {% else %}
+                <input type="checkbox" name="import_email" id="import_email" value="1" checked="checked" />
+                <label for="import_email">Import email address</label>
+              {% endif %}
+            </div>
+            <div class="font-mono">{{ suggested_email }}</div>
+          </div>
+        {% endif %}
+
+        {% if suggested_display_name %}
+          <div class="rounded-lg bg-grey-25 dark:bg-grey-450 p-4">
+            <div class="font-medium">
+              {% if force_display_name %}
+                Will import the following display name
+              {% else %}
+              <input type="checkbox" name="import_display_name" id="import_display_name" value="1" checked="checked" />
+              <label for="import_display_name">Import display name</label>
+              {% endif %}
+            </div>
+            <div class="font-mono">{{ suggested_display_name }}</div>
+          </div>
+        {% endif %}
 
         {{ button::button(text="Create a new account") }}
       </form>

--- a/templates/pages/upstream_oauth2/do_register.html
+++ b/templates/pages/upstream_oauth2/do_register.html
@@ -21,7 +21,11 @@ limitations under the License.
     <div class="grid grid-cols-1 gap-6 w-96">
       <form method="POST" class="grid grid-cols-1 gap-6">
         <h1 class="rounded-lg bg-grey-25 dark:bg-grey-450 p-2 text-center font-medium text-lg">
-          Choose your username
+          {% if force_localpart %}
+            Create a new account
+          {% else %}
+            Choose your username
+          {% endif %}
         </h1>
 
         <input type="hidden" name="csrf" value="{{ csrf_token }}" />
@@ -34,7 +38,7 @@ limitations under the License.
               {% if force_email %}
                 Will import the following email address
               {% else %}
-                <input type="checkbox" name="import_email" id="import_email" value="1" checked="checked" />
+                <input type="checkbox" name="import_email" id="import_email" checked="checked" />
                 <label for="import_email">Import email address</label>
               {% endif %}
             </div>
@@ -48,7 +52,7 @@ limitations under the License.
               {% if force_display_name %}
                 Will import the following display name
               {% else %}
-              <input type="checkbox" name="import_display_name" id="import_display_name" value="1" checked="checked" />
+              <input type="checkbox" name="import_display_name" id="import_display_name" checked="checked" />
               <label for="import_display_name">Import display name</label>
               {% endif %}
             </div>


### PR DESCRIPTION
This adds a bunch of things to upstream IDPs.

## Importing of attributes

The following attributes can be imported

| Attribute | Source claim |
|--------|--------|
| `email` | `email` and `email_verified` |
| `localpart` | `preferred_username` |
| `displayname` | `name` | 

For each of those attribute, there is a preference that is either:

 - `ignore`: don't do anything with the claim
 - `suggest`: suggest importing the attribute if present, but allow user to opt-out
 - `force`: import the attribute if present, but don't fail if absent
 - `required`: import the attribute and fail if absent

## Define upstream IDPs in config

Upstream IDPs can now be defined in config, like this:

```yaml
upstream_oauth2:
  providers:
    - id: "01H3FDH2XZJS8ADKRGWM84PZTY"
      issuer: "https://accounts.google.com"
      token_endpoint_auth_method: "client_secret_basic"
      client_id: "aaaabbbbcccddd.apps.googleusercontent.com"
      client_secret: "foobarbaz"
      scope: "openid profile email"
      claims_imports:
        displayname:
          action: suggest
        localpart:
          action: ignore
        email:
          action: require
```

## Config syncing subcommand

There is a new subcommand to sync the `clients` and upstream IDPs from the config to the database.

```
Sync the clients and providers from the config file to the database

Usage: mas-cli config sync [OPTIONS]

Options:
  -c, --config <CONFIG>  Path to the configuration file
      --prune            Prune elements that are in the database but not in the config file anymore
      --dry-run          Do not actually write to the database
  -h, --help             Print help
```

This supersedes the `mas-cli manage import-clients` and the `mas-cli manage add-oauth-upstream` commands.
For clients, it now keeps track in the database whether the client is a statically-defined one or not.
If the `--prune` flag is set, it will delete clients and upstreams that are no longer defined in the config.