### PR TITLE
Better release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,6 +10,9 @@ on:
         description: "What semver bump to use for the release"
         required: true
         options:
+          - "prerelease"
+          - "premajor"
+          - "preminor"
           - "major"
           - "minor"
           - "patch"
@@ -32,21 +35,30 @@ jobs:
           rustup toolchain install stable
           rustup default stable
 
-      - name: Install cargo-edit
-        run: cargo install cargo-edit
+      - name: Extract the current version
+        id: current
+        run: echo "version=$(cargo metadata --format-version 1 | jq -r '.packages[] | select(.name == "mas-cli") | .version')" >> "$GITHUB_OUTPUT"
 
-      - name: Bump version
-        run: cargo set-version --workspace --bump=${{ github.event.inputs.bump }}
+      - name: Compute the new version
+        id: next
+        run: echo "version=$(npx --yes semver@7.5.4 -i "${{ github.event.inputs.bump }}" --preid rc "${{ steps.current.outputs.version }}")" >> "$GITHUB_OUTPUT"
 
-      - name: Extract version
-        id: version
-        run: echo "version=v$(cargo metadata --format-version 1 | jq -r '.packages[] | select(.name == "mas-cli") | .version')" >> "$GITHUB_OUTPUT"
+      - name: Set the crates version
+        run: |
+          sed -i "s/^package.version = .*/package.version = \"${{ steps.next.outputs.version }}\"/" Cargo.toml
+
+      - name: Run `cargo metadata` to make sure the lockfile is up to date
+        run: cargo metadata --format-version 1
+
+      - name: Set the tools/syn2mas version
+        working-directory: tools/syn2mas
+        run: npm version "${{ steps.next.outputs.version }}" --no-git-tag-version
 
       - name: Commit and tag using the GitHub API
         uses: actions/github-script@v6.4.1
         id: commit
         env:
-          VERSION: ${{ steps.version.outputs.version }}
+          VERSION: ${{ steps.next.outputs.version }}
         with:
           result-encoding: string
           # Commit & tag with the actions token, so that they get signed
@@ -55,80 +67,88 @@ jobs:
             const [owner, repo] = process.env.GITHUB_REPOSITORY.split("/");
             const version = process.env.VERSION;
             const parent = context.sha;
-            const cargoToml = await fs.readFile("Cargo.toml");
-            const cargoTomlBlob = await github.rest.git.createBlob({
-              owner,
-              repo,
-              content: cargoToml.toString("base64"),
-              encoding: "base64",
-            });
 
-            const cargoLock = await fs.readFile("Cargo.lock");
-            const cargoLockBlob = await github.rest.git.createBlob({
-              owner,
-              repo,
-              content: cargoLock.toString("base64"),
-              encoding: "base64",
-            });
+            const files = [
+              "Cargo.toml",
+              "Cargo.lock",
+              "tools/syn2mas/package.json",
+              "tools/syn2mas/package-lock.json",
+            ];
 
-            const tree = await github.rest.git.createTree({
-              owner,
-              repo,
-              tree: [{
-                path: "Cargo.toml",
+            const tree = [];
+            for (const file of files) {
+              const content = await fs.readFile(file);
+              const blob = await github.rest.git.createBlob({
+                owner,
+                repo,
+                content: content.toString("base64"),
+                encoding: "base64",
+              });
+              console.log(`Created blob for ${file}:`, blob.data.url);
+
+              tree.push({
+                path: file,
                 mode: "100644",
                 type: "blob",
-                sha: cargoTomlBlob.data.sha,
-              }, {
-                path: "Cargo.lock",
-                mode: "100644",
-                type: "blob",
-                sha: cargoLockBlob.data.sha,
-              }],
+                sha: blob.data.sha,
+              });
+            }
+
+            const treeObject = await github.rest.git.createTree({
+              owner,
+              repo,
+              tree,
               base_tree: parent,
             });
+            console.log("Created tree:", treeObject.data.url);
 
             const commit = await github.rest.git.createCommit({
               owner,
               repo,
               message: version,
               parents: [parent],
-              tree: tree.data.sha,
+              tree: treeObject.data.sha,
             });
+            console.log("Created commit:", commit.data.url);
 
-            await github.rest.git.createTag({
+            const tag = await github.rest.git.createTag({
               owner,
               repo,
-              tag: version,
+              tag: `v${version}`,
               message: version,
               type: "commit",
               object: commit.data.sha,
             });
+            console.log("Created tag:", tag.data.url);
 
             return commit.data.sha;
 
       - name: Update the refs
         uses: actions/github-script@v6.4.1
         env:
-          VERSION: ${{ steps.version.outputs.version }}
+          VERSION: ${{ steps.next.outputs.version }}
           COMMIT: ${{ steps.commit.outputs.result }}
         with:
-          # Update the refs with the bot
+          # Update the refs with the bot token, so that workflows are triggered
           github-token: ${{ secrets.BOT_GITHUB_TOKEN }}
           script: |
             const [owner, repo] = process.env.GITHUB_REPOSITORY.split("/");
             const version = process.env.VERSION;
             const commit = process.env.COMMIT;
-            await github.rest.git.createRef({
-              owner,
-              repo,
-              ref: `refs/tags/${version}`,
-              sha: commit,
-            });
+            const branch = process.env.GITHUB_REF_NAME;
 
-            await github.rest.git.updateRef({
+            const tag = await github.rest.git.createRef({
               owner,
               repo,
-              ref: "heads/main",
+              ref: `refs/tags/v${version}`,
               sha: commit,
             });
+            console.log("Created tag ref:", tag.data.url);
+
+            const ref = await github.rest.git.updateRef({
+              owner,
+              repo,
+              ref: `heads/${branch}`,
+              sha: commit,
+            });
+            console.log("Updated branch ref:", ref.data.url);

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,13 +3,13 @@ default-members = ["crates/cli"]
 members = ["crates/*"]
 resolver = "2"
 
-[workspace.package]
-version = "0.4.1"
-license = "Apache-2.0"
-authors = ["Quentin Gliech <quenting@element.io>"]
-edition = "2021"
-homepage = "https://matrix-org.github.io/matrix-authentication-service/"
-repository = "https://github.com/matrix-org/matrix-authentication-service/"
+# Updated in the CI with a `sed` command
+package.version = "0.4.1"
+package.license = "Apache-2.0"
+package.authors = ["Quentin Gliech <quenting@element.io>"]
+package.edition = "2021"
+package.homepage = "https://matrix-org.github.io/matrix-authentication-service/"
+package.repository = "https://github.com/matrix-org/matrix-authentication-service/"
 
 [workspace.dependencies]
 


### PR DESCRIPTION
This now sets the version of syn2mas as well, and uses `semver` for the version bumps

It also pushes to the branch from where the workflow was released, which allows us to do releases patch on different branches