### PR TITLE
Allow users to temporarily allow cross-signing reset

### DIFF
--- a/crates/graphql/src/mutations/user.rs
+++ b/crates/graphql/src/mutations/user.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use anyhow::Context as _;
 use async_graphql::{Context, Description, Enum, InputObject, Object, ID};
 use mas_storage::{
     job::{DeactivateUserJob, JobRepositoryExt, ProvisionUserJob},
@@ -22,6 +23,7 @@ use tracing::info;
 use crate::{
     model::{NodeType, User},
     state::ContextExt,
+    UserId,
 };
 
 #[derive(Default)]
@@ -152,6 +154,34 @@ impl SetCanRequestAdminPayload {
     async fn user(&self) -> Option<User> {
         match self {
             Self::Updated(user) => Some(User(user.clone())),
+            Self::NotFound => None,
+        }
+    }
+}
+
+/// The input for the `allowUserCrossSigningReset` mutation.
+#[derive(InputObject)]
+struct AllowUserCrossSigningResetInput {
+    /// The ID of the user to update.
+    user_id: ID,
+}
+
+/// The payload for the `allowUserCrossSigningReset` mutation.
+#[derive(Description)]
+enum AllowUserCrossSigningResetPayload {
+    /// The user was updated.
+    Allowed(mas_data_model::User),
+
+    /// The user was not found.
+    NotFound,
+}
+
+#[Object(use_type_description)]
+impl AllowUserCrossSigningResetPayload {
+    /// The user that was updated.
+    async fn user(&self) -> Option<User> {
+        match self {
+            Self::Allowed(user) => Some(User(user.clone())),
             Self::NotFound => None,
         }
     }
@@ -295,5 +325,37 @@ impl UserMutations {
         repo.save().await?;
 
         Ok(SetCanRequestAdminPayload::Updated(user))
+    }
+
+    /// Temporarily allow user to reset their cross-signing keys.
+    async fn allow_user_cross_signing_reset(
+        &self,
+        ctx: &Context<'_>,
+        input: AllowUserCrossSigningResetInput,
+    ) -> Result<AllowUserCrossSigningResetPayload, async_graphql::Error> {
+        let state = ctx.state();
+        let user_id = NodeType::User.extract_ulid(&input.user_id)?;
+        let requester = ctx.requester();
+
+        if !requester.is_owner_or_admin(&UserId(user_id)) {
+            return Err(async_graphql::Error::new("Unauthorized"));
+        }
+
+        let mut repo = state.repository().await?;
+        let user = repo.user().lookup(user_id).await?;
+        repo.cancel().await?;
+
+        let Some(user) = user else {
+            return Ok(AllowUserCrossSigningResetPayload::NotFound);
+        };
+
+        let conn = state.homeserver_connection();
+        let mxid = conn.mxid(&user.username);
+
+        conn.allow_cross_signing_reset(&mxid)
+            .await
+            .context("Failed to allow cross-signing reset")?;
+
+        Ok(AllowUserCrossSigningResetPayload::Allowed(user))
     }
 }

--- a/crates/matrix/src/lib.rs
+++ b/crates/matrix/src/lib.rs
@@ -282,6 +282,18 @@ pub trait HomeserverConnection: Send + Sync {
     /// Returns an error if the homeserver is unreachable or the displayname
     /// could not be unset.
     async fn unset_displayname(&self, mxid: &str) -> Result<(), Self::Error>;
+
+    /// Temporarily allow a user to reset their cross-signing keys.
+    ///
+    /// # Parameters
+    ///
+    /// * `mxid` - The Matrix ID of the user to allow cross-signing key reset
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the homeserver is unreachable or the cross-signing
+    /// reset could not be allowed.
+    async fn allow_cross_signing_reset(&self, mxid: &str) -> Result<(), Self::Error>;
 }
 
 #[async_trait::async_trait]
@@ -318,5 +330,9 @@ impl<T: HomeserverConnection + Send + Sync + ?Sized> HomeserverConnection for &T
 
     async fn unset_displayname(&self, mxid: &str) -> Result<(), Self::Error> {
         (**self).unset_displayname(mxid).await
+    }
+
+    async fn allow_cross_signing_reset(&self, mxid: &str) -> Result<(), Self::Error> {
+        (**self).allow_cross_signing_reset(mxid).await
     }
 }

--- a/crates/matrix/src/mock.rs
+++ b/crates/matrix/src/mock.rs
@@ -26,6 +26,7 @@ struct MockUser {
     displayname: Option<String>,
     devices: HashSet<String>,
     emails: Option<Vec<String>>,
+    cross_signing_reset_allowed: bool,
 }
 
 /// A mock implementation of a [`HomeserverConnection`], which never fails and
@@ -74,6 +75,7 @@ impl crate::HomeserverConnection for HomeserverConnection {
             displayname: None,
             devices: HashSet::new(),
             emails: None,
+            cross_signing_reset_allowed: false,
         });
 
         anyhow::ensure!(
@@ -134,6 +136,13 @@ impl crate::HomeserverConnection for HomeserverConnection {
         let mut users = self.users.write().await;
         let user = users.get_mut(mxid).context("User not found")?;
         user.displayname = None;
+        Ok(())
+    }
+
+    async fn allow_cross_signing_reset(&self, mxid: &str) -> Result<(), Self::Error> {
+        let mut users = self.users.write().await;
+        let user = users.get_mut(mxid).context("User not found")?;
+        user.cross_signing_reset_allowed = true;
         Ok(())
     }
 }

--- a/frontend/locales/en.json
+++ b/frontend/locales/en.json
@@ -95,16 +95,16 @@
       "total": "Total: {{totalCount}}"
     },
     "reset_cross_signing": {
-      "button": "Allow cross-signing reset",
-      "description": "If you have lost access to all your verified devices and your security key, you can reset your cross-signing keys. Deleting cross-signing keys is permanent, but will allow you to go through the verification process again and set up new keys.",
+      "button": "Allow crypto identity reset",
+      "description": "If you are not signed in anywhere else, and have forgotten or lost all recovery options you’ll need to reset your crypto identity. This means you will lose your existing message history, other users will see that you have reset your identity and you will need to verify your existing devices again.",
       "failure": {
         "description": "This might be a temporary problem, so please try again later. If the problem persists, please contact your server administrator.",
-        "title": "Failed to allow cross-signing"
+        "title": "Failed to allow crypto identity"
       },
-      "heading": "Cross-signing reset",
+      "heading": "Reset crypto identity",
       "success": {
-        "description": "A client can now temporarily reset your account cross-signing keys. Follow the instructions in your client to complete the process.",
-        "title": "Cross-signing reset temporarily allowed"
+        "description": "A client can now temporarily reset your account crypto identity. Follow the instructions in your client to complete the process.",
+        "title": "Crypto identity reset temporarily allowed"
       }
     },
     "selectable_session": {

--- a/frontend/locales/en.json
+++ b/frontend/locales/en.json
@@ -94,6 +94,19 @@
     "pagination_controls": {
       "total": "Total: {{totalCount}}"
     },
+    "reset_cross_signing": {
+      "button": "Allow cross-signing reset",
+      "description": "If you have lost access to all your verified devices and your security key, you can reset your cross-signing keys. Deleting cross-signing keys is permanent, but will allow you to go through the verification process again and set up new keys.",
+      "failure": {
+        "description": "This might be a temporary problem, so please try again later. If the problem persists, please contact your server administrator.",
+        "title": "Failed to allow cross-signing"
+      },
+      "heading": "Cross-signing reset",
+      "success": {
+        "description": "A client can now temporarily reset your account cross-signing keys. Follow the instructions in your client to complete the process.",
+        "title": "Cross-signing reset temporarily allowed"
+      }
+    },
     "selectable_session": {
       "label": "Select session"
     },

--- a/frontend/schema.graphql
+++ b/frontend/schema.graphql
@@ -106,6 +106,26 @@ enum AddUserStatus {
   INVALID
 }
 
+"""
+The input for the `allowUserCrossSigningReset` mutation.
+"""
+input AllowUserCrossSigningResetInput {
+  """
+  The ID of the user to update.
+  """
+  userId: ID!
+}
+
+"""
+The payload for the `allowUserCrossSigningReset` mutation.
+"""
+type AllowUserCrossSigningResetPayload {
+  """
+  The user that was updated.
+  """
+  user: User
+}
+
 type Anonymous implements Node {
   id: ID!
 }
@@ -649,6 +669,12 @@ type Mutation {
   setCanRequestAdmin(
     input: SetCanRequestAdminInput!
   ): SetCanRequestAdminPayload!
+  """
+  Temporarily allow user to reset their cross-signing keys.
+  """
+  allowUserCrossSigningReset(
+    input: AllowUserCrossSigningResetInput!
+  ): AllowUserCrossSigningResetPayload!
   """
   Create a new arbitrary OAuth 2.0 Session.
 

--- a/frontend/src/components/UserProfile/CrossSigningReset.tsx
+++ b/frontend/src/components/UserProfile/CrossSigningReset.tsx
@@ -1,0 +1,95 @@
+// Copyright 2023 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Alert, Button, H3, Text } from "@vector-im/compound-web";
+import { atom, useAtom } from "jotai";
+import { atomFamily } from "jotai/utils";
+import { atomWithMutation } from "jotai-urql";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import { graphql } from "../../gql";
+import BlockList from "../BlockList";
+import LoadingSpinner from "../LoadingSpinner";
+
+const ALLOW_CROSS_SIGING_RESET_MUTATION = graphql(/* GraphQL */ `
+  mutation AllowCrossSigningReset($userId: ID!) {
+    allowUserCrossSigningReset(input: { userId: $userId }) {
+      user {
+        id
+      }
+    }
+  }
+`);
+
+const allowCrossSigningResetFamily = atomFamily((id: string) => {
+  const allowCrossSigingReset = atomWithMutation(
+    ALLOW_CROSS_SIGING_RESET_MUTATION,
+  );
+
+  // A proxy atom which pre-sets the id variable in the mutation
+  const allowCrossSigningResetAtom = atom(
+    (get) => get(allowCrossSigingReset),
+    (_get, set) => set(allowCrossSigingReset, { userId: id }),
+  );
+
+  return allowCrossSigningResetAtom;
+});
+
+const CrossSigningReset: React.FC<{ userId: string }> = ({ userId }) => {
+  const { t } = useTranslation();
+  const [result, allowReset] = useAtom(allowCrossSigningResetFamily(userId));
+  const [inProgress, setInProgress] = useState(false);
+
+  const onClick = (): void => {
+    if (inProgress) return;
+    setInProgress(true);
+    allowReset().finally(() => setInProgress(false));
+  };
+
+  return (
+    <BlockList>
+      <H3>{t("frontend.reset_cross_signing.heading")}</H3>
+      {!result.data && !result.error && (
+        <>
+          <Text className="text-justify">
+            {t("frontend.reset_cross_signing.description")}
+          </Text>
+          <Button kind="destructive" disabled={inProgress} onClick={onClick}>
+            {!!inProgress && <LoadingSpinner inline />}
+            {t("frontend.reset_cross_signing.button")}
+          </Button>
+        </>
+      )}
+      {result.data && (
+        <Alert
+          type="info"
+          title={t("frontend.reset_cross_signing.success.title")}
+        >
+          {t("frontend.reset_cross_signing.success.description")}
+        </Alert>
+      )}
+      {result.error && (
+        <Alert
+          type="critical"
+          title={t("frontend.reset_cross_signing.failure.title")}
+        >
+          {t("frontend.reset_cross_signing.failure.description")}
+        </Alert>
+      )}
+    </BlockList>
+  );
+};
+
+export default CrossSigningReset;

--- a/frontend/src/components/UserProfile/UserProfile.tsx
+++ b/frontend/src/components/UserProfile/UserProfile.tsx
@@ -12,8 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { Separator } from "@vector-im/compound-web";
+
 import BlockList from "../BlockList/BlockList";
 
+import CrossSigningReset from "./CrossSigningReset";
 import UserEmailList from "./UserEmailList";
 import UserName from "./UserName";
 
@@ -22,6 +25,8 @@ const UserProfile: React.FC<{ userId: string }> = ({ userId }) => {
     <BlockList>
       <UserName userId={userId} />
       <UserEmailList userId={userId} />
+      <Separator />
+      <CrossSigningReset userId={userId} />
     </BlockList>
   );
 };

--- a/frontend/src/gql/gql.ts
+++ b/frontend/src/gql/gql.ts
@@ -53,6 +53,8 @@ const documents = {
     types.UserGreetingDocument,
   "\n  mutation AddEmail($userId: ID!, $email: String!) {\n    addEmail(input: { userId: $userId, email: $email }) {\n      status\n      violations\n      email {\n        id\n        ...UserEmail_email\n      }\n    }\n  }\n":
     types.AddEmailDocument,
+  "\n  mutation AllowCrossSigningReset($userId: ID!) {\n    allowUserCrossSigningReset(input: { userId: $userId }) {\n      user {\n        id\n      }\n    }\n  }\n":
+    types.AllowCrossSigningResetDocument,
   "\n  query UserEmailListQuery(\n    $userId: ID!\n    $first: Int\n    $after: String\n    $last: Int\n    $before: String\n  ) {\n    user(id: $userId) {\n      id\n\n      emails(first: $first, after: $after, last: $last, before: $before) {\n        edges {\n          cursor\n          node {\n            id\n            ...UserEmail_email\n          }\n        }\n        totalCount\n        pageInfo {\n          hasNextPage\n          hasPreviousPage\n          startCursor\n          endCursor\n        }\n      }\n    }\n  }\n":
     types.UserEmailListQueryDocument,
   "\n  query UserPrimaryEmail($userId: ID!) {\n    user(id: $userId) {\n      id\n      primaryEmail {\n        id\n      }\n    }\n  }\n":
@@ -213,6 +215,12 @@ export function graphql(
 export function graphql(
   source: "\n  mutation AddEmail($userId: ID!, $email: String!) {\n    addEmail(input: { userId: $userId, email: $email }) {\n      status\n      violations\n      email {\n        id\n        ...UserEmail_email\n      }\n    }\n  }\n",
 ): (typeof documents)["\n  mutation AddEmail($userId: ID!, $email: String!) {\n    addEmail(input: { userId: $userId, email: $email }) {\n      status\n      violations\n      email {\n        id\n        ...UserEmail_email\n      }\n    }\n  }\n"];
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(
+  source: "\n  mutation AllowCrossSigningReset($userId: ID!) {\n    allowUserCrossSigningReset(input: { userId: $userId }) {\n      user {\n        id\n      }\n    }\n  }\n",
+): (typeof documents)["\n  mutation AllowCrossSigningReset($userId: ID!) {\n    allowUserCrossSigningReset(input: { userId: $userId }) {\n      user {\n        id\n      }\n    }\n  }\n"];
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */

--- a/frontend/src/gql/graphql.ts
+++ b/frontend/src/gql/graphql.ts
@@ -1438,6 +1438,18 @@ export type AddEmailMutation = {
   };
 };
 
+export type AllowCrossSigningResetMutationVariables = Exact<{
+  userId: Scalars["ID"]["input"];
+}>;
+
+export type AllowCrossSigningResetMutation = {
+  __typename?: "Mutation";
+  allowUserCrossSigningReset: {
+    __typename?: "AllowUserCrossSigningResetPayload";
+    user?: { __typename?: "User"; id: string } | null;
+  };
+};
+
 export type UserEmailListQueryQueryVariables = Exact<{
   userId: Scalars["ID"]["input"];
   first?: InputMaybe<Scalars["Int"]["input"]>;
@@ -3168,6 +3180,75 @@ export const AddEmailDocument = {
     },
   ],
 } as unknown as DocumentNode<AddEmailMutation, AddEmailMutationVariables>;
+export const AllowCrossSigningResetDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "AllowCrossSigningReset" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: {
+            kind: "Variable",
+            name: { kind: "Name", value: "userId" },
+          },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "allowUserCrossSigningReset" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: {
+                  kind: "ObjectValue",
+                  fields: [
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "userId" },
+                      value: {
+                        kind: "Variable",
+                        name: { kind: "Name", value: "userId" },
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "user" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "id" } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<
+  AllowCrossSigningResetMutation,
+  AllowCrossSigningResetMutationVariables
+>;
 export const UserEmailListQueryDocument = {
   kind: "Document",
   definitions: [

--- a/frontend/src/gql/graphql.ts
+++ b/frontend/src/gql/graphql.ts
@@ -99,6 +99,19 @@ export enum AddUserStatus {
   Invalid = "INVALID",
 }
 
+/** The input for the `allowUserCrossSigningReset` mutation. */
+export type AllowUserCrossSigningResetInput = {
+  /** The ID of the user to update. */
+  userId: Scalars["ID"]["input"];
+};
+
+/** The payload for the `allowUserCrossSigningReset` mutation. */
+export type AllowUserCrossSigningResetPayload = {
+  __typename?: "AllowUserCrossSigningResetPayload";
+  /** The user that was updated. */
+  user?: Maybe<User>;
+};
+
 export type Anonymous = Node & {
   __typename?: "Anonymous";
   id: Scalars["ID"]["output"];
@@ -421,6 +434,8 @@ export type Mutation = {
   addEmail: AddEmailPayload;
   /** Add a user. This is only available to administrators. */
   addUser: AddUserPayload;
+  /** Temporarily allow user to reset their cross-signing keys. */
+  allowUserCrossSigningReset: AllowUserCrossSigningResetPayload;
   /**
    * Create a new arbitrary OAuth 2.0 Session.
    *
@@ -457,6 +472,11 @@ export type MutationAddEmailArgs = {
 /** The mutations root of the GraphQL interface. */
 export type MutationAddUserArgs = {
   input: AddUserInput;
+};
+
+/** The mutations root of the GraphQL interface. */
+export type MutationAllowUserCrossSigningResetArgs = {
+  input: AllowUserCrossSigningResetInput;
 };
 
 /** The mutations root of the GraphQL interface. */

--- a/frontend/src/gql/schema.ts
+++ b/frontend/src/gql/schema.ts
@@ -88,6 +88,22 @@ export default {
       },
       {
         kind: "OBJECT",
+        name: "AllowUserCrossSigningResetPayload",
+        fields: [
+          {
+            name: "user",
+            type: {
+              kind: "OBJECT",
+              name: "User",
+              ofType: null,
+            },
+            args: [],
+          },
+        ],
+        interfaces: [],
+      },
+      {
+        kind: "OBJECT",
         name: "Anonymous",
         fields: [
           {
@@ -1084,6 +1100,29 @@ export default {
               ofType: {
                 kind: "OBJECT",
                 name: "AddUserPayload",
+                ofType: null,
+              },
+            },
+            args: [
+              {
+                name: "input",
+                type: {
+                  kind: "NON_NULL",
+                  ofType: {
+                    kind: "SCALAR",
+                    name: "Any",
+                  },
+                },
+              },
+            ],
+          },
+          {
+            name: "allowUserCrossSigningReset",
+            type: {
+              kind: "NON_NULL",
+              ofType: {
+                kind: "OBJECT",
+                name: "AllowUserCrossSigningResetPayload",
                 ofType: null,
               },
             },


### PR DESCRIPTION
Requires Synapse 1.97.0 or later.

Fixes #1942

A few caveats:

 - clients don't get nice instructions how to go to their account page & reset cross signing
 - there is no feedback about the reset window
 - there is no reauth required
 - we don't detect whether this functionality is available or not

From a user perspective, this now shows at the bottom of the profile page:

![image](https://github.com/matrix-org/matrix-authentication-service/assets/1549952/f9c83c82-0f8d-4e99-81c3-ea31cf0f94cb)

and after clicking the button:

![image](https://github.com/matrix-org/matrix-authentication-service/assets/1549952/7a5de211-eb47-485e-a8e8-11f68772bc9d)

feedback on error (like if Synapse <1.97.0):

![image](https://github.com/matrix-org/matrix-authentication-service/assets/1549952/9cf04c87-0fcd-4202-8d74-9819114f5cc2)
