### PR TITLE
Add a way to discover the GraphQL endpoint in the .well-known/openid-configuration

### DIFF
--- a/crates/handlers/src/lib.rs
+++ b/crates/handlers/src/lib.rs
@@ -118,7 +118,7 @@ where
 {
     let mut router = Router::new()
         .route(
-            "/graphql",
+            mas_router::GraphQL::route(),
             get(self::graphql::get).post(self::graphql::post),
         )
         .layer(
@@ -135,7 +135,10 @@ where
         );
 
     if playground {
-        router = router.route("/graphql/playground", get(self::graphql::playground));
+        router = router.route(
+            mas_router::GraphQLPlayground::route(),
+            get(self::graphql::playground),
+        );
     }
 
     router

--- a/crates/handlers/src/oauth2/discovery.rs
+++ b/crates/handlers/src/oauth2/discovery.rs
@@ -25,6 +25,16 @@ use oauth2_types::{
     requests::{Display, GrantType, Prompt, ResponseMode},
     scope,
 };
+use serde::Serialize;
+
+#[derive(Debug, Serialize)]
+struct DiscoveryResponse {
+    #[serde(flatten)]
+    standard: ProviderMetadata,
+
+    #[serde(rename = "org.matrix.matrix-authentication-service.graphql_endpoint")]
+    graphql_endpoint: url::Url,
+}
 
 #[tracing::instrument(name = "handlers.oauth2.discovery.get", skip_all)]
 #[allow(clippy::too_many_lines)]
@@ -122,7 +132,7 @@ pub(crate) async fn get(
 
     let prompt_values_supported = Some(vec![Prompt::None, Prompt::Login, Prompt::Create]);
 
-    let metadata = ProviderMetadata {
+    let standard = ProviderMetadata {
         issuer,
         authorization_endpoint,
         token_endpoint,
@@ -155,7 +165,10 @@ pub(crate) async fn get(
         ..ProviderMetadata::default()
     };
 
-    Json(metadata)
+    Json(DiscoveryResponse {
+        standard,
+        graphql_endpoint: url_builder.graphql_endpoint(),
+    })
 }
 
 #[cfg(test)]

--- a/crates/router/src/endpoints.rs
+++ b/crates/router/src/endpoints.rs
@@ -692,3 +692,17 @@ impl Route for StaticAsset {
         format!("/assets/{}", self.path).into()
     }
 }
+
+/// `GET|POST /graphql`
+pub struct GraphQL;
+
+impl SimpleRoute for GraphQL {
+    const PATH: &'static str = "/graphql";
+}
+
+/// `GET /graphql/playground`
+pub struct GraphQLPlayground;
+
+impl SimpleRoute for GraphQLPlayground {
+    const PATH: &'static str = "/graphql/playground";
+}

--- a/crates/router/src/url_builder.rs
+++ b/crates/router/src/url_builder.rs
@@ -121,6 +121,12 @@ impl UrlBuilder {
         &self.assets_base
     }
 
+    /// GraphQL endpoint
+    #[must_use]
+    pub fn graphql_endpoint(&self) -> Url {
+        self.url_for(&crate::endpoints::GraphQL)
+    }
+
     /// Upstream redirect URI
     #[must_use]
     pub fn upstream_oauth_callback(&self, id: Ulid) -> Url {


### PR DESCRIPTION
This adds a `org.matrix.matrix-authentication-service.graphql_endpoint` key to it

cc @justinbot