### PR TITLE
Switch to memory-l-storage

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,7 +16,7 @@ env:
 jobs:
   build-assets:
     name: Build assets
-    runs-on: non-dind
+    runs-on: memory-l-storage
     container: docker.io/library/buildpack-deps:bookworm
 
     permissions:
@@ -65,7 +65,7 @@ jobs:
 
   build-linux:
     name: Build for Linux ${{ matrix.arch }}
-    runs-on: non-dind
+    runs-on: memory-l-storage
     container: docker.io/library/buildpack-deps:bookworm
 
     needs:
@@ -127,7 +127,7 @@ jobs:
 
   build-macos:
     name: Build for macOS ${{ matrix.arch }}
-    runs-on: non-dind
+    runs-on: memory-l-storage
     container: docker.io/library/buildpack-deps:bookworm
     env:
       SDKROOT: /opt/MacOSX11.3.sdk

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ env:
 jobs:
   opa-lint:
     name: Lint and test OPA policies
-    runs-on: non-dind
+    runs-on: memory-l-storage
     container: docker.io/library/buildpack-deps:bookworm
 
     permissions:
@@ -42,7 +42,7 @@ jobs:
 
   frontend-lint:
     name: Check frontend style
-    runs-on: non-dind
+    runs-on: memory-l-storage
     container: docker.io/library/buildpack-deps:bookworm
 
     permissions:
@@ -68,7 +68,7 @@ jobs:
 
   frontend-test:
     name: Run the frontend test suite
-    runs-on: non-dind
+    runs-on: memory-l-storage
     container: docker.io/library/buildpack-deps:bookworm
 
     permissions:
@@ -94,7 +94,7 @@ jobs:
 
   rustfmt:
     name: Check Rust style
-    runs-on: non-dind
+    runs-on: memory-l-storage
     container: docker.io/library/buildpack-deps:bookworm
 
     permissions:
@@ -115,7 +115,7 @@ jobs:
 
   cargo-deny:
     name: Run `cargo deny` checks
-    runs-on: non-dind
+    runs-on: memory-l-storage
     container: docker.io/library/buildpack-deps:bookworm
 
     permissions:
@@ -128,10 +128,10 @@ jobs:
       - name: Run `cargo-deny`
         uses: EmbarkStudios/cargo-deny-action@v1.5.4
 
-  
+
   check-schema:
     name: Check schema
-    runs-on: non-dind
+    runs-on: memory-l-storage
     container: docker.io/library/buildpack-deps:bookworm
 
     permissions:
@@ -165,7 +165,7 @@ jobs:
         run: |
           if ! [[ -z $(git status -s) ]]; then
             echo "::error title=Workspace is not clean::Please run 'sh ./misc/update.sh' and commit the changes"
-          
+
             (
               echo '## Diff after running `sh ./misc/update.sh`:'
               echo
@@ -173,7 +173,7 @@ jobs:
               git diff
               echo '```'
             ) >> $GITHUB_STEP_SUMMARY
-          
+
             exit 1
           fi
 
@@ -181,7 +181,7 @@ jobs:
   clippy:
     name: Run Clippy
     needs: [rustfmt, opa-lint]
-    runs-on: non-dind
+    runs-on: memory-l-storage
     container: docker.io/library/buildpack-deps:bookworm
 
     permissions:
@@ -218,7 +218,7 @@ jobs:
   test:
     name: Run test suite with Rust stable
     needs: [rustfmt, opa-lint]
-    runs-on: non-dind
+    runs-on: memory-l-storage
     container: docker.io/library/buildpack-deps:bookworm
 
     permissions:
@@ -285,7 +285,7 @@ jobs:
   build-image:
     name: Build and push Docker image
     needs: [rustfmt, opa-lint]
-    runs-on: non-dind
+    runs-on: memory-l-storage
     container: docker.io/library/buildpack-deps:bookworm
     env:
       IMAGE: ghcr.io/matrix-org/matrix-authentication-service
@@ -399,7 +399,7 @@ jobs:
       - check-schema
       - test
       - build-image
-    runs-on: non-dind
+    runs-on: memory-l-storage
     container: docker.io/library/buildpack-deps:bookworm
 
     steps:

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -17,7 +17,7 @@ env:
 jobs:
   opa:
     name: Run OPA test suite with coverage
-    runs-on: non-dind
+    runs-on: memory-l-storage
     container: docker.io/library/buildpack-deps:bookworm
 
     permissions:
@@ -44,7 +44,7 @@ jobs:
 
   frontend:
     name: Run frontend test suite with coverage
-    runs-on: non-dind
+    runs-on: memory-l-storage
     container: docker.io/library/buildpack-deps:bookworm
 
     permissions:
@@ -75,7 +75,7 @@ jobs:
 
   rust:
     name: Run Rust test suite with coverage
-    runs-on: non-dind
+    runs-on: memory-l-storage
     container: docker.io/library/buildpack-deps:bookworm
 
     permissions:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -17,7 +17,7 @@ env:
 jobs:
   build:
     name: Build the documentation
-    runs-on: non-dind
+    runs-on: memory-l-storage
     container: docker.io/library/buildpack-deps:bookworm
     steps:
       - name: Checkout the code
@@ -57,7 +57,7 @@ jobs:
 
   deploy:
     name: Deploy the documentation on GitHub Pages
-    runs-on: non-dind
+    runs-on: memory-l-storage
     container: docker.io/library/buildpack-deps:bookworm
     needs: build
     if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
Part of https://github.com/vector-im/sre-internal/issues/2778.

This blindly switches all `non-dind` runners to `memory-l-storage`. This because I'm not sure which ones actually need all the resources that this type provides and which ones can run on a smaller runner type. I'll leave it to @sandhose to make the distinction.