### PR TITLE
Revert "Skip certificate chain validation when sending emails"

### DIFF
--- a/crates/email/src/transport.rs
+++ b/crates/email/src/transport.rs
@@ -75,30 +75,8 @@ impl Transport {
     ) -> Result<Self, lettre::transport::smtp::Error> {
         let mut t = match mode {
             SmtpMode::Plain => AsyncSmtpTransport::<Tokio1Executor>::builder_dangerous(hostname),
-            SmtpMode::StartTls => {
-                let tls_parameters =
-                    lettre::transport::smtp::client::TlsParameters::builder(hostname.to_owned())
-                        .dangerous_accept_invalid_certs(true)
-                        .build()?;
-
-                AsyncSmtpTransport::<Tokio1Executor>::builder_dangerous(hostname)
-                    .port(lettre::transport::smtp::SUBMISSION_PORT)
-                    .tls(lettre::transport::smtp::client::Tls::Required(
-                        tls_parameters,
-                    ))
-            }
-            SmtpMode::Tls => {
-                let tls_parameters =
-                    lettre::transport::smtp::client::TlsParameters::builder(hostname.to_owned())
-                        .dangerous_accept_invalid_certs(true)
-                        .build()?;
-
-                AsyncSmtpTransport::<Tokio1Executor>::builder_dangerous(hostname)
-                    .port(lettre::transport::smtp::SUBMISSIONS_PORT)
-                    .tls(lettre::transport::smtp::client::Tls::Wrapper(
-                        tls_parameters,
-                    ))
-            }
+            SmtpMode::StartTls => AsyncSmtpTransport::<Tokio1Executor>::starttls_relay(hostname)?,
+            SmtpMode::Tls => AsyncSmtpTransport::<Tokio1Executor>::relay(hostname)?,
         };
 
         if let Some(credentials) = credentials {


### PR DESCRIPTION
Reverts matrix-org/matrix-authentication-service#1997

Now that lettre fixed the CA thing in 0.11.1, we can revert that workaround.

Closes #1996 