### PR TITLE
Release workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -197,6 +197,9 @@ jobs:
     name: Release
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
+    needs:
+      - build-linux
+      - build-macos
     steps:
       - name: Download the artifacts from the previous job
         uses: actions/download-artifact@v3

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,6 +3,8 @@ name: Build
 on:
   push:
     branches: [ main ]
+    tags:
+      - 'v*'
   pull_request:
     branches: [ main ]
 
@@ -190,3 +192,27 @@ jobs:
         with:
           name: ${{ matrix.arch }}-macos
           path: mas-cli-${{ matrix.arch }}-macos.tar.gz
+
+  release:
+    name: Release
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download the artifacts from the previous job
+        uses: actions/download-artifact@v3
+        with:
+          path: artifacts
+
+      - name: Move the release assets
+        run: |
+          mv ./artifacts/{x86_64,aarch64}-{linux,macos}/* ./
+
+      - name: Prepare a release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            mas-cli-aarch64-linux.tar.gz
+            mas-cli-aarch64-macos.tar.gz
+            mas-cli-x86_64-linux.tar.gz
+            mas-cli-x86_64-macos.tar.gz
+          draft: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,6 +3,8 @@ name: CI
 on:
   push:
     branches: [ main ]
+    tags:
+      - 'v*'
   pull_request:
     branches: [ main ]
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -304,6 +304,8 @@ jobs:
         with:
           images: "${{ env.IMAGE }}"
           bake-target: docker-metadata-action
+          flavor: |
+            latest=auto
           tags: |
             type=ref,event=branch
             type=semver,pattern={{version}}
@@ -317,12 +319,15 @@ jobs:
         with:
           images: "${{ env.IMAGE }}"
           bake-target: docker-metadata-action-debug
+          flavor: |
+            latest=auto
+            suffix=-debug,onlatest=true
           tags: |
-            type=ref,event=branch,suffix=-debug
-            type=semver,pattern={{version}},suffix=-debug
-            type=semver,pattern={{major}}.{{minor}},suffix=-debug
-            type=semver,pattern={{major}},suffix=-debug
-            type=sha,suffix=-debug
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha
 
       - name: Setup Cosign
         uses: sigstore/cosign-installer@v3.1.1


### PR DESCRIPTION
This makes it so that a git tag will create a draft release with the static binaries, and docker images with the right tags get published