### PR TITLE
Allow running the authentication service on a different base path

### DIFF
--- a/crates/cli/src/server.rs
+++ b/crates/cli/src/server.rs
@@ -175,6 +175,7 @@ fn on_http_response_labels<B>(res: &Response<B>) -> Vec<KeyValue> {
 pub fn build_router<B>(
     state: AppState,
     resources: &[HttpResource],
+    prefix: Option<&str>,
     name: Option<&str>,
 ) -> Router<(), B>
 where
@@ -242,6 +243,11 @@ where
                 router
             }
         }
+    }
+
+    if let Some(prefix) = prefix {
+        let path = format!("{}/", prefix.trim_end_matches('/'));
+        router = Router::new().nest(&path, router);
     }
 
     router = router.fallback(mas_handlers::fallback);

--- a/crates/config/src/sections/http.rs
+++ b/crates/config/src/sections/http.rs
@@ -312,6 +312,10 @@ pub struct ListenerConfig {
     /// List of resources to mount
     pub resources: Vec<Resource>,
 
+    /// HTTP prefix to mount the resources on
+    #[serde(default)]
+    pub prefix: Option<String>,
+
     /// List of sockets to bind
     pub binds: Vec<BindConfig>,
 
@@ -359,6 +363,7 @@ impl Default for HttpConfig {
                             path: http_listener_assets_path_default(),
                         },
                     ],
+                    prefix: None,
                     tls: None,
                     proxy_protocol: false,
                     binds: vec![BindConfig::Address {
@@ -368,6 +373,7 @@ impl Default for HttpConfig {
                 ListenerConfig {
                     name: Some("internal".to_owned()),
                     resources: vec![Resource::Health],
+                    prefix: None,
                     tls: None,
                     proxy_protocol: false,
                     binds: vec![BindConfig::Listen {

--- a/crates/handlers/src/oauth2/authorization/complete.rs
+++ b/crates/handlers/src/oauth2/authorization/complete.rs
@@ -21,7 +21,7 @@ use mas_axum_utils::{cookies::CookieJar, csrf::CsrfExt, sentry::SentryEventID, S
 use mas_data_model::{AuthorizationGrant, BrowserSession, Client, Device};
 use mas_keystore::Keystore;
 use mas_policy::{EvaluationResult, Policy};
-use mas_router::{PostAuthAction, Route, UrlBuilder};
+use mas_router::{PostAuthAction, UrlBuilder};
 use mas_storage::{
     oauth2::{OAuth2AuthorizationGrantRepository, OAuth2ClientRepository, OAuth2SessionRepository},
     user::BrowserSessionRepository,
@@ -117,7 +117,11 @@ pub(crate) async fn get(
     let Some(session) = maybe_session else {
         // If there is no session, redirect to the login screen, redirecting here after
         // logout
-        return Ok((cookie_jar, mas_router::Login::and_then(continue_grant).go()).into_response());
+        return Ok((
+            cookie_jar,
+            url_builder.redirect(&mas_router::Login::and_then(continue_grant)),
+        )
+            .into_response());
     };
 
     activity_tracker
@@ -137,7 +141,7 @@ pub(crate) async fn get(
         repo,
         key_store,
         policy,
-        url_builder,
+        &url_builder,
         grant,
         &client,
         &session,
@@ -150,12 +154,12 @@ pub(crate) async fn get(
         }
         Err(GrantCompletionError::RequiresReauth) => Ok((
             cookie_jar,
-            mas_router::Reauth::and_then(continue_grant).go(),
+            url_builder.redirect(&mas_router::Reauth::and_then(continue_grant)),
         )
             .into_response()),
         Err(GrantCompletionError::RequiresConsent) => {
             let next = mas_router::Consent(grant_id);
-            Ok((cookie_jar, next.go()).into_response())
+            Ok((cookie_jar, url_builder.redirect(&next)).into_response())
         }
         Err(GrantCompletionError::PolicyViolation(grant, res)) => {
             warn!(violation = ?res, "Authorization grant for client {} denied by policy", client.id);
@@ -206,7 +210,7 @@ pub(crate) async fn complete(
     mut repo: BoxRepository,
     key_store: Keystore,
     mut policy: Policy,
-    url_builder: UrlBuilder,
+    url_builder: &UrlBuilder,
     grant: AuthorizationGrant,
     client: &Client,
     browser_session: &BrowserSession,
@@ -273,7 +277,7 @@ pub(crate) async fn complete(
         params.id_token = Some(generate_id_token(
             rng,
             clock,
-            &url_builder,
+            url_builder,
             &key_store,
             client,
             &grant,

--- a/crates/handlers/src/upstream_oauth2/callback.rs
+++ b/crates/handlers/src/upstream_oauth2/callback.rs
@@ -25,7 +25,7 @@ use mas_keystore::{Encrypter, Keystore};
 use mas_oidc_client::requests::{
     authorization_code::AuthorizationValidationData, jose::JwtVerificationData,
 };
-use mas_router::{Route, UrlBuilder};
+use mas_router::UrlBuilder;
 use mas_storage::{
     upstream_oauth2::{
         UpstreamOAuthLinkRepository, UpstreamOAuthProviderRepository,
@@ -268,6 +268,6 @@ pub(crate) async fn get(
 
     Ok((
         cookie_jar,
-        mas_router::UpstreamOAuth2Link::new(link.id).go(),
+        url_builder.redirect(&mas_router::UpstreamOAuth2Link::new(link.id)),
     ))
 }

--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -38,12 +38,12 @@ mod tests {
     #[test]
     fn test_relative_urls() {
         assert_eq!(
-            OidcConfiguration.relative_url(),
+            OidcConfiguration.path_and_query(),
             Cow::Borrowed("/.well-known/openid-configuration")
         );
-        assert_eq!(Index.relative_url(), Cow::Borrowed("/"));
+        assert_eq!(Index.path_and_query(), Cow::Borrowed("/"));
         assert_eq!(
-            Login::and_continue_grant(Ulid::nil()).relative_url(),
+            Login::and_continue_grant(Ulid::nil()).path_and_query(),
             Cow::Borrowed("/login?kind=continue_authorization_grant&id=00000000000000000000000000")
         );
     }

--- a/crates/router/src/traits.rs
+++ b/crates/router/src/traits.rs
@@ -28,7 +28,7 @@ pub trait Route {
         Cow::Borrowed(Self::route())
     }
 
-    fn relative_url(&self) -> Cow<'static, str> {
+    fn path_and_query(&self) -> Cow<'static, str> {
         let path = self.path();
         if let Some(query) = self.query() {
             let query = serde_urlencoded::to_string(query).unwrap();
@@ -39,16 +39,9 @@ pub trait Route {
     }
 
     fn absolute_url(&self, base: &Url) -> Url {
-        let relative = self.relative_url();
+        let relative = self.path_and_query();
+        let relative = relative.trim_start_matches('/');
         base.join(relative.borrow()).unwrap()
-    }
-
-    fn go(&self) -> axum::response::Redirect {
-        axum::response::Redirect::to(&self.relative_url())
-    }
-
-    fn go_absolute(&self, base: &Url) -> axum::response::Redirect {
-        axum::response::Redirect::to(self.absolute_url(base).as_str())
     }
 }
 

--- a/crates/templates/src/functions.rs
+++ b/crates/templates/src/functions.rs
@@ -52,7 +52,7 @@ pub fn register(
     env.add_global(
         "include_asset",
         Value::from_object(IncludeAsset {
-            url_builder,
+            url_builder: url_builder.clone(),
             vite_manifest,
         }),
     );
@@ -60,6 +60,19 @@ pub fn register(
         "translator",
         Value::from_object(TranslatorFunc { translator }),
     );
+    env.add_filter("prefix_url", move |url: &str| -> String {
+        if !url.starts_with('/') {
+            // Let's assume it's not an internal URL and return it as-is
+            return url.to_owned();
+        }
+
+        let Some(prefix) = url_builder.prefix() else {
+            // If there is no prefix to add, return the URL as-is
+            return url.to_owned();
+        };
+
+        format!("{prefix}{url}")
+    });
 }
 
 fn tester_empty(seq: &dyn SeqObject) -> bool {

--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -1278,6 +1278,10 @@
           "description": "A unique name for this listener which will be shown in traces and in metrics labels",
           "type": "string"
         },
+        "prefix": {
+          "description": "HTTP prefix to mount the resources on",
+          "type": "string"
+        },
         "proxy_protocol": {
           "description": "Accept HAProxy's Proxy Protocol V1",
           "default": false,

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -23,7 +23,7 @@ limitations under the License.
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>matrix-authentication-service</title>
     <script type="application/javascript">
-      window.APP_CONFIG = JSON.parse('{"root": "/account/"}');
+      window.APP_CONFIG = JSON.parse('{"root": "/account/", "graphqlEndpoint": "/graphql"}');
       (function () {
         const query = window.matchMedia("(prefers-color-scheme: dark)");
         function handleChange(list) {

--- a/frontend/src/components/Layout.test.tsx
+++ b/frontend/src/components/Layout.test.tsx
@@ -38,7 +38,7 @@ const HydrateLocation: React.FC<React.PropsWithChildren<{ path: string }>> = ({
   path,
 }) => {
   useHydrateAtoms([
-    [appConfigAtom, { root: "/" }],
+    [appConfigAtom, { root: "/", graphqlEndpoint: "/graphql" }],
     [locationAtom, { pathname: path }],
   ]);
   return <>{children}</>;

--- a/frontend/src/components/NavBar/NavBar.stories.tsx
+++ b/frontend/src/components/NavBar/NavBar.stories.tsx
@@ -40,7 +40,7 @@ const meta = {
 
 const WithHomePage: React.FC<React.PropsWithChildren<{}>> = ({ children }) => {
   useHydrateAtoms([
-    [appConfigAtom, { root: "/" }],
+    [appConfigAtom, { root: "/", graphqlEndpoint: "/graphql" }],
     [locationAtom, { pathname: "/" }],
   ]);
   return <>{children}</>;

--- a/frontend/src/components/NavItem/NavItem.stories.tsx
+++ b/frontend/src/components/NavItem/NavItem.stories.tsx
@@ -35,7 +35,7 @@ const meta = {
 
 const WithHomePage: React.FC<React.PropsWithChildren<{}>> = ({ children }) => {
   useHydrateAtoms([
-    [appConfigAtom, { root: "/" }],
+    [appConfigAtom, { root: "/", graphqlEndpoint: "/graphql" }],
     [locationAtom, { pathname: "/" }],
   ]);
   return <>{children}</>;

--- a/frontend/src/components/NavItem/NavItem.test.tsx
+++ b/frontend/src/components/NavItem/NavItem.test.tsx
@@ -38,7 +38,7 @@ const HydrateLocation: React.FC<React.PropsWithChildren<{ path: string }>> = ({
   path,
 }) => {
   useHydrateAtoms([
-    [appConfigAtom, { root: "/" }],
+    [appConfigAtom, { root: "/", graphqlEndpoint: "/graphql" }],
     [locationAtom, { pathname: path }],
   ]);
   return <>{children}</>;

--- a/frontend/src/components/UserSessionsOverview/BrowserSessionsOverview.stories.tsx
+++ b/frontend/src/components/UserSessionsOverview/BrowserSessionsOverview.stories.tsx
@@ -27,7 +27,7 @@ type Props = {
 
 const WithHomePage: React.FC<React.PropsWithChildren<{}>> = ({ children }) => {
   useHydrateAtoms([
-    [appConfigAtom, { root: "/" }],
+    [appConfigAtom, { root: "/", graphqlEndpoint: "/graphql" }],
     [locationAtom, { pathname: "/" }],
   ]);
   return <>{children}</>;

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -12,10 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-type AppConfig = {
+export type AppConfig = {
   root: string;
+  graphqlEndpoint: string;
 };
 
-interface Window {
-  APP_CONFIG: AppConfig;
+interface IWindow {
+  APP_CONFIG?: AppConfig;
 }
+
+const config: AppConfig = (typeof window !== "undefined" &&
+  (window as IWindow).APP_CONFIG) || { root: "/", graphqlEndpoint: "/graphql" };
+
+export default config;

--- a/frontend/src/graphql.ts
+++ b/frontend/src/graphql.ts
@@ -18,6 +18,7 @@ import { cacheExchange } from "@urql/exchange-graphcache";
 import { refocusExchange } from "@urql/exchange-refocus";
 import { requestPolicyExchange } from "@urql/exchange-request-policy";
 
+import appConfig from "./config";
 import type {
   MutationAddEmailArgs,
   MutationRemoveEmailArgs,
@@ -130,7 +131,7 @@ const exchanges = [
 ];
 
 export const client = createClient({
-  url: "/graphql",
+  url: appConfig.graphqlEndpoint,
   // Add the devtools exchange in development
   exchanges: import.meta.env.DEV ? [devtoolsExchange, ...exchanges] : exchanges,
 });

--- a/frontend/src/routing/atoms.ts
+++ b/frontend/src/routing/atoms.ts
@@ -15,11 +15,11 @@
 import { atom } from "jotai";
 import { atomWithLocation } from "jotai-location";
 
+import appConfig, { AppConfig } from "../config";
+
 import { Location, pathToRoute, Route, routeToPath } from "./routes";
 
-export const appConfigAtom = atom<AppConfig>(
-  typeof window !== "undefined" ? window.APP_CONFIG : { root: "/" },
-);
+export const appConfigAtom = atom<AppConfig>(appConfig);
 
 const locationToRoute = (root: string, location: Location): Route => {
   if (!location.pathname || !location.pathname.startsWith(root)) {

--- a/frontend/src/test-utils/WithLocation.tsx
+++ b/frontend/src/test-utils/WithLocation.tsx
@@ -24,7 +24,7 @@ const HydrateLocation: React.FC<React.PropsWithChildren<{ path: string }>> = ({
   path,
 }) => {
   useHydrateAtoms([
-    [appConfigAtom, { root: "/" }],
+    [appConfigAtom, { root: "/", graphqlEndpoint: "/graphql" }],
     [locationAtom, { pathname: path }],
   ]);
   return <>{children}</>;

--- a/templates/components/button.html
+++ b/templates/components/button.html
@@ -15,15 +15,15 @@ limitations under the License.
 #}
 
 {% macro link(text, href="#", class="") %}
-  <a class="cpd-button {{ class }}" data-kind="primary" data-size="lg" href="{{ href }}">{{ text }}</a>
+  <a class="cpd-button {{ class }}" data-kind="primary" data-size="lg" href="{{ href | prefix_url }}">{{ text }}</a>
 {% endmacro %}
 
 {% macro link_text(text, href="#", class="") %}
-  <a class="cpd-link {{ class }}" data-kind="primary" href="{{ href }}">{{ text }}</a>
+  <a class="cpd-link {{ class }}" data-kind="primary" href="{{ href | prefix_url }}">{{ text }}</a>
 {% endmacro %}
 
 {% macro link_outline(text, href="#", class="") %}
-  <a class="cpd-button {{ class }}" data-kind="secondary" data-size="lg" href="{{ href }}">{{ text }}</a>
+  <a class="cpd-button {{ class }}" data-kind="secondary" data-size="lg" href="{{ href | prefix_url }}">{{ text }}</a>
 {% endmacro %}
 
 {% macro button(

--- a/templates/components/logout.html
+++ b/templates/components/logout.html
@@ -15,7 +15,7 @@ limitations under the License.
 #}
 
 {% macro button(text, csrf_token, as_link=false, post_logout_action={}) %}
-  <form method="POST" action="/logout" class="inline">
+  <form method="POST" action="{{ "/logout" | prefix_url }}" class="inline">
     <input type="hidden" name="csrf" value="{{ csrf_token }}" />
     {% for key, value in post_logout_action|items %}
       <input type="hidden" name="{{ key }}" value="{{ value }}" />

--- a/templates/pages/404.html
+++ b/templates/pages/404.html
@@ -22,7 +22,7 @@ limitations under the License.
         <h1 class="text-xl font-semibold">{{ _("mas.not_found.heading") }}</h1>
         <p>{{ _("mas.not_found.description") }}</p>
         <div>
-            <a class="cpd-link" data-kind="primary" href="/">{{ _("mas.back_to_homepage") }}</a>
+            {{ button.link_text(text=_("mas.back_to_homepage"), href="/") }}
         </div>
 
         <hr />

--- a/translations/en.json
+++ b/translations/en.json
@@ -77,7 +77,7 @@
     },
     "back_to_homepage": "Go back to the homepage",
     "@back_to_homepage": {
-      "context": "pages/404.html:25:64-89"
+      "context": "pages/404.html:25:37-62"
     },
     "change_password": {
       "change": "Change password",


### PR DESCRIPTION
Fixes #1378

This does a bunch of things:

 - makes all the relative URL build functions use the prefix from the `UrlBuilder`
 - replace a bunch of hardcoded URLs
 - add a helper in the templates to potentially prefix the relative URLs
 - add a listener-level config option to set the prefix
 - makes the GraphQL endpoint configurable on the frontend

An end config would look like:

```yaml
http:
  listeners:
    - name: "web"
      prefix: "/auth/"
      resources:
      - name: discovery
      - name: human
      - name: oauth
      - name: assets
        path: ./frontend/dist/
      - name: graphql
        playground: true
      binds:
      - address: '[::]:1234'

    - name: "compat"
      binds:
      - address: '[::]:1235'
      resources:
      - name: compat

    - name: "internal"
      resources:
      - name: health
      - name: prometheus
      binds:
      - host: localhost
        port: 2345

  public_base: "https://example.com/auth/"
```

Note how the compat resource is on another listener, so that it can have a different prefix (because we actually don't want to prefix it).
The prefix in the `public_base` *has to match* the prefix in listeners.
