### PR TITLE
Work around the CSS split issue

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -37,6 +37,7 @@ export default defineConfig((env) => ({
     sourcemap: true,
     modulePreload: false,
     // We don't handle CSS code splitting well yet, so we disable it for now
+    // This means we have to load all the CSS through the `style.css` virtual entrypoint
     cssCodeSplit: false,
 
     rollupOptions: {

--- a/templates/app.html
+++ b/templates/app.html
@@ -38,6 +38,7 @@ limitations under the License.
         handleChange(query);
       })();
     </script>
+    {{ include_asset(path='style.css') | indent(prefix="    ") | safe }}
     {{ include_asset(path='src/main.tsx') | indent(prefix="    ") | safe }}
   </head>
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -27,6 +27,7 @@ limitations under the License.
     <meta charset="utf-8">
     <title>{% block title %}matrix-authentication-service{% endblock title %}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    {{ include_asset(path='style.css') | indent(prefix="    ") | safe }}
     {{ include_asset(path='src/templates.css') | indent(prefix="    ") | safe }}
   </head>
   <body class="bg-white text-black-900 dark:bg-black-800 dark:text-white flex flex-col min-h-screen">


### PR DESCRIPTION
For some reason, CSS included in dynamically included chunks don't appear in the manifest.
This broke the asset loading, so I disabled CSS code split.

Turns out, it means we need to explicitly include the `style.css` asset, else nothing gets included.