### PR TITLE
Enable HTTP keepalive correctly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2971,6 +2971,7 @@ dependencies = [
  "libc",
  "pin-project-lite",
  "rustls-pemfile",
+ "socket2 0.5.4",
  "thiserror",
  "tokio",
  "tokio-rustls",
@@ -5043,9 +5044,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2538b18701741680e0322a2302176d3253a35388e2e62f172f64f4f16605f877"
+checksum = "4031e820eb552adee9295814c0ced9e5cf38ddf1e8b7d566d6de8e2538ea989e"
 dependencies = [
  "libc",
  "windows-sys 0.48.0",
@@ -5564,7 +5565,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.5.3",
+ "socket2 0.5.4",
  "tokio-macros",
  "windows-sys 0.48.0",
 ]

--- a/crates/listener/Cargo.toml
+++ b/crates/listener/Cargo.toml
@@ -13,6 +13,7 @@ futures-util = "0.3.28"
 http-body = "0.4.5"
 hyper = { version = "0.14.27", features = ["server", "http1", "http2", "tcp"] }
 pin-project-lite = "0.2.13"
+socket2 = "0.5.4"
 thiserror.workspace = true
 tokio = { version = "1.32.0", features = ["net", "rt", "macros", "signal", "time"] }
 tokio-rustls = "0.24.1"

--- a/crates/listener/src/server.rs
+++ b/crates/listener/src/server.rs
@@ -176,7 +176,7 @@ where
     } else {
         hyper::server::conn::Http::new()
             .http1_only(true)
-            .http1_keep_alive(false)
+            .http1_keep_alive(true)
             .serve_connection(stream, service)
             .with_upgrades()
             .await?;

--- a/crates/listener/src/unix_or_tcp.rs
+++ b/crates/listener/src/unix_or_tcp.rs
@@ -152,10 +152,20 @@ impl UnixOrTcpListener {
         match self {
             Self::Unix(listener) => {
                 let (stream, remote_addr) = listener.accept().await?;
+
+                let socket = socket2::SockRef::from(&stream);
+                socket.set_keepalive(true)?;
+                socket.set_nodelay(true)?;
+
                 Ok((remote_addr.into(), UnixOrTcpConnection::Unix { stream }))
             }
             Self::Tcp(listener) => {
                 let (stream, remote_addr) = listener.accept().await?;
+
+                let socket = socket2::SockRef::from(&stream);
+                socket.set_keepalive(true)?;
+                socket.set_nodelay(true)?;
+
                 Ok((remote_addr.into(), UnixOrTcpConnection::Tcp { stream }))
             }
         }


### PR DESCRIPTION
Turns out we were disabling HTTP keep-alive, without properly advertising it in the headers.
This was causing issues with Synapse.
This properly enables it, also on the socket level.
