### PR TITLE
Allow a trailing slash on the compat SSO route

### DIFF
--- a/crates/handlers/src/lib.rs
+++ b/crates/handlers/src/lib.rs
@@ -330,6 +330,10 @@ where
             get(self::compat::login_sso_redirect::get),
         )
         .route(
+            mas_router::CompatLoginSsoRedirectSlash::route(),
+            get(self::compat::login_sso_redirect::get),
+        )
+        .route(
             mas_router::CompatLoginSsoComplete::route(),
             get(self::compat::login_sso_complete::get).post(self::compat::login_sso_complete::post),
         )

--- a/crates/router/src/endpoints.rs
+++ b/crates/router/src/endpoints.rs
@@ -481,14 +481,24 @@ impl SimpleRoute for CompatRefresh {
     const PATH: &'static str = "/_matrix/client/:version/refresh";
 }
 
-/// `POST /_matrix/client/v3/login/sso/redirect`
+/// `GET /_matrix/client/v3/login/sso/redirect`
 pub struct CompatLoginSsoRedirect;
 
 impl SimpleRoute for CompatLoginSsoRedirect {
     const PATH: &'static str = "/_matrix/client/:version/login/sso/redirect";
 }
 
-/// `POST /_matrix/client/v3/login/sso/redirect/:idp`
+/// `GET /_matrix/client/v3/login/sso/redirect/`
+///
+/// This is a workaround for the fact some clients (Element iOS) sends a
+/// trailing slash, even though it's not in the spec.
+pub struct CompatLoginSsoRedirectSlash;
+
+impl SimpleRoute for CompatLoginSsoRedirectSlash {
+    const PATH: &'static str = "/_matrix/client/:version/login/sso/redirect/";
+}
+
+/// `GET /_matrix/client/v3/login/sso/redirect/:idp`
 pub struct CompatLoginSsoRedirectIdp;
 
 impl SimpleRoute for CompatLoginSsoRedirectIdp {


### PR DESCRIPTION
A bug in Element iOS makes it that it generates the SSO redirect URL with a trailing slash.
Even though it's not valid with the spec, I'd rather accept buggy clients than expect them to fix it right now.
