### PR TITLE
fix(syn2mas): use postgres host when connecting

### DIFF
--- a/tools/syn2mas/src/db.mts
+++ b/tools/syn2mas/src/db.mts
@@ -40,6 +40,7 @@ export function connectToSynapseDatabase({
   database.args.database && (connection.database = database.args.database);
   database.args.user && (connection.user = database.args.user);
   database.args.password && (connection.password = database.args.password);
+  database.args.host && (connection.host = database.args.host);
   typeof database.args.port === "number" &&
     (connection.port = database.args.port);
   typeof database.args.port === "string" &&
@@ -66,6 +67,7 @@ export function connectToMASDatabase({
     database.database && (connection.database = database.database);
     database.username && (connection.user = database.username);
     database.password && (connection.password = database.password);
+    database.host && (connection.host = database.host);
     database.port && (connection.port = database.port);
   }
 


### PR DESCRIPTION
For dockerized setups syn2mas is unusable, since the database most likely is not accessible on localhost. Therfore we also need to set the actual host parameter of the postgres config when connecting.