### PR TITLE
Standardise consent screens

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -20,6 +20,7 @@ limitations under the License.
 {% import "components/logout.html" as logout %}
 {% import "components/navbar.html" as navbar %}
 {% import "components/errors.html" as errors %}
+{% import "components/scope.html" as scope %}
 
 <!DOCTYPE html>
 <html>

--- a/templates/components/scope.html
+++ b/templates/components/scope.html
@@ -1,0 +1,39 @@
+{#
+Copyright 2023 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+#}
+
+{% macro list(scopes) %}
+  <ul class="list-disc">
+    {% for scope in scopes | split(pat=" ") %}
+      {% if scope == "openid" %}
+        <li>See your profile info and contact details</li>
+      {% elif scope == "urn:mas:graphql:*" %}
+        <li>Edit your profile and contact details</li>
+        <li>Manage your devices and sessions</li>
+      {% elif scope == "urn:matrix:org.matrix.msc2967.client:api:*" %}
+        <li>View your existing messages and data</li>
+        <li>Send new messages on your behalf</li>
+      {% elif scope == "urn:synapse:admin:*" %}
+        <li>Administer the Synapse homeserver</li>
+      {% elif scope == "urn:mas:graphql:admin" %}
+        <li>Administer any user on the MAS authentication server</li>
+      {% elif scope is matching("^urn:matrix:org.matrix.msc2967.client:device:") %}
+        {# <li>{{ scope }}</li> #}
+      {% else %}
+        <li>{{ scope }}</li>
+      {% endif %}
+    {% endfor %}
+  </ul>
+{% endmacro %}

--- a/templates/pages/consent.html
+++ b/templates/pages/consent.html
@@ -27,38 +27,18 @@ limitations under the License.
               <img class="w-16 h-16" src="{{ client.logo_uri }}" />
               {% endif %}
             </div>
-            <h1 class="text-lg text-center font-medium"><a target="_blank" href="{{ client.client_uri }}" class="text-accent">{{ client.client_name | default(value=client.client_id) }}</a></h1>
-            <h1>at {{ grant.redirect_uri }}</h1>
-            <h1>wants to access your Matrix account</h1>
+            <h1 class="text-center font-medium"><a target="_blank" href="{{ client.client_uri }}" class="text-accent">{{ client.client_name | default(value=client.client_id) }}</a></h1>
+            <h1>at {{ grant.redirect_uri | simplify_url }}</h1>
+            <h1>wants to access your account</h1>
           </div>
           <div class="flex items-center m-2">
             <div class="px-4 flex-1">
               <p>This will allow <a target="_blank" href="{{ client.client_uri }}" class="text-accent">{{ client.client_name | default(value=client.client_id) }}</a> to:</p>
 
               <p class="my-2">
-                <ul class="list-disc">
-                  {% for scope in grant.scope | split(pat=" ") %}
-                    {% if scope == "openid" %}
-                      <li>See your profile info and contact details</li>
-                    {% elif scope == "urn:mas:graphql:*" %}
-                      <li>Edit your profile and contact details</li>
-                      <li>Manage your devices and sessions</li>
-                    {% elif scope == "urn:matrix:org.matrix.msc2967.client:api:*" %}
-                      <li>View your existing messages and data</li>
-                      <li>Send new messages on your behalf</li>
-                    {% elif scope == "urn:synapse:admin:*" %}
-                      <li>Administer the Synapse homeserver</li>
-                    {% elif scope == "urn:mas:graphql:admin" %}
-                      <li>Administer any user on the MAS authentication server</li>
-                    {% elif scope is matching("^urn:matrix:org.matrix.msc2967.client:device:") %}
-                      {# <li>{{ scope }}</li> #}
-                    {% else %}
-                      <li>{{ scope }}</li>
-                    {% endif %}
-                  {% endfor %}
-                </ul>  
+                {{ scope::list(scopes=grant.scope) }}
               </p>
-              <p class="font-bold my-2">Make sure that you trust {{ client.client_name }}</p>
+              <p class="font-bold my-2">Make sure that you trust {{ client.client_name | default(value=client.client_id) }}.</p>
               <p>
                 You may be sharing sensitive information with this site or app.
                 {% if client.policy_uri or client.tos_uri %}

--- a/templates/pages/sso.html
+++ b/templates/pages/sso.html
@@ -23,7 +23,18 @@ limitations under the License.
         <div class="rounded-lg bg-grey-25 dark:bg-grey-450 p-2 flex flex-col">
           <div class="text-center">
             <h1 class="text-lg text-center font-medium">{{ login.redirect_uri | simplify_url }}</h1>
-            <h1>wants to access your Matrix account</h1>
+            <h1>wants to access your account</h1>
+          </div>
+          <div class="flex items-center m-2">
+            <div class="px-4 flex-1">
+              <p>This will allow it to:</p>
+
+              <p class="my-2">
+                {{ scope::list(scopes="openid urn:matrix:org.matrix.msc2967.client:api:*") }}
+              </p>
+
+              <p class="font-bold my-2">Make sure that you trust it.</p>
+            </div>
           </div>
         </div>
 


### PR DESCRIPTION
Fixes #1638

I made the consent descriptions reusable

<img width="432" alt="image" src="https://github.com/matrix-org/matrix-authentication-service/assets/6955675/786770d7-66b4-4dec-ac0b-ed4f871ea686">
<img width="447" alt="image" src="https://github.com/matrix-org/matrix-authentication-service/assets/6955675/868f0605-5794-4fad-9fc5-3912f08d25ab">
