### PR TITLE
Expose the GraphQL API to OAuth2 clients

### DIFF
--- a/crates/graphql/src/lib.rs
+++ b/crates/graphql/src/lib.rs
@@ -67,6 +67,49 @@ pub enum Requester {
     OAuth2Session(Session, User),
 }
 
+trait OwnerId {
+    fn owner_id(&self) -> Option<Ulid>;
+}
+
+impl OwnerId for User {
+    fn owner_id(&self) -> Option<Ulid> {
+        Some(self.id)
+    }
+}
+
+impl OwnerId for BrowserSession {
+    fn owner_id(&self) -> Option<Ulid> {
+        Some(self.user.id)
+    }
+}
+
+impl OwnerId for mas_data_model::UserEmail {
+    fn owner_id(&self) -> Option<Ulid> {
+        Some(self.user_id)
+    }
+}
+
+impl OwnerId for mas_data_model::CompatSession {
+    fn owner_id(&self) -> Option<Ulid> {
+        Some(self.user_id)
+    }
+}
+
+impl OwnerId for mas_data_model::UpstreamOAuthLink {
+    fn owner_id(&self) -> Option<Ulid> {
+        self.user_id
+    }
+}
+
+/// A dumb wrapper around a `Ulid` to implement `OwnerId` for it.
+pub struct UserId(Ulid);
+
+impl OwnerId for UserId {
+    fn owner_id(&self) -> Option<Ulid> {
+        Some(self.0)
+    }
+}
+
 impl Requester {
     fn browser_session(&self) -> Option<&BrowserSession> {
         match self {
@@ -83,19 +126,23 @@ impl Requester {
         }
     }
 
-    fn ensure_owner_or_admin(&self, user_id: Ulid) -> Result<(), async_graphql::Error> {
+    /// Returns true if the requester can access the resource.
+    fn is_owner_or_admin(&self, resource: &impl OwnerId) -> bool {
         // If the requester is an admin, they can do anything.
         if self.is_admin() {
-            return Ok(());
+            return true;
         }
 
-        // Else check that they are the owner.
-        let user = self.user().context("Unauthorized")?;
-        if user.id == user_id {
-            Ok(())
-        } else {
-            Err(async_graphql::Error::new("Unauthorized"))
-        }
+        // Otherwise, they must be the owner of the resource.
+        let Some(owner_id) = resource.owner_id() else {
+            return false;
+        };
+
+        let Some(user) = self.user() else {
+            return false;
+        };
+
+        user.id == owner_id
     }
 
     fn is_admin(&self) -> bool {

--- a/crates/graphql/src/lib.rs
+++ b/crates/graphql/src/lib.rs
@@ -26,7 +26,6 @@
     clippy::unused_async
 )]
 
-use anyhow::Context;
 use async_graphql::EmptySubscription;
 use mas_data_model::{BrowserSession, Session, User};
 use ulid::Ulid;

--- a/crates/graphql/src/model/viewer/mod.rs
+++ b/crates/graphql/src/model/viewer/mod.rs
@@ -14,7 +14,7 @@
 
 use async_graphql::Union;
 
-use crate::model::{BrowserSession, User};
+use crate::model::{BrowserSession, OAuth2Session, User};
 
 mod anonymous;
 pub use self::anonymous::Anonymous;
@@ -40,12 +40,17 @@ impl Viewer {
 #[derive(Union)]
 pub enum ViewerSession {
     BrowserSession(BrowserSession),
+    OAuth2Session(OAuth2Session),
     Anonymous(Anonymous),
 }
 
 impl ViewerSession {
     pub fn browser_session(session: mas_data_model::BrowserSession) -> Self {
         Self::BrowserSession(BrowserSession(session))
+    }
+
+    pub fn oauth2_session(session: mas_data_model::Session) -> Self {
+        Self::OAuth2Session(OAuth2Session(session))
     }
 
     pub fn anonymous() -> Self {

--- a/crates/graphql/src/query/upstream_oauth.rs
+++ b/crates/graphql/src/query/upstream_oauth.rs
@@ -49,7 +49,8 @@ impl UpstreamOAuthQuery {
         let link = repo.upstream_oauth_link().lookup(id).await?;
 
         // Ensure that the link belongs to the current user
-        let link = link.filter(|link| link.user_id == Some(current_user.id));
+        let link =
+            link.filter(|link| link.user_id == Some(current_user.id) || requester.is_admin());
 
         Ok(link.map(UpstreamOAuth2Link::new))
     }

--- a/crates/graphql/src/query/upstream_oauth.rs
+++ b/crates/graphql/src/query/upstream_oauth.rs
@@ -41,18 +41,19 @@ impl UpstreamOAuthQuery {
         let id = NodeType::UpstreamOAuth2Link.extract_ulid(&id)?;
         let requester = ctx.requester();
 
-        let Some(current_user) = requester.user() else {
+        let mut repo = state.repository().await?;
+        let link = repo.upstream_oauth_link().lookup(id).await?;
+        repo.cancel().await?;
+
+        let Some(link) = link else {
             return Ok(None);
         };
-        let mut repo = state.repository().await?;
 
-        let link = repo.upstream_oauth_link().lookup(id).await?;
+        if !requester.is_owner_or_admin(&link) {
+            return Ok(None);
+        }
 
-        // Ensure that the link belongs to the current user
-        let link =
-            link.filter(|link| link.user_id == Some(current_user.id) || requester.is_admin());
-
-        Ok(link.map(UpstreamOAuth2Link::new))
+        Ok(Some(UpstreamOAuth2Link::new(link)))
     }
 
     /// Fetch an upstream OAuth 2.0 provider by its ID.
@@ -68,7 +69,11 @@ impl UpstreamOAuthQuery {
         let provider = repo.upstream_oauth_provider().lookup(id).await?;
         repo.cancel().await?;
 
-        Ok(provider.map(UpstreamOAuth2Provider::new))
+        let Some(provider) = provider else {
+            return Ok(None);
+        };
+
+        Ok(Some(UpstreamOAuth2Provider::new(provider)))
     }
 
     /// Get a list of upstream OAuth 2.0 providers.

--- a/crates/graphql/src/query/viewer.rs
+++ b/crates/graphql/src/query/viewer.rs
@@ -31,6 +31,7 @@ impl ViewerQuery {
 
         match requester {
             Requester::BrowserSession(session) => Viewer::user(session.user.clone()),
+            Requester::OAuth2Session(_session, user) => Viewer::user(user.clone()),
             Requester::Anonymous => Viewer::anonymous(),
         }
     }
@@ -41,6 +42,9 @@ impl ViewerQuery {
 
         match requester {
             Requester::BrowserSession(session) => ViewerSession::browser_session(session.clone()),
+            Requester::OAuth2Session(session, _user) => {
+                ViewerSession::oauth2_session(session.clone())
+            }
             Requester::Anonymous => ViewerSession::anonymous(),
         }
     }

--- a/crates/handlers/src/graphql.rs
+++ b/crates/handlers/src/graphql.rs
@@ -21,23 +21,28 @@ use async_graphql::{
 use axum::{
     async_trait,
     extract::{BodyStream, RawQuery, State},
-    response::{Html, IntoResponse},
+    http::StatusCode,
+    response::{Html, IntoResponse, Response},
     Json, TypedHeader,
 };
 use axum_extra::extract::PrivateCookieJar;
 use futures_util::TryStreamExt;
-use headers::{ContentType, HeaderValue};
+use headers::{authorization::Bearer, Authorization, ContentType, HeaderValue};
 use hyper::header::CACHE_CONTROL;
-use mas_axum_utils::{FancyError, SessionInfoExt};
+use mas_axum_utils::{FancyError, SessionInfo, SessionInfoExt};
 use mas_graphql::{Requester, Schema};
 use mas_keystore::Encrypter;
 use mas_matrix::HomeserverConnection;
-use mas_storage::{BoxClock, BoxRepository, BoxRng, Repository, RepositoryError, SystemClock};
+use mas_storage::{
+    BoxClock, BoxRepository, BoxRng, Clock, Repository, RepositoryError, SystemClock,
+};
 use mas_storage_pg::PgRepository;
 use rand::{thread_rng, SeedableRng};
 use rand_chacha::ChaChaRng;
 use sqlx::PgPool;
 use tracing::{info_span, Instrument};
+
+use crate::impl_from_error_for_route;
 
 struct GraphQLState {
     pool: PgPool,
@@ -107,17 +112,129 @@ fn span_for_graphql_request(request: &async_graphql::Request) -> tracing::Span {
     span
 }
 
+#[derive(thiserror::Error, Debug)]
+pub enum RouteError {
+    #[error(transparent)]
+    Internal(Box<dyn std::error::Error + Send + Sync + 'static>),
+
+    #[error("Loading of some database objects failed")]
+    LoadFailed,
+
+    #[error("Invalid access token")]
+    InvalidToken,
+
+    #[error("Missing scope")]
+    MissingScope,
+
+    #[error(transparent)]
+    ParseRequest(#[from] async_graphql::ParseRequestError),
+}
+
+impl_from_error_for_route!(mas_storage::RepositoryError);
+
+impl IntoResponse for RouteError {
+    fn into_response(self) -> Response {
+        sentry::capture_error(&self);
+
+        match self {
+            e @ (Self::Internal(_) | Self::LoadFailed) => {
+                let error = async_graphql::Error::new_with_source(e);
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(serde_json::json!({"errors": [error]})),
+                )
+                    .into_response()
+            }
+
+            Self::InvalidToken => {
+                let error = async_graphql::Error::new("Invalid token");
+                (
+                    StatusCode::UNAUTHORIZED,
+                    Json(serde_json::json!({"errors": [error]})),
+                )
+                    .into_response()
+            }
+
+            Self::MissingScope => {
+                let error = async_graphql::Error::new("Missing urn:mas:graphql:* scope");
+                (
+                    StatusCode::UNAUTHORIZED,
+                    Json(serde_json::json!({"errors": [error]})),
+                )
+                    .into_response()
+            }
+
+            Self::ParseRequest(e) => {
+                let error = async_graphql::Error::new_with_source(e);
+                (
+                    StatusCode::BAD_REQUEST,
+                    Json(serde_json::json!({"errors": [error]})),
+                )
+                    .into_response()
+            }
+        }
+    }
+}
+
+async fn get_requester(
+    clock: &impl Clock,
+    mut repo: BoxRepository,
+    session_info: SessionInfo,
+    token: Option<&str>,
+) -> Result<Requester, RouteError> {
+    let requester = if let Some(token) = token {
+        let token = repo
+            .oauth2_access_token()
+            .find_by_token(token)
+            .await?
+            .ok_or(RouteError::InvalidToken)?;
+
+        let session = repo
+            .oauth2_session()
+            .lookup(token.session_id)
+            .await?
+            .ok_or(RouteError::LoadFailed)?;
+
+        // XXX: The user_id should really be directly on the OAuth session
+        let browser_session = repo
+            .browser_session()
+            .lookup(session.user_session_id)
+            .await?
+            .ok_or(RouteError::LoadFailed)?;
+
+        let user = browser_session.user;
+
+        if !token.is_valid(clock.now()) || !session.is_valid() || !user.is_valid() {
+            return Err(RouteError::InvalidToken);
+        }
+
+        if !session.scope.contains("urn:mas:graphql:*") {
+            return Err(RouteError::MissingScope);
+        }
+
+        Requester::OAuth2Session(session, user)
+    } else {
+        let maybe_session = session_info.load_session(&mut repo).await?;
+        Requester::from(maybe_session)
+    };
+    repo.cancel().await?;
+    Ok(requester)
+}
+
 pub async fn post(
     State(schema): State<Schema>,
-    mut repo: BoxRepository,
+    clock: BoxClock,
+    repo: BoxRepository,
     cookie_jar: PrivateCookieJar<Encrypter>,
     content_type: Option<TypedHeader<ContentType>>,
+    authorization: Option<TypedHeader<Authorization<Bearer>>>,
     body: BodyStream,
-) -> Result<impl IntoResponse, FancyError> {
+) -> Result<impl IntoResponse, RouteError> {
+    let token = authorization
+        .as_ref()
+        .map(|TypedHeader(Authorization(bearer))| bearer.token());
     let (session_info, _cookie_jar) = cookie_jar.session_info();
-    let maybe_session = session_info.load_session(&mut repo).await?;
-    let requester = Requester::from(maybe_session);
-    repo.cancel().await?;
+    let requester = get_requester(&clock, repo, session_info, token).await?;
 
     let content_type = content_type.map(|TypedHeader(h)| h.to_string());
 
@@ -146,14 +263,17 @@ pub async fn post(
 
 pub async fn get(
     State(schema): State<Schema>,
-    mut repo: BoxRepository,
+    clock: BoxClock,
+    repo: BoxRepository,
     cookie_jar: PrivateCookieJar<Encrypter>,
+    authorization: Option<TypedHeader<Authorization<Bearer>>>,
     RawQuery(query): RawQuery,
 ) -> Result<impl IntoResponse, FancyError> {
+    let token = authorization
+        .as_ref()
+        .map(|TypedHeader(Authorization(bearer))| bearer.token());
     let (session_info, _cookie_jar) = cookie_jar.session_info();
-    let maybe_session = session_info.load_session(&mut repo).await?;
-    let requester = Requester::from(maybe_session);
-    repo.cancel().await?;
+    let requester = get_requester(&clock, repo, session_info, token).await?;
 
     let request =
         async_graphql::http::parse_query_string(&query.unwrap_or_default())?.data(requester);

--- a/crates/handlers/src/graphql/mod.rs
+++ b/crates/handlers/src/graphql/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 The Matrix.org Foundation C.I.C.
+// Copyright 2022, 2023 The Matrix.org Foundation C.I.C.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -43,6 +43,9 @@ use sqlx::PgPool;
 use tracing::{info_span, Instrument};
 
 use crate::impl_from_error_for_route;
+
+#[cfg(test)]
+mod tests;
 
 struct GraphQLState {
     pool: PgPool,

--- a/crates/handlers/src/graphql/tests.rs
+++ b/crates/handlers/src/graphql/tests.rs
@@ -1,0 +1,203 @@
+// Copyright 2023 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use axum::http::Request;
+use hyper::StatusCode;
+use mas_data_model::AuthorizationCode;
+use mas_router::SimpleRoute;
+use oauth2_types::{
+    registration::ClientRegistrationResponse,
+    requests::{AccessTokenResponse, ResponseMode},
+    scope::{Scope, ScopeToken, OPENID},
+};
+use sqlx::PgPool;
+
+use crate::test_utils::{init_tracing, RequestBuilderExt, ResponseExt, TestState};
+
+const GRAPHQL_SCOPE: ScopeToken = ScopeToken::from_static("urn:mas:graphql:*");
+
+#[derive(serde::Deserialize)]
+struct GraphQLResponse {
+    data: serde_json::Value,
+    errors: Option<Vec<serde_json::Value>>,
+}
+
+#[sqlx::test(migrator = "mas_storage_pg::MIGRATOR")]
+async fn test_anonymous_viewer(pool: PgPool) {
+    init_tracing();
+    let state = TestState::from_pool(pool).await.unwrap();
+
+    let req = Request::post("/graphql").json(serde_json::json!({
+        "query": r#"
+            query {
+                viewer {
+                    __typename
+                }
+            }
+        "#,
+    }));
+
+    let response = state.request(req).await;
+    response.assert_status(StatusCode::OK);
+    let response: GraphQLResponse = response.json();
+
+    assert_eq!(response.errors, None);
+    assert_eq!(
+        response.data,
+        serde_json::json!({
+            "viewer": {
+                "__typename": "Anonymous",
+            },
+        })
+    );
+}
+
+#[sqlx::test(migrator = "mas_storage_pg::MIGRATOR")]
+async fn test_oauth2_viewer(pool: PgPool) {
+    init_tracing();
+    let state = TestState::from_pool(pool).await.unwrap();
+
+    // Start by creating a user, a client and a token
+    // XXX: this is a lot of boilerplate just to get an access token!
+
+    // Provision a client
+    let request =
+        Request::post(mas_router::OAuth2RegistrationEndpoint::PATH).json(serde_json::json!({
+            "client_uri": "https://example.com/",
+            "redirect_uris": ["https://example.com/callback"],
+            "contacts": ["contact@example.com"],
+            "token_endpoint_auth_method": "none",
+            "response_types": ["code"],
+            "grant_types": ["authorization_code"],
+        }));
+
+    let response = state.request(request).await;
+    response.assert_status(StatusCode::CREATED);
+
+    let ClientRegistrationResponse { client_id, .. } = response.json();
+
+    // Let's provision a user and create a session for them.
+    let mut repo = state.repository().await.unwrap();
+
+    let user = repo
+        .user()
+        .add(&mut state.rng(), &state.clock, "alice".to_owned())
+        .await
+        .unwrap();
+
+    let browser_session = repo
+        .browser_session()
+        .add(&mut state.rng(), &state.clock, &user)
+        .await
+        .unwrap();
+
+    // Lookup the client in the database.
+    let client = repo
+        .oauth2_client()
+        .find_by_client_id(&client_id)
+        .await
+        .unwrap()
+        .unwrap();
+
+    // Start a grant
+    let code = "thisisaverysecurecode";
+    let grant = repo
+        .oauth2_authorization_grant()
+        .add(
+            &mut state.rng(),
+            &state.clock,
+            &client,
+            "https://example.com/redirect".parse().unwrap(),
+            Scope::from_iter([OPENID, GRAPHQL_SCOPE]),
+            Some(AuthorizationCode {
+                code: code.to_owned(),
+                pkce: None,
+            }),
+            Some("state".to_owned()),
+            Some("nonce".to_owned()),
+            None,
+            ResponseMode::Query,
+            false,
+            false,
+        )
+        .await
+        .unwrap();
+
+    let session = repo
+        .oauth2_session()
+        .add(
+            &mut state.rng(),
+            &state.clock,
+            &client,
+            &browser_session,
+            grant.scope.clone(),
+        )
+        .await
+        .unwrap();
+
+    // And fulfill it
+    let grant = repo
+        .oauth2_authorization_grant()
+        .fulfill(&state.clock, &session, grant)
+        .await
+        .unwrap();
+
+    repo.save().await.unwrap();
+
+    // Now call the token endpoint to get an access token.
+    let request = Request::post(mas_router::OAuth2TokenEndpoint::PATH).form(serde_json::json!({
+        "grant_type": "authorization_code",
+        "code": code,
+        "redirect_uri": grant.redirect_uri,
+        "client_id": client.client_id,
+    }));
+
+    let response = state.request(request).await;
+    response.assert_status(StatusCode::OK);
+
+    let AccessTokenResponse { access_token, .. } = response.json();
+
+    let req = Request::post("/graphql")
+        .bearer(&access_token)
+        .json(serde_json::json!({
+            "query": r#"
+                query {
+                    viewer {
+                        __typename
+                        
+                        ... on User {
+                            id
+                            username
+                        }
+                    }
+                }
+            "#,
+        }));
+
+    let response = state.request(req).await;
+    response.assert_status(StatusCode::OK);
+    let response: GraphQLResponse = response.json();
+
+    assert_eq!(response.errors, None);
+    assert_eq!(
+        response.data,
+        serde_json::json!({
+            "viewer": {
+                "__typename": "User",
+                "id": format!("user:{id}", id = user.id),
+                "username": "alice",
+            },
+        })
+    );
+}

--- a/crates/handlers/src/graphql/tests.rs
+++ b/crates/handlers/src/graphql/tests.rs
@@ -13,26 +13,141 @@
 // limitations under the License.
 
 use axum::http::Request;
+use chrono::Duration;
 use hyper::StatusCode;
-use mas_data_model::AuthorizationCode;
-use mas_router::SimpleRoute;
-use oauth2_types::{
-    registration::ClientRegistrationResponse,
-    requests::{AccessTokenResponse, ResponseMode},
-    scope::{Scope, ScopeToken, OPENID},
-};
+use mas_data_model::{AccessToken, Client, TokenType, User};
+use mas_storage::{oauth2::OAuth2ClientRepository, RepositoryAccess};
+use oauth2_types::scope::{Scope, ScopeToken, OPENID};
 use sqlx::PgPool;
 
 use crate::test_utils::{init_tracing, RequestBuilderExt, ResponseExt, TestState};
 
-const GRAPHQL_SCOPE: ScopeToken = ScopeToken::from_static("urn:mas:graphql:*");
+async fn create_test_client(state: &TestState) -> Client {
+    let mut repo = state.repository().await.unwrap();
+    let mut rng = state.rng();
+
+    let client = repo
+        .oauth2_client()
+        .add(
+            &mut rng,
+            &state.clock,
+            vec![],
+            None,
+            vec![],
+            vec![],
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+    repo.save().await.unwrap();
+
+    client
+}
+
+async fn create_test_user<U: Into<String> + Send>(state: &TestState, username: U) -> User {
+    let username = username.into();
+    let mut repo = state.repository().await.unwrap();
+    let mut rng = state.rng();
+
+    let user = repo
+        .user()
+        .add(&mut rng, &state.clock, username)
+        .await
+        .unwrap();
+
+    repo.save().await.unwrap();
+
+    user
+}
+
+async fn start_oauth_session(
+    state: &TestState,
+    client: &Client,
+    user: &User,
+    scope: Scope,
+) -> AccessToken {
+    let mut repo = state.repository().await.unwrap();
+    let mut rng = state.rng();
+
+    let browser_session = repo
+        .browser_session()
+        .add(&mut rng, &state.clock, user)
+        .await
+        .unwrap();
+
+    let session = repo
+        .oauth2_session()
+        .add(&mut rng, &state.clock, client, &browser_session, scope)
+        .await
+        .unwrap();
+
+    let access_token_str = TokenType::AccessToken.generate(&mut rng);
+
+    let access_token = repo
+        .oauth2_access_token()
+        .add(
+            &mut rng,
+            &state.clock,
+            &session,
+            access_token_str,
+            Duration::minutes(5),
+        )
+        .await
+        .unwrap();
+
+    repo.save().await.unwrap();
+
+    access_token
+}
+
+const GRAPHQL: ScopeToken = ScopeToken::from_static("urn:mas:graphql:*");
+const ADMIN: ScopeToken = ScopeToken::from_static("urn:mas:admin");
 
 #[derive(serde::Deserialize)]
 struct GraphQLResponse {
+    #[serde(default)]
     data: serde_json::Value,
-    errors: Option<Vec<serde_json::Value>>,
+    #[serde(default)]
+    errors: Vec<serde_json::Value>,
 }
 
+/// Test that the GraphQL endpoint can be queried with a GET request.
+#[sqlx::test(migrator = "mas_storage_pg::MIGRATOR")]
+async fn test_get(pool: PgPool) {
+    init_tracing();
+    let state = TestState::from_pool(pool).await.unwrap();
+
+    let request = Request::get("/graphql?query={viewer{__typename}}").empty();
+
+    let response = state.request(request).await;
+    response.assert_status(StatusCode::OK);
+    let response: GraphQLResponse = response.json();
+
+    assert!(response.errors.is_empty());
+    assert_eq!(
+        response.data,
+        serde_json::json!({
+            "viewer": {
+                "__typename": "Anonymous",
+            },
+        })
+    );
+}
+
+/// Test that the GraphQL endpoint can be queried with a POST request
+/// anonymously.
 #[sqlx::test(migrator = "mas_storage_pg::MIGRATOR")]
 async fn test_anonymous_viewer(pool: PgPool) {
     init_tracing();
@@ -52,7 +167,7 @@ async fn test_anonymous_viewer(pool: PgPool) {
     response.assert_status(StatusCode::OK);
     let response: GraphQLResponse = response.json();
 
-    assert_eq!(response.errors, None);
+    assert!(response.errors.is_empty());
     assert_eq!(
         response.data,
         serde_json::json!({
@@ -63,110 +178,18 @@ async fn test_anonymous_viewer(pool: PgPool) {
     );
 }
 
+/// Test that the GraphQL endpoint can be authenticated with a bearer token.
 #[sqlx::test(migrator = "mas_storage_pg::MIGRATOR")]
 async fn test_oauth2_viewer(pool: PgPool) {
     init_tracing();
     let state = TestState::from_pool(pool).await.unwrap();
 
     // Start by creating a user, a client and a token
-    // XXX: this is a lot of boilerplate just to get an access token!
-
-    // Provision a client
-    let request =
-        Request::post(mas_router::OAuth2RegistrationEndpoint::PATH).json(serde_json::json!({
-            "client_uri": "https://example.com/",
-            "redirect_uris": ["https://example.com/callback"],
-            "contacts": ["contact@example.com"],
-            "token_endpoint_auth_method": "none",
-            "response_types": ["code"],
-            "grant_types": ["authorization_code"],
-        }));
-
-    let response = state.request(request).await;
-    response.assert_status(StatusCode::CREATED);
-
-    let ClientRegistrationResponse { client_id, .. } = response.json();
-
-    // Let's provision a user and create a session for them.
-    let mut repo = state.repository().await.unwrap();
-
-    let user = repo
-        .user()
-        .add(&mut state.rng(), &state.clock, "alice".to_owned())
-        .await
-        .unwrap();
-
-    let browser_session = repo
-        .browser_session()
-        .add(&mut state.rng(), &state.clock, &user)
-        .await
-        .unwrap();
-
-    // Lookup the client in the database.
-    let client = repo
-        .oauth2_client()
-        .find_by_client_id(&client_id)
-        .await
-        .unwrap()
-        .unwrap();
-
-    // Start a grant
-    let code = "thisisaverysecurecode";
-    let grant = repo
-        .oauth2_authorization_grant()
-        .add(
-            &mut state.rng(),
-            &state.clock,
-            &client,
-            "https://example.com/redirect".parse().unwrap(),
-            Scope::from_iter([OPENID, GRAPHQL_SCOPE]),
-            Some(AuthorizationCode {
-                code: code.to_owned(),
-                pkce: None,
-            }),
-            Some("state".to_owned()),
-            Some("nonce".to_owned()),
-            None,
-            ResponseMode::Query,
-            false,
-            false,
-        )
-        .await
-        .unwrap();
-
-    let session = repo
-        .oauth2_session()
-        .add(
-            &mut state.rng(),
-            &state.clock,
-            &client,
-            &browser_session,
-            grant.scope.clone(),
-        )
-        .await
-        .unwrap();
-
-    // And fulfill it
-    let grant = repo
-        .oauth2_authorization_grant()
-        .fulfill(&state.clock, &session, grant)
-        .await
-        .unwrap();
-
-    repo.save().await.unwrap();
-
-    // Now call the token endpoint to get an access token.
-    let request = Request::post(mas_router::OAuth2TokenEndpoint::PATH).form(serde_json::json!({
-        "grant_type": "authorization_code",
-        "code": code,
-        "redirect_uri": grant.redirect_uri,
-        "client_id": client.client_id,
-    }));
-
-    let response = state.request(request).await;
-    response.assert_status(StatusCode::OK);
-
-    let AccessTokenResponse { access_token, .. } = response.json();
+    let client = create_test_client(&state).await;
+    let user = create_test_user(&state, "alice").await;
+    let access_token =
+        start_oauth_session(&state, &client, &user, Scope::from_iter([GRAPHQL])).await;
+    let access_token = access_token.access_token;
 
     let req = Request::post("/graphql")
         .bearer(&access_token)
@@ -189,7 +212,7 @@ async fn test_oauth2_viewer(pool: PgPool) {
     response.assert_status(StatusCode::OK);
     let response: GraphQLResponse = response.json();
 
-    assert_eq!(response.errors, None);
+    assert!(response.errors.is_empty());
     assert_eq!(
         response.data,
         serde_json::json!({
@@ -197,6 +220,130 @@ async fn test_oauth2_viewer(pool: PgPool) {
                 "__typename": "User",
                 "id": format!("user:{id}", id = user.id),
                 "username": "alice",
+            },
+        })
+    );
+}
+
+/// Test that the GraphQL endpoint requires the GraphQL scope.
+#[sqlx::test(migrator = "mas_storage_pg::MIGRATOR")]
+async fn test_oauth2_no_scope(pool: PgPool) {
+    init_tracing();
+    let state = TestState::from_pool(pool).await.unwrap();
+
+    // Start by creating a user, a client and a token
+    let client = create_test_client(&state).await;
+    let user = create_test_user(&state, "alice").await;
+    let access_token =
+        start_oauth_session(&state, &client, &user, Scope::from_iter([OPENID])).await;
+    let access_token = access_token.access_token;
+
+    let req = Request::post("/graphql")
+        .bearer(&access_token)
+        .json(serde_json::json!({
+            "query": r#"
+                query {
+                    viewer {
+                        __typename
+                    }
+                }
+            "#,
+        }));
+
+    let response = state.request(req).await;
+    response.assert_status(StatusCode::UNAUTHORIZED);
+    let response: GraphQLResponse = response.json();
+
+    assert_eq!(
+        response.errors,
+        vec![serde_json::json!({
+            "message": "Missing urn:mas:graphql:* scope",
+        })]
+    );
+    assert_eq!(response.data, serde_json::json!(null));
+}
+
+/// Test the admin scope on the GraphQL endpoint.
+#[sqlx::test(migrator = "mas_storage_pg::MIGRATOR")]
+async fn test_oauth2_admin(pool: PgPool) {
+    init_tracing();
+    let state = TestState::from_pool(pool).await.unwrap();
+
+    // Start by creating a user, a client and two tokens
+    let client = create_test_client(&state).await;
+    let user = create_test_user(&state, "alice").await;
+
+    // Regular access token
+    let access_token =
+        start_oauth_session(&state, &client, &user, Scope::from_iter([GRAPHQL])).await;
+    let access_token = access_token.access_token;
+
+    // Admin access token
+    let access_token_admin =
+        start_oauth_session(&state, &client, &user, Scope::from_iter([GRAPHQL, ADMIN])).await;
+    let access_token_admin = access_token_admin.access_token;
+
+    // Create a second user and try to query stuff about it
+    let user2 = create_test_user(&state, "bob").await;
+
+    let request = Request::post("/graphql")
+        .bearer(&access_token)
+        .json(serde_json::json!({
+            "query": r#"
+                query UserQuery($id: ID) {
+                    user(id: $id) {
+                        id
+                        username
+                    }
+                }
+            "#, 
+            "variables": {
+                "id": format!("user:{id}", id = user2.id),
+            },
+        }));
+
+    let response = state.request(request).await;
+    response.assert_status(StatusCode::OK);
+    let response: GraphQLResponse = response.json();
+
+    // It should not find the user, because it's not the owner and not an admin
+    assert!(response.errors.is_empty());
+    assert_eq!(
+        response.data,
+        serde_json::json!({
+            "user": null,
+        })
+    );
+
+    // Do the same request with the admin token
+    let request = Request::post("/graphql")
+        .bearer(&access_token_admin)
+        .json(serde_json::json!({
+            "query": r#"
+                query UserQuery($id: ID) {
+                    user(id: $id) {
+                        id
+                        username
+                    }
+                }
+            "#, 
+            "variables": {
+                "id": format!("user:{id}", id = user2.id),
+            },
+        }));
+
+    let response = state.request(request).await;
+    response.assert_status(StatusCode::OK);
+    let response: GraphQLResponse = response.json();
+
+    // It should find the user, because the token has the admin scope
+    assert!(response.errors.is_empty());
+    assert_eq!(
+        response.data,
+        serde_json::json!({
+            "user": {
+                "id": format!("user:{id}", id = user2.id),
+                "username": "bob",
             },
         })
     );

--- a/crates/handlers/src/lib.rs
+++ b/crates/handlers/src/lib.rs
@@ -103,6 +103,7 @@ where
     S: Clone + Send + Sync + 'static,
     mas_graphql::Schema: FromRef<S>,
     BoxRepository: FromRequestParts<S>,
+    BoxClock: FromRequestParts<S>,
     Encrypter: FromRef<S>,
 {
     let mut router = Router::new().route(

--- a/frontend/schema.graphql
+++ b/frontend/schema.graphql
@@ -1165,7 +1165,7 @@ union Viewer = User | Anonymous
 """
 Represents the current viewer's session
 """
-union ViewerSession = BrowserSession | Anonymous
+union ViewerSession = BrowserSession | Oauth2Session | Anonymous
 
 schema {
   query: Query

--- a/frontend/src/gql/graphql.ts
+++ b/frontend/src/gql/graphql.ts
@@ -873,7 +873,7 @@ export enum VerifyEmailStatus {
 export type Viewer = Anonymous | User;
 
 /** Represents the current viewer's session */
-export type ViewerSession = Anonymous | BrowserSession;
+export type ViewerSession = Anonymous | BrowserSession | Oauth2Session;
 
 export type CurrentViewerQueryQueryVariables = Exact<{ [key: string]: never }>;
 
@@ -892,7 +892,8 @@ export type CurrentViewerSessionQueryQuery = {
   __typename?: "Query";
   viewerSession:
     | { __typename: "Anonymous"; id: string }
-    | { __typename: "BrowserSession"; id: string };
+    | { __typename: "BrowserSession"; id: string }
+    | { __typename: "Oauth2Session" };
 };
 
 export type AddEmailMutationVariables = Exact<{

--- a/frontend/src/gql/schema.ts
+++ b/frontend/src/gql/schema.ts
@@ -2601,6 +2601,10 @@ export default {
             kind: "OBJECT",
             name: "BrowserSession",
           },
+          {
+            kind: "OBJECT",
+            name: "Oauth2Session",
+          },
         ],
       },
       {

--- a/policies/authorization_grant.rego
+++ b/policies/authorization_grant.rego
@@ -15,7 +15,17 @@ allowed_scope("openid") = true
 
 allowed_scope("email") = true
 
+# This grants access to Synapse's admin API endpoints
 allowed_scope("urn:synapse:admin:*") {
+	some user in data.admin_users
+	input.user.username == user
+}
+
+# This grants access to the /graphql API endpoint
+allowed_scope("urn:mas:graphql:*") = true
+
+# This makes it possible to query and do anything in the GraphQL API as an admin
+allowed_scope("urn:mas:admin") {
 	some user in data.admin_users
 	input.user.username == user
 }

--- a/policies/authorization_grant_test.rego
+++ b/policies/authorization_grant_test.rego
@@ -4,6 +4,9 @@ user := {"username": "john"}
 
 test_standard_scopes {
 	allow with input.user as user
+		with input.authorization_grant as {"scope": ""}
+
+	allow with input.user as user
 		with input.authorization_grant as {"scope": "openid"}
 
 	allow with input.user as user
@@ -60,4 +63,17 @@ test_synapse_admin_scopes {
 	not allow with input.user as user
 		with data.admin_users as []
 		with input.authorization_grant as {"scope": "urn:synapse:admin:*"}
+}
+
+test_mas_scopes {
+	allow with input.user as user
+		with input.authorization_grant as {"scope": "urn:mas:graphql:*"}
+
+	allow with input.user as user
+		with data.admin_users as ["john"]
+		with input.authorization_grant as {"scope": "urn:mas:admin"}
+
+	not allow with input.user as user
+		with data.admin_users as []
+		with input.authorization_grant as {"scope": "urn:mas:admin"}
 }


### PR DESCRIPTION
This exposes the /graphql endpoint to OAuth 2.0 clients.
To do that, they need to ask for the `urn:mas:graphql:*` scope.
Additionally, if it is allowed by the policy, they can ask for the `urn:mas:admin` scope which allows them to query/mutate any resource, not just the ones they own.
