### PR TITLE
Share the HTTP client properly

### DIFF
--- a/crates/axum-utils/src/client_authorization.rs
+++ b/crates/axum-utils/src/client_authorization.rs
@@ -191,8 +191,7 @@ async fn fetch_jwks(
         .unwrap();
 
     let mut client = http_client_factory
-        .client()
-        .await?
+        .client("client.fetch_jwks")
         .response_body_to_bytes()
         .json_response::<PublicJsonWebKeySet>();
 

--- a/crates/cli/src/commands/debug.rs
+++ b/crates/cli/src/commands/debug.rs
@@ -67,7 +67,7 @@ impl Options {
     #[tracing::instrument(skip_all)]
     pub async fn run(self, root: &super::Options) -> anyhow::Result<()> {
         use Subcommand as SC;
-        let http_client_factory = HttpClientFactory::new(10);
+        let http_client_factory = HttpClientFactory::new().await?;
         match self.subcommand {
             SC::Http {
                 show_headers,
@@ -75,7 +75,7 @@ impl Options {
                 url,
             } => {
                 let _span = info_span!("cli.debug.http").entered();
-                let mut client = http_client_factory.client().await?;
+                let mut client = http_client_factory.client("debug");
                 let request = hyper::Request::builder()
                     .uri(url)
                     .body(hyper::Body::empty())?;
@@ -99,8 +99,7 @@ impl Options {
             } => {
                 let _span = info_span!("cli.debug.http").entered();
                 let mut client = http_client_factory
-                    .client()
-                    .await?
+                    .client("debug")
                     .response_body_to_bytes()
                     .json_response();
                 let request = hyper::Request::builder()

--- a/crates/cli/src/commands/worker.rs
+++ b/crates/cli/src/commands/worker.rs
@@ -49,7 +49,7 @@ impl Options {
         let mailer = mailer_from_config(&config.email, &templates)?;
         mailer.test_connection().await?;
 
-        let http_client_factory = HttpClientFactory::new(50);
+        let http_client_factory = HttpClientFactory::new().await?;
         let conn = SynapseConnection::new(
             config.matrix.homeserver.clone(),
             config.matrix.endpoint.clone(),

--- a/crates/handlers/src/app_state.rs
+++ b/crates/handlers/src/app_state.rs
@@ -122,9 +122,7 @@ impl AppState {
 
         let http_service = self
             .http_client_factory
-            .http_service()
-            .await
-            .expect("Failed to create the HTTP service");
+            .http_service("upstream_oauth2.metadata");
 
         self.metadata_cache
             .warm_up_and_run(

--- a/crates/handlers/src/test_utils.rs
+++ b/crates/handlers/src/test_utils.rs
@@ -142,7 +142,7 @@ impl TestState {
 
         let homeserver_connection = MockHomeserverConnection::new("example.com");
 
-        let http_client_factory = HttpClientFactory::new(10);
+        let http_client_factory = HttpClientFactory::new().await?;
 
         let site_config = SiteConfig::default();
 

--- a/crates/handlers/src/upstream_oauth2/authorize.rs
+++ b/crates/handlers/src/upstream_oauth2/authorize.rs
@@ -84,7 +84,7 @@ pub(crate) async fn get(
         .await?
         .ok_or(RouteError::ProviderNotFound)?;
 
-    let http_service = http_client_factory.http_service().await?;
+    let http_service = http_client_factory.http_service("upstream_oauth2.authorize");
 
     // First, discover the provider
     let metadata = metadata_cache.get(&http_service, &provider.issuer).await?;

--- a/crates/handlers/src/upstream_oauth2/callback.rs
+++ b/crates/handlers/src/upstream_oauth2/callback.rs
@@ -188,7 +188,7 @@ pub(crate) async fn get(
         CodeOrError::Code { code } => code,
     };
 
-    let http_service = http_client_factory.http_service().await?;
+    let http_service = http_client_factory.http_service("upstream_oauth2.callback");
 
     // Discover the provider
     let metadata = metadata_cache.get(&http_service, &provider.issuer).await?;

--- a/crates/http/src/client.rs
+++ b/crates/http/src/client.rs
@@ -14,13 +14,11 @@
 
 use std::convert::Infallible;
 
-use hyper::{
-    client::{
-        connect::dns::{GaiResolver, Name},
-        HttpConnector,
-    },
-    Client,
+use hyper::client::{
+    connect::dns::{GaiResolver, Name},
+    HttpConnector,
 };
+pub use hyper::Client;
 use hyper_rustls::{HttpsConnector, HttpsConnectorBuilder};
 use mas_tower::{
     DurationRecorderLayer, DurationRecorderService, FnWrapper, InFlightCounterLayer,

--- a/crates/http/src/lib.rs
+++ b/crates/http/src/lib.rs
@@ -33,7 +33,7 @@ mod service;
 #[cfg(feature = "client")]
 pub use self::{
     client::{
-        make_traced_client, make_traced_connector, make_untraced_client, ClientInitError,
+        make_traced_client, make_traced_connector, make_untraced_client, Client, ClientInitError,
         TracedClient, TracedConnector, UntracedClient, UntracedConnector,
     },
     layers::client::{ClientLayer, ClientService},

--- a/crates/matrix-synapse/src/lib.rs
+++ b/crates/matrix-synapse/src/lib.rs
@@ -154,8 +154,7 @@ impl HomeserverConnection for SynapseConnection {
     async fn query_user(&self, mxid: &str) -> Result<MatrixUser, Self::Error> {
         let mut client = self
             .http_client_factory
-            .client()
-            .await?
+            .client("homeserver.query_user")
             .response_body_to_bytes()
             .json_response();
 
@@ -218,8 +217,7 @@ impl HomeserverConnection for SynapseConnection {
 
         let mut client = self
             .http_client_factory
-            .client()
-            .await?
+            .client("homeserver.provision_user")
             .request_bytes_to_body()
             .json_request();
 
@@ -255,8 +253,7 @@ impl HomeserverConnection for SynapseConnection {
     async fn create_device(&self, mxid: &str, device_id: &str) -> Result<(), Self::Error> {
         let mut client = self
             .http_client_factory
-            .client()
-            .await?
+            .client("homeserver.create_device")
             .request_bytes_to_body()
             .json_request();
 
@@ -284,7 +281,7 @@ impl HomeserverConnection for SynapseConnection {
         err(Display),
     )]
     async fn delete_device(&self, mxid: &str, device_id: &str) -> Result<(), Self::Error> {
-        let mut client = self.http_client_factory.client().await?;
+        let mut client = self.http_client_factory.client("homeserver.delete_device");
 
         let request = self
             .delete(&format!(
@@ -314,8 +311,7 @@ impl HomeserverConnection for SynapseConnection {
     async fn delete_user(&self, mxid: &str, erase: bool) -> Result<(), Self::Error> {
         let mut client = self
             .http_client_factory
-            .client()
-            .await?
+            .client("homeserver.delete_user")
             .request_bytes_to_body()
             .json_request();
 
@@ -345,8 +341,7 @@ impl HomeserverConnection for SynapseConnection {
     async fn set_displayname(&self, mxid: &str, displayname: &str) -> Result<(), Self::Error> {
         let mut client = self
             .http_client_factory
-            .client()
-            .await?
+            .client("homeserver.set_displayname")
             .request_bytes_to_body()
             .json_request();
 

--- a/crates/tower/src/metrics/in_flight.rs
+++ b/crates/tower/src/metrics/in_flight.rs
@@ -40,7 +40,7 @@ impl InFlightCounterLayer {
     pub fn new(name: &'static str) -> Self {
         let counter = crate::meter()
             .i64_up_down_counter(name)
-            .with_unit(Unit::new("ms"))
+            .with_unit(Unit::new("{request}"))
             .with_description("The number of in-flight requests")
             .init();
 

--- a/crates/tower/src/metrics/make_attributes.rs
+++ b/crates/tower/src/metrics/make_attributes.rs
@@ -69,6 +69,17 @@ where
     }
 }
 
+impl<V, T, const N: usize> MetricsAttributes<T> for [V; N]
+where
+    V: MetricsAttributes<T> + 'static,
+    T: 'static,
+{
+    type Iter<'a> = Box<dyn Iterator<Item = KeyValue> + 'a>;
+    fn attributes<'a>(&'a self, t: &'a T) -> Self::Iter<'_> {
+        Box::new(self.iter().flat_map(|v| v.attributes(t)))
+    }
+}
+
 impl<V, T> MetricsAttributes<T> for KV<V>
 where
     V: Into<Value> + Clone + 'static,


### PR DESCRIPTION
- Always initialize a metric reader to avoid crashes
- Make the HTTP client factory reuse the underlying client
