### PR TITLE
Add support for all authorization request parameters 

### DIFF
--- a/crates/handlers/src/upstream_oauth2/authorize.rs
+++ b/crates/handlers/src/upstream_oauth2/authorize.rs
@@ -86,17 +86,20 @@ pub(crate) async fn get(
 
     let redirect_uri = url_builder.upstream_oauth_callback(provider.id);
 
-    let data = AuthorizationRequestData::new(
+    let mut data = AuthorizationRequestData::new(
         provider.client_id.clone(),
         provider.scope.clone(),
         redirect_uri,
     );
 
+    if let Some(methods) = metadata.code_challenge_methods_supported.clone() {
+        data = data.with_code_challenge_methods_supported(methods);
+    }
+
     // Build an authorization request for it
     let (url, data) = mas_oidc_client::requests::authorization_code::build_authorization_url(
         metadata.authorization_endpoint().clone(),
         data,
-        metadata.code_challenge_methods_supported.as_deref(),
         &mut rng,
     )?;
 

--- a/crates/handlers/src/upstream_oauth2/authorize.rs
+++ b/crates/handlers/src/upstream_oauth2/authorize.rs
@@ -89,7 +89,6 @@ pub(crate) async fn get(
     let data = AuthorizationRequestData {
         client_id: &provider.client_id,
         scope: &provider.scope,
-        prompt: None,
         redirect_uri: &redirect_uri,
         code_challenge_methods_supported: metadata.code_challenge_methods_supported.as_deref(),
     };
@@ -98,6 +97,7 @@ pub(crate) async fn get(
     let (url, data) = mas_oidc_client::requests::authorization_code::build_authorization_url(
         metadata.authorization_endpoint().clone(),
         data,
+        None,
         &mut rng,
     )?;
 

--- a/crates/handlers/src/upstream_oauth2/authorize.rs
+++ b/crates/handlers/src/upstream_oauth2/authorize.rs
@@ -86,18 +86,17 @@ pub(crate) async fn get(
 
     let redirect_uri = url_builder.upstream_oauth_callback(provider.id);
 
-    let data = AuthorizationRequestData {
-        client_id: &provider.client_id,
-        scope: &provider.scope,
-        redirect_uri: &redirect_uri,
-        code_challenge_methods_supported: metadata.code_challenge_methods_supported.as_deref(),
-    };
+    let data = AuthorizationRequestData::new(
+        provider.client_id.clone(),
+        provider.scope.clone(),
+        redirect_uri,
+    );
 
     // Build an authorization request for it
     let (url, data) = mas_oidc_client::requests::authorization_code::build_authorization_url(
         metadata.authorization_endpoint().clone(),
         data,
-        None,
+        metadata.code_challenge_methods_supported.as_deref(),
         &mut rng,
     )?;
 

--- a/crates/oidc-client/src/requests/authorization_code.rs
+++ b/crates/oidc-client/src/requests/authorization_code.rs
@@ -106,7 +106,8 @@ pub struct AuthorizationRequestData {
 }
 
 impl AuthorizationRequestData {
-    /// Constructs a new `AuthorizationRequestData` with all the required fields.
+    /// Constructs a new `AuthorizationRequestData` with all the required
+    /// fields.
     #[must_use]
     pub fn new(client_id: String, scope: Scope, redirect_uri: Url) -> Self {
         Self {

--- a/crates/oidc-client/tests/it/requests/authorization_code.rs
+++ b/crates/oidc-client/tests/it/requests/authorization_code.rs
@@ -64,8 +64,8 @@ fn pass_authorization_url() {
             CLIENT_ID.to_owned(),
             [ScopeToken::Openid].into_iter().collect(),
             redirect_uri,
-        ),
-        Some(&[PkceCodeChallengeMethod::S256]),
+        )
+        .with_code_challenge_methods_supported(vec![PkceCodeChallengeMethod::S256]),
         &mut rng,
     )
     .unwrap();
@@ -117,8 +117,7 @@ fn pass_full_authorization_url() {
     .with_acr_values(["custom".to_owned()].into());
 
     let (url, validation_data) =
-        build_authorization_url(authorization_endpoint, authorization_data, None, &mut rng)
-            .unwrap();
+        build_authorization_url(authorization_endpoint, authorization_data, &mut rng).unwrap();
 
     assert_eq!(validation_data.state, "OrJ8xbWovSpJUTKz");
     assert_eq!(validation_data.code_challenge_verifier, None);
@@ -190,8 +189,8 @@ async fn pass_pushed_authorization_request() {
             CLIENT_ID.to_owned(),
             [ScopeToken::Openid].into_iter().collect(),
             redirect_uri,
-        ),
-        Some(&[PkceCodeChallengeMethod::S256]),
+        )
+        .with_code_challenge_methods_supported(vec![PkceCodeChallengeMethod::S256]),
         now(),
         &mut rng,
     )
@@ -241,8 +240,8 @@ async fn fail_pushed_authorization_request_404() {
             CLIENT_ID.to_owned(),
             [ScopeToken::Openid].into_iter().collect(),
             redirect_uri,
-        ),
-        Some(&[PkceCodeChallengeMethod::S256]),
+        )
+        .with_code_challenge_methods_supported(vec![PkceCodeChallengeMethod::S256]),
         now(),
         &mut rng,
     )

--- a/crates/oidc-client/tests/it/requests/authorization_code.rs
+++ b/crates/oidc-client/tests/it/requests/authorization_code.rs
@@ -14,6 +14,7 @@
 
 use std::{
     collections::HashMap,
+    num::NonZeroU32,
     sync::{Arc, Mutex},
 };
 
@@ -36,7 +37,7 @@ use mas_oidc_client::{
     },
     types::scope::{ScopeExt, ScopeToken},
 };
-use oauth2_types::requests::{AccessTokenResponse, PushedAuthorizationResponse};
+use oauth2_types::requests::{AccessTokenResponse, Display, Prompt, PushedAuthorizationResponse};
 use rand::SeedableRng;
 use tokio::sync::oneshot;
 use url::Url;
@@ -82,11 +83,67 @@ fn pass_authorization_url() {
     assert_eq!(query_pairs.get("response_type").unwrap(), "code");
     assert_eq!(query_pairs.get("client_id").unwrap(), CLIENT_ID);
     assert_eq!(query_pairs.get("redirect_uri").unwrap(), REDIRECT_URI);
+    assert_eq!(query_pairs.get("display"), None);
+    assert_eq!(query_pairs.get("prompt"), None);
+    assert_eq!(query_pairs.get("max_age"), None);
+    assert_eq!(query_pairs.get("ui_locales"), None);
+    assert_eq!(query_pairs.get("id_token_hint"), None);
+    assert_eq!(query_pairs.get("login_hint"), None);
+    assert_eq!(query_pairs.get("acr_values"), None);
     assert_eq!(*query_pairs.get("state").unwrap(), validation_data.state);
     assert_eq!(query_pairs.get("nonce").unwrap(), "ox0PigY5l9xl5uTL");
     let code_challenge = query_pairs.get("code_challenge").unwrap();
     assert!(code_challenge.len() >= 43);
     assert_eq!(query_pairs.get("code_challenge_method").unwrap(), "S256");
+}
+
+#[test]
+fn pass_full_authorization_url() {
+    let issuer = Url::parse("http://localhost/").unwrap();
+    let authorization_endpoint = issuer.join("authorize").unwrap();
+    let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(42);
+
+    let authorization_data = AuthorizationRequestData::new(
+        CLIENT_ID.to_owned(),
+        [ScopeToken::Openid].into_iter().collect(),
+        Url::parse(REDIRECT_URI).unwrap(),
+    )
+    .with_display(Display::Touch)
+    .with_prompt(vec![Prompt::Create])
+    .with_max_age(NonZeroU32::new(86400).unwrap())
+    .with_ui_locales(vec!["de".parse().unwrap()])
+    .with_id_token_hint("fake.id.token".to_owned())
+    .with_login_hint("mxid:@user:localhost".to_owned())
+    .with_acr_values(["custom".to_owned()].into());
+
+    let (url, validation_data) =
+        build_authorization_url(authorization_endpoint, authorization_data, None, &mut rng)
+            .unwrap();
+
+    assert_eq!(validation_data.state, "OrJ8xbWovSpJUTKz");
+    assert_eq!(validation_data.code_challenge_verifier, None);
+
+    assert_eq!(url.path(), "/authorize");
+
+    let query_pairs = url.query_pairs().collect::<HashMap<_, _>>();
+    assert_eq!(query_pairs.get("scope").unwrap(), "openid");
+    assert_eq!(query_pairs.get("response_type").unwrap(), "code");
+    assert_eq!(query_pairs.get("client_id").unwrap(), CLIENT_ID);
+    assert_eq!(query_pairs.get("redirect_uri").unwrap(), REDIRECT_URI);
+    assert_eq!(query_pairs.get("display").unwrap(), "touch");
+    assert_eq!(query_pairs.get("prompt").unwrap(), "create");
+    assert_eq!(query_pairs.get("max_age").unwrap(), "86400");
+    assert_eq!(query_pairs.get("ui_locales").unwrap(), "de");
+    assert_eq!(query_pairs.get("id_token_hint").unwrap(), "fake.id.token");
+    assert_eq!(
+        query_pairs.get("login_hint").unwrap(),
+        "mxid:@user:localhost"
+    );
+    assert_eq!(query_pairs.get("acr_values").unwrap(), "custom");
+    assert_eq!(*query_pairs.get("state").unwrap(), validation_data.state);
+    assert_eq!(query_pairs.get("nonce").unwrap(), "ox0PigY5l9xl5uTL");
+    assert_eq!(query_pairs.get("code_challenge"), None);
+    assert_eq!(query_pairs.get("code_challenge_method"), None);
 }
 
 #[tokio::test]

--- a/crates/oidc-client/tests/it/requests/authorization_code.rs
+++ b/crates/oidc-client/tests/it/requests/authorization_code.rs
@@ -64,8 +64,8 @@ fn pass_authorization_url() {
             code_challenge_methods_supported: Some(&[PkceCodeChallengeMethod::S256]),
             scope: &[ScopeToken::Openid].into_iter().collect(),
             redirect_uri: &redirect_uri,
-            prompt: None,
         },
+        None,
         &mut rng,
     )
     .unwrap();
@@ -135,8 +135,8 @@ async fn pass_pushed_authorization_request() {
             code_challenge_methods_supported: Some(&[PkceCodeChallengeMethod::S256]),
             scope: &[ScopeToken::Openid].into_iter().collect(),
             redirect_uri: &redirect_uri,
-            prompt: None,
         },
+        None,
         now(),
         &mut rng,
     )
@@ -187,8 +187,8 @@ async fn fail_pushed_authorization_request_404() {
             code_challenge_methods_supported: Some(&[PkceCodeChallengeMethod::S256]),
             scope: &[ScopeToken::Openid].into_iter().collect(),
             redirect_uri: &redirect_uri,
-            prompt: None,
         },
+        None,
         now(),
         &mut rng,
     )

--- a/crates/oidc-client/tests/it/requests/authorization_code.rs
+++ b/crates/oidc-client/tests/it/requests/authorization_code.rs
@@ -59,13 +59,12 @@ fn pass_authorization_url() {
 
     let (url, validation_data) = build_authorization_url(
         authorization_endpoint,
-        AuthorizationRequestData {
-            client_id: CLIENT_ID,
-            code_challenge_methods_supported: Some(&[PkceCodeChallengeMethod::S256]),
-            scope: &[ScopeToken::Openid].into_iter().collect(),
-            redirect_uri: &redirect_uri,
-        },
-        None,
+        AuthorizationRequestData::new(
+            CLIENT_ID.to_owned(),
+            [ScopeToken::Openid].into_iter().collect(),
+            redirect_uri,
+        ),
+        Some(&[PkceCodeChallengeMethod::S256]),
         &mut rng,
     )
     .unwrap();
@@ -130,13 +129,12 @@ async fn pass_pushed_authorization_request() {
         client_credentials,
         &par_endpoint,
         authorization_endpoint,
-        AuthorizationRequestData {
-            client_id: CLIENT_ID,
-            code_challenge_methods_supported: Some(&[PkceCodeChallengeMethod::S256]),
-            scope: &[ScopeToken::Openid].into_iter().collect(),
-            redirect_uri: &redirect_uri,
-        },
-        None,
+        AuthorizationRequestData::new(
+            CLIENT_ID.to_owned(),
+            [ScopeToken::Openid].into_iter().collect(),
+            redirect_uri,
+        ),
+        Some(&[PkceCodeChallengeMethod::S256]),
         now(),
         &mut rng,
     )
@@ -182,13 +180,12 @@ async fn fail_pushed_authorization_request_404() {
         client_credentials,
         &par_endpoint,
         authorization_endpoint,
-        AuthorizationRequestData {
-            client_id: CLIENT_ID,
-            code_challenge_methods_supported: Some(&[PkceCodeChallengeMethod::S256]),
-            scope: &[ScopeToken::Openid].into_iter().collect(),
-            redirect_uri: &redirect_uri,
-        },
-        None,
+        AuthorizationRequestData::new(
+            CLIENT_ID.to_owned(),
+            [ScopeToken::Openid].into_iter().collect(),
+            redirect_uri,
+        ),
+        Some(&[PkceCodeChallengeMethod::S256]),
         now(),
         &mut rng,
     )


### PR DESCRIPTION
So the request is fully customizable.

Base on #1453 because both need to add the `language-tags` crate to `oidc-client`.