### PR TITLE
Session detail page

### DIFF
--- a/frontend/src/Router.test.tsx
+++ b/frontend/src/Router.test.tsx
@@ -28,8 +28,8 @@ describe("Router", () => {
       expect(segmentsToRoute(segments)).toEqual({ type: "profile" });
     });
 
-    it("returns browser session list for sessions", () => {
-      const segments: string[] = ["sessions"];
+    it("returns browser session list for browser-sessions", () => {
+      const segments: string[] = ["browser-sessions"];
       expect(segmentsToRoute(segments)).toEqual({
         type: "browser-session-list",
       });
@@ -57,10 +57,10 @@ describe("Router", () => {
       });
     });
 
-    it("returns session detail route correctly", () => {
-      const segments: string[] = ["sessions", "session-id"];
+    it("returns browser session detail route correctly", () => {
+      const segments: string[] = ["browser-sessions", "session-id"];
       expect(segmentsToRoute(segments)).toEqual({
-        type: "session",
+        type: "browser-session",
         id: "session-id",
       });
     });

--- a/frontend/src/Router.test.tsx
+++ b/frontend/src/Router.test.tsx
@@ -65,6 +65,14 @@ describe("Router", () => {
       });
     });
 
+    it("returns session detail route correctly", () => {
+      const segments: string[] = ["session", "device-id"];
+      expect(segmentsToRoute(segments)).toEqual({
+        type: "session",
+        id: "device-id",
+      });
+    });
+
     it("returns unknown for other segments", () => {
       const segments: string[] = ["just", "testing"];
       expect(segmentsToRoute(segments)).toEqual({ type: "unknown", segments });

--- a/frontend/src/Router.tsx
+++ b/frontend/src/Router.tsx
@@ -29,7 +29,7 @@ type ProfileRoute = { type: "profile" };
 type SessionOverviewRoute = { type: "sessions-overview" };
 type OAuth2ClientRoute = { type: "client"; id: string };
 type OAuth2SessionList = { type: "oauth2-session-list" };
-type BrowserSessionRoute = { type: "session"; id: string };
+type BrowserSessionRoute = { type: "browser-session"; id: string };
 type BrowserSessionListRoute = { type: "browser-session-list" };
 type CompatSessionListRoute = { type: "compat-session-list" };
 type VerifyEmailRoute = { type: "verify-email"; id: string };
@@ -57,9 +57,9 @@ const routeToSegments = (route: Route): string[] => {
     case "client":
       return ["clients", route.id];
     case "browser-session-list":
-      return ["sessions"];
-    case "session":
-      return ["sessions", route.id];
+      return ["browser-sessions"];
+    case "browser-session":
+      return ["browser-sessions", route.id];
     case "oauth2-session-list":
       return ["oauth2-sessions"];
     case "compat-session-list":
@@ -104,7 +104,7 @@ export const segmentsToRoute = (segments: string[]): Route => {
     return { type: "sessions-overview" };
   }
 
-  if (matches("sessions")) {
+  if (matches("browser-sessions")) {
     return { type: "browser-session-list" };
   }
 
@@ -124,8 +124,8 @@ export const segmentsToRoute = (segments: string[]): Route => {
     return { type: "client", id: segments[1] };
   }
 
-  if (matches("sessions", P)) {
-    return { type: "session", id: segments[1] };
+  if (matches("browser-sessions", P)) {
+    return { type: "browser-session", id: segments[1] };
   }
 
   return { type: "unknown", segments };
@@ -194,7 +194,7 @@ const InnerRouter: React.FC = () => {
       return <CompatSessionList />;
     case "client":
       return <OAuth2Client id={route.id} />;
-    case "session":
+    case "browser-session":
       return <BrowserSession id={route.id} />;
     case "verify-email":
       return <VerifyEmail id={route.id} />;

--- a/frontend/src/Router.tsx
+++ b/frontend/src/Router.tsx
@@ -27,6 +27,7 @@ type Location = {
 
 type ProfileRoute = { type: "profile" };
 type SessionOverviewRoute = { type: "sessions-overview" };
+type SessionDetailRoute = { type: "session"; id: string };
 type OAuth2ClientRoute = { type: "client"; id: string };
 type OAuth2SessionList = { type: "oauth2-session-list" };
 type BrowserSessionRoute = { type: "browser-session"; id: string };
@@ -37,6 +38,7 @@ type UnknownRoute = { type: "unknown"; segments: string[] };
 
 export type Route =
   | SessionOverviewRoute
+  | SessionDetailRoute
   | ProfileRoute
   | OAuth2ClientRoute
   | OAuth2SessionList
@@ -52,6 +54,8 @@ const routeToSegments = (route: Route): string[] => {
       return [];
     case "sessions-overview":
       return ["sessions-overview"];
+    case "session":
+      return ["session", route.id];
     case "verify-email":
       return ["emails", route.id, "verify"];
     case "client":
@@ -128,6 +132,10 @@ export const segmentsToRoute = (segments: string[]): Route => {
     return { type: "browser-session", id: segments[1] };
   }
 
+  if (matches("session", P)) {
+    return { type: "session", id: segments[1] };
+  }
+
   return { type: "unknown", segments };
 };
 
@@ -170,6 +178,7 @@ export const routeAtom = atom(
 );
 
 const SessionsOverview = lazy(() => import("./pages/SessionsOverview"));
+const SessionDetail = lazy(() => import("./pages/SessionDetail"));
 const Profile = lazy(() => import("./pages/Profile"));
 const OAuth2Client = lazy(() => import("./pages/OAuth2Client"));
 const BrowserSession = lazy(() => import("./pages/BrowserSession"));
@@ -186,6 +195,8 @@ const InnerRouter: React.FC = () => {
       return <Profile />;
     case "sessions-overview":
       return <SessionsOverview />;
+    case "session":
+      return <SessionDetail deviceId={route.id} />;
     case "oauth2-session-list":
       return <OAuth2SessionList />;
     case "browser-session-list":

--- a/frontend/src/components/SessionDetail/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail/SessionDetail.tsx
@@ -16,7 +16,7 @@ import { Alert } from "@vector-im/compound-web";
 import { useAtomValue } from "jotai";
 import { atomFamily } from "jotai/utils";
 import { atomWithQuery } from "jotai-urql";
-import { useRef } from "react";
+import { useMemo } from "react";
 
 import { Link } from "../../Router";
 import { graphql } from "../../gql/gql";
@@ -48,8 +48,11 @@ const SessionDetail: React.FC<{
   deviceId: string;
   userId: string;
 }> = ({ deviceId, userId }) => {
-  const props = useRef({ userId, deviceId });
-  const result = useAtomValue(sessionFamily(props.current));
+  const sessionFamilyAtomWithProps = useMemo(
+    () => sessionFamily({ deviceId, userId }),
+    [deviceId, userId],
+  );
+  const result = useAtomValue(sessionFamilyAtomWithProps);
 
   const session = result.data?.session;
 

--- a/frontend/src/components/SessionDetail/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail/SessionDetail.tsx
@@ -1,0 +1,27 @@
+// Copyright 2022 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const SessionDetail: React.FC<{
+  deviceId: string;
+  userId: string;
+}> = ({ deviceId, userId }) => {
+  return (
+    <>
+      <code>deviceId: {deviceId}</code>
+      <code>userId: {userId}</code>
+    </>
+  );
+};
+
+export default SessionDetail;

--- a/frontend/src/components/SessionDetail/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail/SessionDetail.tsx
@@ -1,4 +1,4 @@
-// Copyright 2022 The Matrix.org Foundation C.I.C.
+// Copyright 2023 The Matrix.org Foundation C.I.C.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Alert, Body } from "@vector-im/compound-web";
+import { Alert } from "@vector-im/compound-web";
 import { useAtomValue } from "jotai";
 import { atomFamily } from "jotai/utils";
 import { atomWithQuery } from "jotai-urql";
@@ -54,10 +54,9 @@ const SessionDetail: React.FC<{
   const session = result.data?.session;
 
   if (!session) {
-    // TODO put a back button here
     return (
-      <Alert type="critical" title="Error">
-        <Body>Cannot find session: {deviceId}</Body>
+      <Alert type="critical" title={`Cannot find session: ${deviceId}`}>
+        This session does not exist, or is no longer active.
         <Link kind="button" route={{ type: "sessions-overview" }}>
           Go back
         </Link>
@@ -69,15 +68,9 @@ const SessionDetail: React.FC<{
 
   if (sessionType === "Oauth2Session") {
     return <OAuth2Session session={session} />;
-  } else if (sessionType === "CompatSession") {
+  } else {
     return <CompatSession session={session} />;
   }
-
-  return (
-    <Alert title="Error" type="critical">
-      Unexpected session type
-    </Alert>
-  );
 };
 
 export default SessionDetail;

--- a/frontend/src/components/SessionDetail/index.ts
+++ b/frontend/src/components/SessionDetail/index.ts
@@ -1,0 +1,15 @@
+// Copyright 2023 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export { default } from "./SessionDetail";

--- a/frontend/src/components/UserSessionsOverview/__snapshots__/UserSessionsOverview.test.tsx.snap
+++ b/frontend/src/components/UserSessionsOverview/__snapshots__/UserSessionsOverview.test.tsx.snap
@@ -31,7 +31,7 @@ exports[`UserSessionsOverview > render a <UserSessionsOverview /> with sessions 
     </div>
     <a
       className="_linkButton_4f14fc"
-      href="/sessions"
+      href="/browser-sessions"
       onClick={[Function]}
     >
       View all
@@ -127,7 +127,7 @@ exports[`UserSessionsOverview > render an simple <UserSessionsOverview /> 1`] = 
     </div>
     <a
       className="_linkButton_4f14fc"
-      href="/sessions"
+      href="/browser-sessions"
       onClick={[Function]}
     >
       View all

--- a/frontend/src/gql/gql.ts
+++ b/frontend/src/gql/gql.ts
@@ -37,6 +37,8 @@ const documents = {
     types.EndOAuth2SessionDocument,
   "\n  query OAuth2SessionListQuery(\n    $userId: ID!\n    $state: Oauth2SessionState\n    $first: Int\n    $after: String\n    $last: Int\n    $before: String\n  ) {\n    user(id: $userId) {\n      id\n      oauth2Sessions(\n        state: $state\n        first: $first\n        after: $after\n        last: $last\n        before: $before\n      ) {\n        edges {\n          cursor\n          node {\n            id\n            ...OAuth2Session_session\n          }\n        }\n\n        totalCount\n        pageInfo {\n          hasNextPage\n          hasPreviousPage\n          startCursor\n          endCursor\n        }\n      }\n    }\n  }\n":
     types.OAuth2SessionListQueryDocument,
+  "\n  query SessionQuery($userId: ID!, $deviceId: String!) {\n    session(userId: $userId, deviceId: $deviceId) {\n      __typename\n      ...CompatSession_session\n      ...OAuth2Session_session\n    }\n  }\n":
+    types.SessionQueryDocument,
   "\n  fragment UnverifiedEmailAlert on User {\n    id\n    unverifiedEmails: emails(first: 0, state: PENDING) {\n      totalCount\n    }\n  }\n":
     types.UnverifiedEmailAlertFragmentDoc,
   "\n  fragment UserEmail_email on UserEmail {\n    id\n    email\n    confirmedAt\n  }\n":
@@ -159,6 +161,12 @@ export function graphql(
 export function graphql(
   source: "\n  query OAuth2SessionListQuery(\n    $userId: ID!\n    $state: Oauth2SessionState\n    $first: Int\n    $after: String\n    $last: Int\n    $before: String\n  ) {\n    user(id: $userId) {\n      id\n      oauth2Sessions(\n        state: $state\n        first: $first\n        after: $after\n        last: $last\n        before: $before\n      ) {\n        edges {\n          cursor\n          node {\n            id\n            ...OAuth2Session_session\n          }\n        }\n\n        totalCount\n        pageInfo {\n          hasNextPage\n          hasPreviousPage\n          startCursor\n          endCursor\n        }\n      }\n    }\n  }\n",
 ): (typeof documents)["\n  query OAuth2SessionListQuery(\n    $userId: ID!\n    $state: Oauth2SessionState\n    $first: Int\n    $after: String\n    $last: Int\n    $before: String\n  ) {\n    user(id: $userId) {\n      id\n      oauth2Sessions(\n        state: $state\n        first: $first\n        after: $after\n        last: $last\n        before: $before\n      ) {\n        edges {\n          cursor\n          node {\n            id\n            ...OAuth2Session_session\n          }\n        }\n\n        totalCount\n        pageInfo {\n          hasNextPage\n          hasPreviousPage\n          startCursor\n          endCursor\n        }\n      }\n    }\n  }\n"];
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(
+  source: "\n  query SessionQuery($userId: ID!, $deviceId: String!) {\n    session(userId: $userId, deviceId: $deviceId) {\n      __typename\n      ...CompatSession_session\n      ...OAuth2Session_session\n    }\n  }\n",
+): (typeof documents)["\n  query SessionQuery($userId: ID!, $deviceId: String!) {\n    session(userId: $userId, deviceId: $deviceId) {\n      __typename\n      ...CompatSession_session\n      ...OAuth2Session_session\n    }\n  }\n"];
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */

--- a/frontend/src/gql/graphql.ts
+++ b/frontend/src/gql/graphql.ts
@@ -1146,6 +1146,27 @@ export type OAuth2SessionListQueryQuery = {
   } | null;
 };
 
+export type SessionQueryQueryVariables = Exact<{
+  userId: Scalars["ID"]["input"];
+  deviceId: Scalars["String"]["input"];
+}>;
+
+export type SessionQueryQuery = {
+  __typename?: "Query";
+  session?:
+    | ({ __typename: "CompatSession" } & {
+        " $fragmentRefs"?: {
+          CompatSession_SessionFragment: CompatSession_SessionFragment;
+        };
+      })
+    | ({ __typename: "Oauth2Session" } & {
+        " $fragmentRefs"?: {
+          OAuth2Session_SessionFragment: OAuth2Session_SessionFragment;
+        };
+      })
+    | null;
+};
+
 export type UnverifiedEmailAlertFragment = {
   __typename?: "User";
   id: string;
@@ -2891,6 +2912,160 @@ export const OAuth2SessionListQueryDocument = {
   OAuth2SessionListQueryQuery,
   OAuth2SessionListQueryQueryVariables
 >;
+export const SessionQueryDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "query",
+      name: { kind: "Name", value: "SessionQuery" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: {
+            kind: "Variable",
+            name: { kind: "Name", value: "userId" },
+          },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+          },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: {
+            kind: "Variable",
+            name: { kind: "Name", value: "deviceId" },
+          },
+          type: {
+            kind: "NonNullType",
+            type: {
+              kind: "NamedType",
+              name: { kind: "Name", value: "String" },
+            },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "session" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "userId" },
+                value: {
+                  kind: "Variable",
+                  name: { kind: "Name", value: "userId" },
+                },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "deviceId" },
+                value: {
+                  kind: "Variable",
+                  name: { kind: "Name", value: "deviceId" },
+                },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                { kind: "Field", name: { kind: "Name", value: "__typename" } },
+                {
+                  kind: "FragmentSpread",
+                  name: { kind: "Name", value: "CompatSession_session" },
+                },
+                {
+                  kind: "FragmentSpread",
+                  name: { kind: "Name", value: "OAuth2Session_session" },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "CompatSession_sso_login" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "CompatSsoLogin" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "id" } },
+          { kind: "Field", name: { kind: "Name", value: "redirectUri" } },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "CompatSession_session" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "CompatSession" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "id" } },
+          { kind: "Field", name: { kind: "Name", value: "createdAt" } },
+          { kind: "Field", name: { kind: "Name", value: "deviceId" } },
+          { kind: "Field", name: { kind: "Name", value: "finishedAt" } },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "ssoLogin" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                { kind: "Field", name: { kind: "Name", value: "id" } },
+                {
+                  kind: "FragmentSpread",
+                  name: { kind: "Name", value: "CompatSession_sso_login" },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "OAuth2Session_session" },
+      typeCondition: {
+        kind: "NamedType",
+        name: { kind: "Name", value: "Oauth2Session" },
+      },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "id" } },
+          { kind: "Field", name: { kind: "Name", value: "scope" } },
+          { kind: "Field", name: { kind: "Name", value: "createdAt" } },
+          { kind: "Field", name: { kind: "Name", value: "finishedAt" } },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "client" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                { kind: "Field", name: { kind: "Name", value: "id" } },
+                { kind: "Field", name: { kind: "Name", value: "clientId" } },
+                { kind: "Field", name: { kind: "Name", value: "clientName" } },
+                { kind: "Field", name: { kind: "Name", value: "clientUri" } },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<SessionQueryQuery, SessionQueryQueryVariables>;
 export const RemoveEmailDocument = {
   kind: "Document",
   definitions: [

--- a/frontend/src/pages/SessionDetail.tsx
+++ b/frontend/src/pages/SessionDetail.tsx
@@ -1,0 +1,23 @@
+// Copyright 2023 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const SessionDetail: React.FC<{ deviceId: string }> = ({ deviceId }) => {
+  return (
+    <pre>
+      <code>Session: {deviceId}</code>
+    </pre>
+  );
+};
+
+export default SessionDetail;

--- a/frontend/src/pages/SessionDetail.tsx
+++ b/frontend/src/pages/SessionDetail.tsx
@@ -12,12 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { useAtomValue } from "jotai";
+
+import { currentUserIdAtom } from "../atoms";
+import GraphQLError from "../components/GraphQLError";
+import NotLoggedIn from "../components/NotLoggedIn";
+import UserSessionDetail from "../components/SessionDetail";
+import { isErr, unwrapErr, unwrapOk } from "../result";
+
 const SessionDetail: React.FC<{ deviceId: string }> = ({ deviceId }) => {
-  return (
-    <pre>
-      <code>Session: {deviceId}</code>
-    </pre>
-  );
+  const result = useAtomValue(currentUserIdAtom);
+  if (isErr(result)) return <GraphQLError error={unwrapErr(result)} />;
+
+  const userId = unwrapOk(result);
+  if (userId === null) return <NotLoggedIn />;
+
+  return <UserSessionDetail userId={userId} deviceId={deviceId} />;
 };
 
 export default SessionDetail;


### PR DESCRIPTION
For https://github.com/matrix-org/matrix-authentication-service/issues/1550

<img width="454" alt="Screenshot 2023-08-31 at 16 12 13" src="https://github.com/matrix-org/matrix-authentication-service/assets/3055605/76e167f5-b2da-434b-b28e-d384a13e9252">
<img width="475" alt="Screenshot 2023-08-31 at 16 27 21" src="https://github.com/matrix-org/matrix-authentication-service/assets/3055605/be6216b4-bc9d-41c3-a36f-24fe9670e212">

- Renames browser session route from `/sessions` -> `browser-sessions`, `/session` -> `browser-session`
- Add session detail route `/session/<deviceId>`
- Get session and display using session tile

In next PRs:
- linking from session lists to detail
- handling route params to redirect to detail
- ? more detail on detail page