### PR TITLE
Add Sentry event ID in response headers & have more granular errors on token refresh

### DIFF
--- a/crates/axum-utils/src/fancy_error.rs
+++ b/crates/axum-utils/src/fancy_error.rs
@@ -19,6 +19,8 @@ use axum::{
 };
 use mas_templates::ErrorContext;
 
+use crate::sentry::SentryEventID;
+
 pub struct FancyError {
     context: ErrorContext,
 }
@@ -59,9 +61,10 @@ impl<E: std::fmt::Debug + std::fmt::Display> From<E> for FancyError {
 impl IntoResponse for FancyError {
     fn into_response(self) -> Response {
         let error = format!("{:?}", self.context);
-        sentry::capture_message(&error, sentry::Level::Error);
+        let event_id = sentry::capture_message(&error, sentry::Level::Error);
         (
             StatusCode::INTERNAL_SERVER_ERROR,
+            SentryEventID::from(event_id),
             Extension(self.context),
             error,
         )

--- a/crates/axum-utils/src/lib.rs
+++ b/crates/axum-utils/src/lib.rs
@@ -28,6 +28,7 @@ pub mod csrf;
 pub mod fancy_error;
 pub mod http_client_factory;
 pub mod jwt;
+pub mod sentry;
 pub mod session;
 pub mod user_authorization;
 

--- a/crates/axum-utils/src/sentry.rs
+++ b/crates/axum-utils/src/sentry.rs
@@ -1,0 +1,38 @@
+// Copyright 2023 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::convert::Infallible;
+
+use axum::response::{IntoResponseParts, ResponseParts};
+use sentry::types::Uuid;
+
+/// A wrapper to include a Sentry event ID in the response headers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct SentryEventID(Uuid);
+
+impl From<Uuid> for SentryEventID {
+    fn from(uuid: Uuid) -> Self {
+        Self(uuid)
+    }
+}
+
+impl IntoResponseParts for SentryEventID {
+    type Error = Infallible;
+    fn into_response_parts(self, mut res: ResponseParts) -> Result<ResponseParts, Self::Error> {
+        res.headers_mut()
+            .insert("X-Sentry-Event-ID", self.0.to_string().parse().unwrap());
+
+        Ok(res)
+    }
+}

--- a/crates/handlers/src/oauth2/consent.rs
+++ b/crates/handlers/src/oauth2/consent.rs
@@ -20,6 +20,7 @@ use hyper::StatusCode;
 use mas_axum_utils::{
     cookies::CookieJar,
     csrf::{CsrfExt, ProtectedForm},
+    sentry::SentryEventID,
     SessionInfoExt,
 };
 use mas_data_model::{AuthorizationGrantStage, Device};
@@ -63,8 +64,12 @@ impl_from_error_for_route!(mas_policy::EvaluationError);
 
 impl IntoResponse for RouteError {
     fn into_response(self) -> axum::response::Response {
-        sentry::capture_error(&self);
-        StatusCode::INTERNAL_SERVER_ERROR.into_response()
+        let event_id = sentry::capture_error(&self);
+        (
+            SentryEventID::from(event_id),
+            StatusCode::INTERNAL_SERVER_ERROR,
+        )
+            .into_response()
     }
 }
 

--- a/crates/handlers/src/oauth2/introspection.rs
+++ b/crates/handlers/src/oauth2/introspection.rs
@@ -17,6 +17,7 @@ use hyper::StatusCode;
 use mas_axum_utils::{
     client_authorization::{ClientAuthorization, CredentialsVerificationError},
     http_client_factory::HttpClientFactory,
+    sentry::SentryEventID,
 };
 use mas_data_model::{TokenFormatError, TokenType, User};
 use mas_iana::oauth::{OAuthClientAuthenticationMethod, OAuthTokenTypeHint};
@@ -59,8 +60,8 @@ pub enum RouteError {
 
 impl IntoResponse for RouteError {
     fn into_response(self) -> axum::response::Response {
-        sentry::capture_error(&self);
-        match self {
+        let event_id = sentry::capture_error(&self);
+        let response = match self {
             Self::Internal(e) => (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(
@@ -92,7 +93,9 @@ impl IntoResponse for RouteError {
                 Json(ClientError::from(ClientErrorCode::InvalidRequest)),
             )
                 .into_response(),
-        }
+        };
+
+        (SentryEventID::from(event_id), response).into_response()
     }
 }
 

--- a/crates/handlers/src/oauth2/revoke.rs
+++ b/crates/handlers/src/oauth2/revoke.rs
@@ -17,6 +17,7 @@ use hyper::StatusCode;
 use mas_axum_utils::{
     client_authorization::{ClientAuthorization, CredentialsVerificationError},
     http_client_factory::HttpClientFactory,
+    sentry::SentryEventID,
 };
 use mas_data_model::{Device, TokenType};
 use mas_iana::oauth::OAuthTokenTypeHint;
@@ -62,8 +63,8 @@ pub(crate) enum RouteError {
 
 impl IntoResponse for RouteError {
     fn into_response(self) -> axum::response::Response {
-        sentry::capture_error(&self);
-        match self {
+        let event_id = sentry::capture_error(&self);
+        let response = match self {
             Self::Internal(_) => (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(ClientError::from(ClientErrorCode::ServerError)),
@@ -96,7 +97,9 @@ impl IntoResponse for RouteError {
 
             // If the token is unknown, we still return a 200 OK response.
             Self::UnknownToken => StatusCode::OK.into_response(),
-        }
+        };
+
+        (SentryEventID::from(event_id), response).into_response()
     }
 }
 


### PR DESCRIPTION
- Add the Sentry event ID in error response headers
- Have more granular errors on the refresh token grant
