### PR TITLE
syn2mas: fix the import of email addresses

### DIFF
--- a/tools/syn2mas/Dockerfile
+++ b/tools/syn2mas/Dockerfile
@@ -45,4 +45,4 @@ COPY --from=builder /syn2mas/dist ./dist
 ARG TARGETARCH
 COPY --from=deps /deps/${TARGETARCH}/node_modules ./node_modules
 
-ENTRYPOINT ["/nodejs/bin/node", "dist/index.js"]
+ENTRYPOINT ["/nodejs/bin/node", "--enable-source-maps", "dist/index.js"]

--- a/tools/syn2mas/src/migrate.mts
+++ b/tools/syn2mas/src/migrate.mts
@@ -255,9 +255,7 @@ export async function migrate(): Promise<void> {
         );
         continue;
       }
-      const threePidCreatedAt = new Date(
-        parseInt(`${threePid.added_at}`) * 1000,
-      );
+      const threePidCreatedAt = new Date(parseInt(`${threePid.added_at}`));
       const masUserEmail: MUserEmail = {
         user_email_id: makeUuid(threePidCreatedAt),
         user_id: masUser.user_id,
@@ -267,7 +265,7 @@ export async function migrate(): Promise<void> {
 
       if (threePid.validated_at) {
         masUserEmail.confirmed_at = new Date(
-          parseInt(`${threePid.validated_at}`) * 1000,
+          parseInt(`${threePid.validated_at}`),
         );
       }
 


### PR DESCRIPTION
Synapse uses both millisecond and second timestamps, which leads to confusing.
This fixes a bug where we were wrongly multiplying by 1000 the email timestamps.
