### PR TITLE
API to find a session by its device ID

### DIFF
--- a/crates/graphql/src/model/users.rs
+++ b/crates/graphql/src/model/users.rs
@@ -213,7 +213,7 @@ impl User {
                     .extend(page.edges.into_iter().map(|(session, sso_login)| {
                         Edge::new(
                             OpaqueCursor(NodeCursor(NodeType::CompatSession, session.id)),
-                            CompatSession(session, sso_login),
+                            CompatSession::new(session).with_loaded_sso_login(sso_login),
                         )
                     }));
 

--- a/crates/graphql/src/mutations/compat_session.rs
+++ b/crates/graphql/src/mutations/compat_session.rs
@@ -66,8 +66,7 @@ impl EndCompatSessionPayload {
     /// Returns the ended session.
     async fn compat_session(&self) -> Option<CompatSession> {
         match self {
-            // XXX: the SSO login is not returned here.
-            Self::Ended(session) => Some(CompatSession(session.clone(), None)),
+            Self::Ended(session) => Some(CompatSession::new(session.clone())),
             Self::NotFound => None,
         }
     }

--- a/crates/graphql/src/query/mod.rs
+++ b/crates/graphql/src/query/mod.rs
@@ -20,14 +20,15 @@ use crate::{
     UserId,
 };
 
+mod session;
 mod upstream_oauth;
 mod viewer;
 
-use self::{upstream_oauth::UpstreamOAuthQuery, viewer::ViewerQuery};
+use self::{session::SessionQuery, upstream_oauth::UpstreamOAuthQuery, viewer::ViewerQuery};
 
 /// The query root of the GraphQL interface.
 #[derive(Default, MergedObject)]
-pub struct Query(BaseQuery, UpstreamOAuthQuery, ViewerQuery);
+pub struct Query(BaseQuery, UpstreamOAuthQuery, SessionQuery, ViewerQuery);
 
 impl Query {
     #[must_use]

--- a/crates/graphql/src/query/session.rs
+++ b/crates/graphql/src/query/session.rs
@@ -1,0 +1,106 @@
+// Copyright 2023 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use async_graphql::{Context, Object, Union, ID};
+use mas_data_model::Device;
+use mas_storage::{
+    compat::CompatSessionRepository, oauth2::OAuth2SessionFilter, Pagination, RepositoryAccess,
+};
+use oauth2_types::scope::Scope;
+
+use crate::{
+    model::{CompatSession, NodeType, OAuth2Session},
+    state::ContextExt,
+    UserId,
+};
+
+#[derive(Default)]
+pub struct SessionQuery;
+
+/// A client session, either compat or OAuth 2.0
+#[derive(Union)]
+enum Session {
+    CompatSession(Box<CompatSession>),
+    OAuth2Session(Box<OAuth2Session>),
+}
+
+#[Object]
+impl SessionQuery {
+    /// Lookup a compat or OAuth 2.0 session
+    async fn session(
+        &self,
+        ctx: &Context<'_>,
+        user_id: ID,
+        device_id: String,
+    ) -> Result<Option<Session>, async_graphql::Error> {
+        let user_id = NodeType::User.extract_ulid(&user_id)?;
+        let requester = ctx.requester();
+        if !requester.is_owner_or_admin(&UserId(user_id)) {
+            return Ok(None);
+        }
+
+        let Ok(device) = Device::try_from(device_id) else {
+            return Ok(None);
+        };
+        let state = ctx.state();
+        let mut repo = state.repository().await?;
+
+        // Lookup the user
+        let Some(user) = repo.user().lookup(user_id).await? else {
+            return Ok(None);
+        };
+
+        // First, try to find a compat session
+        let compat_session = repo.compat_session().find_by_device(&user, &device).await?;
+        if let Some(compat_session) = compat_session {
+            repo.cancel().await?;
+
+            // XXX: we should load the compat SSO login as well
+            return Ok(Some(Session::CompatSession(Box::new(CompatSession(
+                compat_session,
+                None,
+            )))));
+        }
+
+        // Then, try to find an OAuth 2.0 session. Because we don't have any dedicated
+        // device column, we're looking up using the device scope.
+        let scope = Scope::from_iter([device.to_scope_token()]);
+        let filter = OAuth2SessionFilter::new()
+            .for_user(&user)
+            .active_only()
+            .with_scope(&scope);
+        // We only want most recent session
+        let pagination = Pagination::last(1);
+        let sessions = repo.oauth2_session().list(filter, pagination).await?;
+
+        // It's technically possible to have multiple active OAuth 2.0 sessions. For
+        // now, we just log it if it is the case
+        if sessions.has_next_page {
+            // XXX: should we bail out?
+            tracing::warn!(
+                "Found more than one active session with device {device} for user {user_id}"
+            );
+        }
+
+        if let Some(session) = sessions.edges.into_iter().next() {
+            repo.cancel().await?;
+            return Ok(Some(Session::OAuth2Session(Box::new(OAuth2Session(
+                session,
+            )))));
+        }
+        repo.cancel().await?;
+
+        Ok(None)
+    }
+}

--- a/crates/graphql/src/query/session.rs
+++ b/crates/graphql/src/query/session.rs
@@ -66,10 +66,8 @@ impl SessionQuery {
         if let Some(compat_session) = compat_session {
             repo.cancel().await?;
 
-            // XXX: we should load the compat SSO login as well
-            return Ok(Some(Session::CompatSession(Box::new(CompatSession(
+            return Ok(Some(Session::CompatSession(Box::new(CompatSession::new(
                 compat_session,
-                None,
             )))));
         }
 

--- a/crates/storage-pg/.sqlx/query-1787a5e86b60f57295fe5111259a29ffb15aa31e707cb7f2ad4269d125f6d8c9.json
+++ b/crates/storage-pg/.sqlx/query-1787a5e86b60f57295fe5111259a29ffb15aa31e707cb7f2ad4269d125f6d8c9.json
@@ -1,0 +1,58 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                SELECT compat_sso_login_id\n                     , login_token\n                     , redirect_uri\n                     , created_at\n                     , fulfilled_at\n                     , exchanged_at\n                     , compat_session_id\n\n                FROM compat_sso_logins\n                WHERE compat_session_id = $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "compat_sso_login_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "login_token",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "redirect_uri",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 4,
+        "name": "fulfilled_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 5,
+        "name": "exchanged_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 6,
+        "name": "compat_session_id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true
+    ]
+  },
+  "hash": "1787a5e86b60f57295fe5111259a29ffb15aa31e707cb7f2ad4269d125f6d8c9"
+}

--- a/crates/storage-pg/.sqlx/query-89e8bb889b8e604d1b4669e904d3233e70b44277e7fe2ce4317c9d821512d86b.json
+++ b/crates/storage-pg/.sqlx/query-89e8bb889b8e604d1b4669e904d3233e70b44277e7fe2ce4317c9d821512d86b.json
@@ -1,0 +1,53 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                SELECT compat_session_id\n                     , device_id\n                     , user_id\n                     , created_at\n                     , finished_at\n                     , is_synapse_admin\n                FROM compat_sessions\n                WHERE user_id = $1\n                  AND device_id = $2\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "compat_session_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "device_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "user_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 3,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 4,
+        "name": "finished_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 5,
+        "name": "is_synapse_admin",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      true,
+      false
+    ]
+  },
+  "hash": "89e8bb889b8e604d1b4669e904d3233e70b44277e7fe2ce4317c9d821512d86b"
+}

--- a/crates/storage-pg/Cargo.toml
+++ b/crates/storage-pg/Cargo.toml
@@ -8,8 +8,8 @@ license = "Apache-2.0"
 [dependencies]
 async-trait = "0.1.73"
 sqlx = { version = "0.7.1", features = ["runtime-tokio-rustls", "postgres", "migrate", "chrono", "json", "uuid"] }
-sea-query = { version = "0.30.1", features = ["derive", "attr", "with-uuid", "with-chrono"] }
-sea-query-binder = { version = "0.5.0", features = ["sqlx-postgres", "with-uuid", "with-chrono"] }
+sea-query = { version = "0.30.1", features = ["derive", "attr", "with-uuid", "with-chrono", "postgres-array"] }
+sea-query-binder = { version = "0.5.0", features = ["sqlx-postgres", "with-uuid", "with-chrono", "postgres-array"] }
 chrono.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/storage-pg/src/compat/mod.rs
+++ b/crates/storage-pg/src/compat/mod.rs
@@ -129,6 +129,19 @@ mod tests {
         assert!(session_lookup.is_valid());
         assert!(!session_lookup.is_finished());
 
+        // Look up the session by device
+        let session_lookup = repo
+            .compat_session()
+            .find_by_device(&user, &session.device)
+            .await
+            .unwrap()
+            .expect("compat session not found");
+        assert_eq!(session_lookup.id, session.id);
+        assert_eq!(session_lookup.user_id, user.id);
+        assert_eq!(session_lookup.device.as_str(), device_str);
+        assert!(session_lookup.is_valid());
+        assert!(!session_lookup.is_finished());
+
         // Finish the session
         let session = repo.compat_session().finish(&clock, session).await.unwrap();
         assert!(!session.is_valid());

--- a/crates/storage/src/compat/session.rs
+++ b/crates/storage/src/compat/session.rs
@@ -148,6 +148,24 @@ pub trait CompatSessionRepository: Send + Sync {
     /// Returns [`Self::Error`] if the underlying repository fails
     async fn lookup(&mut self, id: Ulid) -> Result<Option<CompatSession>, Self::Error>;
 
+    /// Find a compatibility session by its device ID
+    ///
+    /// Returns the compat session if it exists, `None` otherwise
+    ///
+    /// # Parameters
+    ///
+    /// * `user`: The user to lookup the compat session for
+    /// * `device`: The device ID of the compat session to lookup
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Self::Error`] if the underlying repository fails
+    async fn find_by_device(
+        &mut self,
+        user: &User,
+        device: &Device,
+    ) -> Result<Option<CompatSession>, Self::Error>;
+
     /// Start a new compat session
     ///
     /// Returns the newly created compat session
@@ -222,6 +240,12 @@ pub trait CompatSessionRepository: Send + Sync {
 
 repository_impl!(CompatSessionRepository:
     async fn lookup(&mut self, id: Ulid) -> Result<Option<CompatSession>, Self::Error>;
+
+    async fn find_by_device(
+        &mut self,
+        user: &User,
+        device: &Device,
+    ) -> Result<Option<CompatSession>, Self::Error>;
 
     async fn add(
         &mut self,

--- a/crates/storage/src/compat/sso_login.rs
+++ b/crates/storage/src/compat/sso_login.rs
@@ -122,6 +122,22 @@ pub trait CompatSsoLoginRepository: Send + Sync {
     /// Returns [`Self::Error`] if the underlying repository fails
     async fn lookup(&mut self, id: Ulid) -> Result<Option<CompatSsoLogin>, Self::Error>;
 
+    /// Find a compat SSO login by its session
+    ///
+    /// Returns the compat SSO login if it exists, `None` otherwise
+    ///
+    /// # Parameters
+    ///
+    /// * `session`: The session of the compat SSO login to lookup
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Self::Error`] if the underlying repository fails
+    async fn find_for_session(
+        &mut self,
+        session: &CompatSession,
+    ) -> Result<Option<CompatSsoLogin>, Self::Error>;
+
     /// Find a compat SSO login by its login token
     ///
     /// Returns the compat SSO login if found, `None` otherwise
@@ -231,6 +247,11 @@ pub trait CompatSsoLoginRepository: Send + Sync {
 
 repository_impl!(CompatSsoLoginRepository:
     async fn lookup(&mut self, id: Ulid) -> Result<Option<CompatSsoLogin>, Self::Error>;
+
+    async fn find_for_session(
+        &mut self,
+        session: &CompatSession,
+    ) -> Result<Option<CompatSsoLogin>, Self::Error>;
 
     async fn find_by_token(
         &mut self,

--- a/crates/storage/src/oauth2/session.rs
+++ b/crates/storage/src/oauth2/session.rs
@@ -42,6 +42,7 @@ pub struct OAuth2SessionFilter<'a> {
     user: Option<&'a User>,
     client: Option<&'a Client>,
     state: Option<OAuth2SessionState>,
+    scope: Option<&'a Scope>,
 }
 
 impl<'a> OAuth2SessionFilter<'a> {
@@ -101,6 +102,21 @@ impl<'a> OAuth2SessionFilter<'a> {
     #[must_use]
     pub fn state(&self) -> Option<OAuth2SessionState> {
         self.state
+    }
+
+    /// Only return sessions with the given scope
+    #[must_use]
+    pub fn with_scope(mut self, scope: &'a Scope) -> Self {
+        self.scope = Some(scope);
+        self
+    }
+
+    /// Get the scope filter
+    ///
+    /// Returns [`None`] if no scope filter was set
+    #[must_use]
+    pub fn scope(&self) -> Option<&Scope> {
+        self.scope
     }
 }
 

--- a/frontend/schema.graphql
+++ b/frontend/schema.graphql
@@ -702,6 +702,10 @@ type Query {
     last: Int
   ): UpstreamOAuth2ProviderConnection!
   """
+  Lookup a compat or OAuth 2.0 session
+  """
+  session(userId: ID!, deviceId: String!): Session
+  """
   Get the viewer
   """
   viewer: Viewer!
@@ -798,6 +802,11 @@ enum SendVerificationEmailStatus {
   """
   ALREADY_VERIFIED
 }
+
+"""
+A client session, either compat or OAuth 2.0
+"""
+union Session = CompatSession | Oauth2Session
 
 """
 The input for the `addEmail` mutation

--- a/frontend/src/gql/graphql.ts
+++ b/frontend/src/gql/graphql.ts
@@ -505,6 +505,8 @@ export type Query = {
   node?: Maybe<Node>;
   /** Fetch an OAuth 2.0 client by its ID. */
   oauth2Client?: Maybe<Oauth2Client>;
+  /** Lookup a compat or OAuth 2.0 session */
+  session?: Maybe<Session>;
   /** Fetch an upstream OAuth 2.0 link by its ID. */
   upstreamOauth2Link?: Maybe<UpstreamOAuth2Link>;
   /** Fetch an upstream OAuth 2.0 provider by its ID. */
@@ -534,6 +536,12 @@ export type QueryNodeArgs = {
 /** The query root of the GraphQL interface. */
 export type QueryOauth2ClientArgs = {
   id: Scalars["ID"]["input"];
+};
+
+/** The query root of the GraphQL interface. */
+export type QuerySessionArgs = {
+  deviceId: Scalars["String"]["input"];
+  userId: Scalars["ID"]["input"];
 };
 
 /** The query root of the GraphQL interface. */
@@ -615,6 +623,9 @@ export enum SendVerificationEmailStatus {
   /** The verification email was sent */
   Sent = "SENT",
 }
+
+/** A client session, either compat or OAuth 2.0 */
+export type Session = CompatSession | Oauth2Session;
 
 /** The input for the `addEmail` mutation */
 export type SetDisplayNameInput = {

--- a/frontend/src/gql/schema.ts
+++ b/frontend/src/gql/schema.ts
@@ -1505,6 +1505,36 @@ export default {
             ],
           },
           {
+            name: "session",
+            type: {
+              kind: "UNION",
+              name: "Session",
+              ofType: null,
+            },
+            args: [
+              {
+                name: "deviceId",
+                type: {
+                  kind: "NON_NULL",
+                  ofType: {
+                    kind: "SCALAR",
+                    name: "Any",
+                  },
+                },
+              },
+              {
+                name: "userId",
+                type: {
+                  kind: "NON_NULL",
+                  ofType: {
+                    kind: "SCALAR",
+                    name: "Any",
+                  },
+                },
+              },
+            ],
+          },
+          {
             name: "upstreamOauth2Link",
             type: {
               kind: "OBJECT",
@@ -1729,6 +1759,20 @@ export default {
           },
         ],
         interfaces: [],
+      },
+      {
+        kind: "UNION",
+        name: "Session",
+        possibleTypes: [
+          {
+            kind: "OBJECT",
+            name: "CompatSession",
+          },
+          {
+            kind: "OBJECT",
+            name: "Oauth2Session",
+          },
+        ],
       },
       {
         kind: "OBJECT",


### PR DESCRIPTION
Fixes https://github.com/matrix-org/matrix-authentication-service/issues/1640

This adds a `session(userId, deviceId)` API which lets find a compat/oauth session by its device ID.
A few caveats:

 - we're looking for comapt sessions first, then oauth sessions
 - for OAuth sessions, we're only looking for active sessions
 - because multiple OAuth sessions might be active for the same device (it should not happen in the real world, but it's possible), we're returning the oldest one. We're logging a warning if multiple active sessions are found for the same device.

Example query:

```graphql
{
  session(userId: "user:01H909Q0ZY8VJXSMBE2SQ6CB4E", deviceId: "bLGaVKdrnP") {
    __typename
    
    ... on Oauth2Session {
      client {
        id
        clientName
      }
    }
    
    ... on CompatSession {
      deviceId
      ssoLogin {redirectUri}
    }
  }
}
```


cc @kerryarchibald 