### PR TITLE
Deny URIs from client that are public suffixes & allow subdomains

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2844,6 +2844,7 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-semantic-conventions",
  "pbkdf2",
+ "psl",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "sentry",
@@ -4166,6 +4167,15 @@ name = "protobuf"
 version = "2.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
+
+[[package]]
+name = "psl"
+version = "2.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a1be0afcd844b15cfce18bf8cccf2dfa887a00a6454a9ea135f122b948cee91"
+dependencies = [
+ "psl-types",
+]
 
 [[package]]
 name = "psl-types"

--- a/crates/handlers/Cargo.toml
+++ b/crates/handlers/Cargo.toml
@@ -53,6 +53,7 @@ zeroize = "1.6.0"
 # Various data types and utilities
 camino = "1.1.6"
 chrono.workspace = true
+psl = "2.1.4"
 time = "0.3.28"
 url.workspace = true
 mime = "0.3.17"

--- a/crates/handlers/src/oauth2/registration.rs
+++ b/crates/handlers/src/oauth2/registration.rs
@@ -171,8 +171,11 @@ fn host_is_public_suffix(url: &Url) -> bool {
         return false;
     }
 
-    if host.len() < suffix.as_bytes().len() + 2 {
-        // Host is too short to be a valid domain
+    // We want to cover two cases:
+    // - The host is the suffix itself, like `com`
+    // - The host is a dot followed by the suffix, like `.com`
+    if host.len() <= suffix.as_bytes().len() + 1 {
+        // The host only has the suffix in it, so it's a public suffix
         return true;
     }
 
@@ -323,10 +326,14 @@ mod tests {
             host_is_public_suffix(&Url::parse(url).unwrap())
         }
 
+        assert!(url_is_public_suffix("https://.com"));
         assert!(url_is_public_suffix("https://.com."));
         assert!(url_is_public_suffix("https://co.uk"));
         assert!(url_is_public_suffix("https://github.io"));
         assert!(!url_is_public_suffix("https://example.com"));
+        assert!(!url_is_public_suffix("https://example.com."));
+        assert!(!url_is_public_suffix("https://x.com"));
+        assert!(!url_is_public_suffix("https://x.com."));
         assert!(!url_is_public_suffix("https://matrix-org.github.io"));
         assert!(!url_is_public_suffix("http://localhost"));
         assert!(!url_is_public_suffix("org.matrix:/callback"));

--- a/policies/client_registration.rego
+++ b/policies/client_registration.rego
@@ -54,7 +54,7 @@ host_matches_client_uri(x) {
 host_matches_client_uri(x) {
 	client_uri := parse_uri(input.client_metadata.client_uri)
 	uri := parse_uri(x)
-	uri.host == client_uri.host
+	is_subdomain(client_uri.host, uri.host)
 }
 
 violation[{"msg": "missing client_uri"}] {
@@ -168,6 +168,21 @@ reverse_dns_match(host, reverse_dns) {
 
 	# Check that the reverse_dns strictly is a subdomain of the host
 	array.slice(dns_parts, 0, count(host_parts)) == host_parts
+}
+
+# Used to verify that all the various URIs are subdomains of the client_uri
+is_subdomain(host, subdomain) {
+    is_string(host)
+    is_string(subdomain)
+
+    # Split the host
+    host_parts := array.reverse(split(host, "."))
+
+    # Split the subdomain
+    subdomain_parts := array.reverse(split(subdomain, "."))
+
+    # Check that the subdomain strictly is a subdomain of the host
+    array.slice(subdomain_parts, 0, count(host_parts)) == host_parts
 }
 
 valid_native_redirector(x) {

--- a/policies/client_registration.rego
+++ b/policies/client_registration.rego
@@ -172,17 +172,17 @@ reverse_dns_match(host, reverse_dns) {
 
 # Used to verify that all the various URIs are subdomains of the client_uri
 is_subdomain(host, subdomain) {
-    is_string(host)
-    is_string(subdomain)
+	is_string(host)
+	is_string(subdomain)
 
-    # Split the host
-    host_parts := array.reverse(split(host, "."))
+	# Split the host
+	host_parts := array.reverse(split(host, "."))
 
-    # Split the subdomain
-    subdomain_parts := array.reverse(split(subdomain, "."))
+	# Split the subdomain
+	subdomain_parts := array.reverse(split(subdomain, "."))
 
-    # Check that the subdomain strictly is a subdomain of the host
-    array.slice(subdomain_parts, 0, count(host_parts)) == host_parts
+	# Check that the subdomain strictly is a subdomain of the host
+	array.slice(subdomain_parts, 0, count(host_parts)) == host_parts
 }
 
 valid_native_redirector(x) {

--- a/policies/client_registration_test.rego
+++ b/policies/client_registration_test.rego
@@ -435,15 +435,15 @@ test_client_credentials_grant {
 }
 
 test_is_subdomain {
-    is_subdomain("example.com", "example.com")
-    is_subdomain("example.com", "app.example.com")
-    not is_subdomain("example.com", "example.org")
-    not is_subdomain("test.com", "example.com")
+	is_subdomain("example.com", "example.com")
+	is_subdomain("example.com", "app.example.com")
+	not is_subdomain("example.com", "example.org")
+	not is_subdomain("test.com", "example.com")
 }
 
 test_reverse_dns_match {
-    reverse_dns_match("example.com", "com.example")
-    reverse_dns_match("example.com", "com.example.app")
-    not reverse_dns_match("example.com", "org.example")
-    not reverse_dns_match("test.com", "com.example")
+	reverse_dns_match("example.com", "com.example")
+	reverse_dns_match("example.com", "com.example.app")
+	not reverse_dns_match("example.com", "org.example")
+	not reverse_dns_match("test.com", "com.example")
 }

--- a/policies/client_registration_test.rego
+++ b/policies/client_registration_test.rego
@@ -63,6 +63,14 @@ test_tos_uri {
 		"contacts": ["contact@example.com"],
 	}
 
+	# TOS on a subdomain of the client_uri host is allowed
+	allow with input.client_metadata as {
+		"grant_types": [],
+		"client_uri": "https://example.com/",
+		"tos_uri": "https://tos.example.com/",
+		"contacts": ["contact@example.com"],
+	}
+
 	# Host mistmatch, but allowed by the config
 	allow with input.client_metadata as {
 		"grant_types": [],
@@ -106,6 +114,14 @@ test_logo_uri {
 		"contacts": ["contact@example.com"],
 	}
 
+	# Logo on a subdomain of the client_uri host is allowed
+	allow with input.client_metadata as {
+		"grant_types": [],
+		"client_uri": "https://example.com/",
+		"logo_uri": "https://static.example.com/logo.png",
+		"contacts": ["contact@example.com"],
+	}
+
 	# Host mistmatch, but allowed by the config
 	allow with input.client_metadata as {
 		"grant_types": [],
@@ -146,6 +162,14 @@ test_policy_uri {
 		"grant_types": [],
 		"client_uri": "https://example.com/",
 		"policy_uri": "https://example.org/policy",
+		"contacts": ["contact@example.com"],
+	}
+
+	# Policy on a subdomain of the client_uri host is allowed
+	allow with input.client_metadata as {
+		"grant_types": [],
+		"client_uri": "https://example.com/",
+		"policy_uri": "https://policy.example.com/",
 		"contacts": ["contact@example.com"],
 	}
 
@@ -243,6 +267,14 @@ test_web_redirect_uri {
 		"contacts": ["contact@example.com"],
 	}
 		with data.client_registration.allow_host_mismatch as true
+
+	# Redirect URI on a subdomain of the client_uri host is allowed
+	allow with input.client_metadata as {
+		"application_type": "web",
+		"client_uri": "https://example.com/",
+		"redirect_uris": ["https://app.example.com/callback"],
+		"contacts": ["contact@example.com"],
+	}
 
 	# No custom scheme allowed
 	not allow with input.client_metadata as {
@@ -400,4 +432,18 @@ test_client_credentials_grant {
 		"client_uri": "https://example.com/",
 		"contacts": ["contact@example.com"],
 	}
+}
+
+test_is_subdomain {
+    is_subdomain("example.com", "example.com")
+    is_subdomain("example.com", "app.example.com")
+    not is_subdomain("example.com", "example.org")
+    not is_subdomain("test.com", "example.com")
+}
+
+test_reverse_dns_match {
+    reverse_dns_match("example.com", "com.example")
+    reverse_dns_match("example.com", "com.example.app")
+    not reverse_dns_match("example.com", "org.example")
+    not reverse_dns_match("test.com", "com.example")
 }


### PR DESCRIPTION
This does two things:

 - check that hostnames in URIs are not public suffixes, so no one can claim to be `co.uk`, `github.io` or `s3.amazonaws.com`
 - allow subdomains in client registrations, so you can claim to be `https://example.com/`, have your redirect URI be `https://app.example.com/callback` and your logo hosted on `https://assets.example.com/logo.png`