### PR TITLE
cargo-deny: ignore RUSTSEC-2023-0071

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -16,6 +16,10 @@ ignore = [
     # `wasmtime` depends on `mach`
     # PR to migrate to `mach2`: https://github.com/bytecodealliance/wasmtime/pull/6164
     "RUSTSEC-2020-0168",
+
+    # RSA key extraction "Marvin Attack". This is only relevant when using
+    # PKCS#1 v1.5 encryption, which we don't
+    "RUSTSEC-2023-0071"
 ]
 
 [licenses]


### PR DESCRIPTION
This attack is relevant if a client can make the server decrypt through PKCS#1 v1.5 and tightly observe the timing.
Since we're over the network, timing can't be reliably observed, and we don't use PKCS#1 v1.5 encryption, therefore this attack is not relevant to us.
