### PR TITLE
Simplify the URL displayed on compatibility SSO logins

### DIFF
--- a/templates/pages/sso.html
+++ b/templates/pages/sso.html
@@ -22,7 +22,7 @@ limitations under the License.
       <form method="POST" class="grid grid-cols-1 gap-6">
         <div class="rounded-lg bg-grey-25 dark:bg-grey-450 p-2 flex flex-col">
           <div class="text-center">
-            <h1 class="text-lg text-center font-medium">{{ login.redirect_uri }}</h1>
+            <h1 class="text-lg text-center font-medium">{{ login.redirect_uri | simplify_url }}</h1>
             <h1>wants to access your Matrix account</h1>
           </div>
         </div>


### PR DESCRIPTION
See #1638

**This only simplifies the URL, doesn't do the other things mentioned in the issue**

Logic is:

 - for `https://` URLs, just show the domain
 - for other handlers (including `http://`), redact the fragment (`#...`) and the query  (`?...`)

It's the same logic as [what Synapse does](https://github.com/matrix-org/synapse/blob/d0c4257f14addbf0c9072c2e34ae1c8294716ed5/synapse/handlers/auth.py#L1799-L1811).

For a web client:
![image](https://github.com/matrix-org/matrix-authentication-service/assets/1549952/0658d1cf-7c53-4277-8578-35f36455aeaa)

For a native client:

![image](https://github.com/matrix-org/matrix-authentication-service/assets/1549952/da27d203-a69f-4ac4-832b-97b0fba722ea)
