### PR TITLE
graphql: expose the logo_uri in the OAuth 2.0 client

### DIFF
--- a/crates/graphql/src/model/oauth.rs
+++ b/crates/graphql/src/model/oauth.rs
@@ -158,6 +158,11 @@ impl OAuth2Client {
         self.0.client_uri.as_ref()
     }
 
+    /// Logo URI advertised by the client.
+    pub async fn logo_uri(&self) -> Option<&Url> {
+        self.0.logo_uri.as_ref()
+    }
+
     /// Terms of services URI advertised by the client.
     pub async fn tos_uri(&self) -> Option<&Url> {
         self.0.tos_uri.as_ref()

--- a/frontend/schema.graphql
+++ b/frontend/schema.graphql
@@ -634,6 +634,10 @@ type Oauth2Client implements Node {
   """
   clientUri: Url
   """
+  Logo URI advertised by the client.
+  """
+  logoUri: Url
+  """
   Terms of services URI advertised by the client.
   """
   tosUri: Url

--- a/frontend/src/gql/graphql.ts
+++ b/frontend/src/gql/graphql.ts
@@ -485,6 +485,8 @@ export type Oauth2Client = Node & {
   contacts: Array<Scalars["String"]["output"]>;
   /** ID of the object. */
   id: Scalars["ID"]["output"];
+  /** Logo URI advertised by the client. */
+  logoUri?: Maybe<Scalars["Url"]["output"]>;
   /** Privacy policy URI advertised by the client. */
   policyUri?: Maybe<Scalars["Url"]["output"]>;
   /** List of redirect URIs used for authorization grants by the client. */

--- a/frontend/src/gql/schema.ts
+++ b/frontend/src/gql/schema.ts
@@ -1262,6 +1262,14 @@ export default {
             args: [],
           },
           {
+            name: "logoUri",
+            type: {
+              kind: "SCALAR",
+              name: "Any",
+            },
+            args: [],
+          },
+          {
             name: "policyUri",
             type: {
               kind: "SCALAR",


### PR DESCRIPTION
Fixes #1705

cc @kerryarchibald 