### PR TITLE
Make the email verification state more configurable on upstream OAuth 2.0 registration

### DIFF
--- a/crates/config/src/sections/mod.rs
+++ b/crates/config/src/sections/mod.rs
@@ -49,8 +49,11 @@ pub use self::{
     },
     templates::TemplatesConfig,
     upstream_oauth2::{
-        ClaimsImports as UpstreamOAuth2ClaimsImports, ImportAction as UpstreamOAuth2ImportAction,
-        ImportPreference as UpstreamOAuth2ImportPreference, UpstreamOAuth2Config,
+        ClaimsImports as UpstreamOAuth2ClaimsImports,
+        EmailImportPreference as UpstreamOAuth2EmailImportPreference,
+        ImportAction as UpstreamOAuth2ImportAction,
+        ImportPreference as UpstreamOAuth2ImportPreference,
+        SetEmailVerification as UpstreamOAuth2SetEmailVerification, UpstreamOAuth2Config,
     },
 };
 use crate::util::ConfigurationSection;

--- a/crates/config/src/sections/upstream_oauth2.rs
+++ b/crates/config/src/sections/upstream_oauth2.rs
@@ -104,6 +104,34 @@ pub struct ImportPreference {
     pub action: ImportAction,
 }
 
+/// Should the email address be marked as verified
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum SetEmailVerification {
+    /// Mark the email address as verified
+    Always,
+
+    /// Don't mark the email address as verified
+    Never,
+
+    /// Mark the email address as verified if the upstream provider says it is
+    /// through the `email_verified` claim
+    #[default]
+    Import,
+}
+
+/// What should be done with the email claim
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default, JsonSchema)]
+pub struct EmailImportPreference {
+    /// How to handle the claim
+    #[serde(default)]
+    pub action: ImportAction,
+
+    /// Should the email address be marked as verified
+    #[serde(default)]
+    pub set_email_verification: SetEmailVerification,
+}
+
 /// How claims should be imported
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default, JsonSchema)]
 pub struct ClaimsImports {
@@ -118,7 +146,7 @@ pub struct ClaimsImports {
     /// Import the email address of the user based on the `email` and
     /// `email_verified` claims
     #[serde(default)]
-    pub email: Option<ImportPreference>,
+    pub email: Option<EmailImportPreference>,
 }
 
 #[skip_serializing_none]

--- a/crates/data-model/src/lib.rs
+++ b/crates/data-model/src/lib.rs
@@ -46,9 +46,10 @@ pub use self::{
         AccessToken, AccessTokenState, RefreshToken, RefreshTokenState, TokenFormatError, TokenType,
     },
     upstream_oauth2::{
-        UpstreamOAuthAuthorizationSession, UpstreamOAuthAuthorizationSessionState,
-        UpstreamOAuthLink, UpstreamOAuthProvider, UpstreamOAuthProviderClaimsImports,
-        UpstreamOAuthProviderImportAction, UpstreamOAuthProviderImportPreference,
+        UpsreamOAuthProviderSetEmailVerification, UpstreamOAuthAuthorizationSession,
+        UpstreamOAuthAuthorizationSessionState, UpstreamOAuthLink, UpstreamOAuthProvider,
+        UpstreamOAuthProviderClaimsImports, UpstreamOAuthProviderImportAction,
+        UpstreamOAuthProviderImportPreference,
     },
     users::{
         Authentication, AuthenticationMethod, BrowserSession, Password, User, UserEmail,

--- a/crates/data-model/src/upstream_oauth2/mod.rs
+++ b/crates/data-model/src/upstream_oauth2/mod.rs
@@ -21,7 +21,8 @@ pub use self::{
     provider::{
         ClaimsImports as UpstreamOAuthProviderClaimsImports,
         ImportAction as UpstreamOAuthProviderImportAction,
-        ImportPreference as UpstreamOAuthProviderImportPreference, UpstreamOAuthProvider,
+        ImportPreference as UpstreamOAuthProviderImportPreference,
+        SetEmailVerification as UpsreamOAuthProviderSetEmailVerification, UpstreamOAuthProvider,
     },
     session::{UpstreamOAuthAuthorizationSession, UpstreamOAuthAuthorizationSessionState},
 };

--- a/crates/data-model/src/upstream_oauth2/provider.rs
+++ b/crates/data-model/src/upstream_oauth2/provider.rs
@@ -31,6 +31,32 @@ pub struct UpstreamOAuthProvider {
     pub claims_imports: ClaimsImports,
 }
 
+/// Whether to set the email as verified when importing it from the upstream
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum SetEmailVerification {
+    /// Set the email as verified
+    Always,
+
+    /// Never set the email as verified
+    Never,
+
+    /// Set the email as verified if the upstream provider claims it is verified
+    #[default]
+    Import,
+}
+
+impl SetEmailVerification {
+    #[must_use]
+    pub fn should_mark_as_verified(&self, upstream_verified: bool) -> bool {
+        match self {
+            Self::Always => true,
+            Self::Never => false,
+            Self::Import => upstream_verified,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct ClaimsImports {
     #[serde(default)]
@@ -41,6 +67,9 @@ pub struct ClaimsImports {
 
     #[serde(default)]
     pub email: ImportPreference,
+
+    #[serde(default)]
+    pub verify_email: SetEmailVerification,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]

--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -307,7 +307,7 @@
           "default": null,
           "allOf": [
             {
-              "$ref": "#/definitions/ImportPreference"
+              "$ref": "#/definitions/EmailImportPreference"
             }
           ]
         },
@@ -684,6 +684,30 @@
           "default": "\"Authentication Service\" <root@localhost>",
           "type": "string",
           "format": "email"
+        }
+      }
+    },
+    "EmailImportPreference": {
+      "description": "What should be done with the email claim",
+      "type": "object",
+      "properties": {
+        "action": {
+          "description": "How to handle the claim",
+          "default": "ignore",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ImportAction"
+            }
+          ]
+        },
+        "set_email_verification": {
+          "description": "Should the email address be marked as verified",
+          "default": "import",
+          "allOf": [
+            {
+              "$ref": "#/definitions/SetEmailVerification"
+            }
+          ]
         }
       }
     },
@@ -1751,6 +1775,32 @@
           "format": "uri"
         }
       }
+    },
+    "SetEmailVerification": {
+      "description": "Should the email address be marked as verified",
+      "oneOf": [
+        {
+          "description": "Mark the email address as verified",
+          "type": "string",
+          "enum": [
+            "always"
+          ]
+        },
+        {
+          "description": "Don't mark the email address as verified",
+          "type": "string",
+          "enum": [
+            "never"
+          ]
+        },
+        {
+          "description": "Mark the email address as verified if the upstream provider says it is through the `email_verified` claim",
+          "type": "string",
+          "enum": [
+            "import"
+          ]
+        }
+      ]
     },
     "TelemetryConfig": {
       "description": "Configuration related to sending monitoring data",


### PR DESCRIPTION
This also marks the email as primary
