### PR TITLE
Add placeholders in the documentation to make browsing the documentation source less confusing

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,5 +7,5 @@ A hosted version is available at <https://matrix-org.github.io/matrix-authentica
 
 ## Links
 
- - Technical documentation for individual crates: [`rustdoc`](./rustdoc/mas_handlers/index.html)
- - UI components: [`storybook`](./storybook/index.html)
+ - Technical documentation for individual crates: [`rustdoc`](./rustdoc/mas_handlers/)
+ - UI components: [`storybook`](./storybook/)

--- a/docs/rustdoc/mas_handlers/README.md
+++ b/docs/rustdoc/mas_handlers/README.md
@@ -1,0 +1,2 @@
+This is a placeholder which is replaced by the built crates technical documentation when building the documentation.
+If you're seeing this, you're probably looking at the documentation source, and should look at the built documentation instead here: <https://matrix-org.github.io/matrix-authentication-service/rustdoc/mas_handlers/>

--- a/docs/storybook/README.md
+++ b/docs/storybook/README.md
@@ -1,0 +1,2 @@
+This is a placeholder which is replaced by the built Storybook when building the documentation.
+If you're seeing this, you're probably looking at the documentation source, and should look at the built documentation instead here: <https://matrix-org.github.io/matrix-authentication-service/storybook/>

--- a/misc/build-docs.sh
+++ b/misc/build-docs.sh
@@ -43,6 +43,7 @@ env RUSTC_BOOTSTRAP=1 \
 rm target/doc/.lock
 
 # Move the Rust documentation within the mdBook
+rm -rf target/book/rustdoc
 mv target/doc target/book/rustdoc
 
 # Build the frontend storybook


### PR DESCRIPTION
Fixes #1078
