### PR TITLE
Bump Open Policy Agent version to 0.59.0

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: Setup OPA
         uses: open-policy-agent/setup-opa@v2.1.0
         with:
-          version: 0.58.0
+          version: 0.59.0
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup OPA
         uses: open-policy-agent/setup-opa@v2.1.0
         with:
-          version: 0.58.0
+          version: 0.59.0
 
       - name: Lint policies
         working-directory: ./policies
@@ -202,7 +202,7 @@ jobs:
       - name: Setup OPA
         uses: open-policy-agent/setup-opa@v2.1.0
         with:
-          version: 0.58.0
+          version: 0.59.0
 
       - name: Compile OPA policies
         working-directory: ./policies
@@ -264,7 +264,7 @@ jobs:
       - name: Setup OPA
         uses: open-policy-agent/setup-opa@v2.1.0
         with:
-          version: 0.58.0
+          version: 0.59.0
 
       - name: Compile OPA policies
         working-directory: ./policies

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup OPA
         uses: open-policy-agent/setup-opa@v2.1.0
         with:
-          version: 0.58.0
+          version: 0.59.0
 
       - name: Run OPA tests with coverage
         working-directory: ./policies
@@ -123,7 +123,7 @@ jobs:
       - name: Setup OPA
         uses: open-policy-agent/setup-opa@v2.1.0
         with:
-          version: 0.58.0
+          version: 0.59.0
 
       - name: Compile OPA policies
         working-directory: ./policies

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ ARG RUSTC_VERSION=1.73.0
 # XXX: Upgrade to 0.11.0 blocked by https://github.com/rust-cross/cargo-zigbuild/issues/162
 ARG ZIG_VERSION=0.9.1
 ARG NODEJS_VERSION=20.9.0
-ARG OPA_VERSION=0.58.0
+ARG OPA_VERSION=0.59.0
 ARG CARGO_AUDITABLE_VERSION=0.6.1
 ARG CARGO_CHEF_VERSION=0.1.62
 ARG CARGO_ZIGBUILD_VERSION=0.17.5
@@ -78,9 +78,9 @@ ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
 # Network access: to fetch dependencies
 RUN --network=default \
   cargo install --locked \
-    cargo-chef@=${CARGO_CHEF_VERSION} \
-    cargo-zigbuild@=${CARGO_ZIGBUILD_VERSION} \
-    cargo-auditable@=${CARGO_AUDITABLE_VERSION}
+  cargo-chef@=${CARGO_CHEF_VERSION} \
+  cargo-zigbuild@=${CARGO_ZIGBUILD_VERSION} \
+  cargo-auditable@=${CARGO_AUDITABLE_VERSION}
 
 # Download zig compiler for cross-compilation
 # Network access: to download zig
@@ -92,9 +92,9 @@ RUN --network=default \
 # Network access: to download the targets
 RUN --network=default \
   rustup target add  \
-    --toolchain "${RUSTC_VERSION}" \
-    x86_64-unknown-linux-musl \
-    aarch64-unknown-linux-musl
+  --toolchain "${RUSTC_VERSION}" \
+  x86_64-unknown-linux-musl \
+  aarch64-unknown-linux-musl
 
 # Set the working directory
 WORKDIR /app
@@ -106,7 +106,7 @@ FROM --platform=${BUILDPLATFORM} toolchain AS planner
 COPY ./Cargo.toml ./Cargo.lock /app/
 COPY ./crates /app/crates
 RUN --network=none \
-    cargo chef prepare --recipe-path recipe.json --bin crates/cli
+  cargo chef prepare --recipe-path recipe.json --bin crates/cli
 
 ########################
 ## Actual build stage ##
@@ -118,15 +118,15 @@ COPY --from=planner /app/recipe.json recipe.json
 # Network access: cargo-chef cook fetches the dependencies
 RUN --network=default \
   cargo chef cook \
-    --zigbuild \
-    --bin mas-cli \
-    --release \
-    --recipe-path recipe.json \
-    --no-default-features \
-    --features docker \
-    --target x86_64-unknown-linux-musl \
-    --target aarch64-unknown-linux-musl \
-    --package mas-cli
+  --zigbuild \
+  --bin mas-cli \
+  --release \
+  --recipe-path recipe.json \
+  --no-default-features \
+  --features docker \
+  --target x86_64-unknown-linux-musl \
+  --target aarch64-unknown-linux-musl \
+  --package mas-cli
 
 # Build the rest
 COPY ./Cargo.toml ./Cargo.lock /app/
@@ -135,13 +135,13 @@ ENV SQLX_OFFLINE=true
 # Network access: cargo auditable needs it
 RUN --network=default \
   cargo auditable zigbuild \
-    --locked \
-    --release \
-    --bin mas-cli \
-    --no-default-features \
-    --features docker \
-    --target x86_64-unknown-linux-musl \
-    --target aarch64-unknown-linux-musl
+  --locked \
+  --release \
+  --bin mas-cli \
+  --no-default-features \
+  --features docker \
+  --target x86_64-unknown-linux-musl \
+  --target aarch64-unknown-linux-musl
 
 # Move the binary to avoid having to guess its name in the next stage
 RUN --network=none \

--- a/policies/Makefile
+++ b/policies/Makefile
@@ -1,6 +1,6 @@
 # Set to 1 to run OPA through Docker
 DOCKER := 0
-OPA_DOCKER_IMAGE := docker.io/openpolicyagent/opa:0.58.0-debug
+OPA_DOCKER_IMAGE := docker.io/openpolicyagent/opa:0.59.0-debug
 
 INPUTS := \
 	client_registration.rego \


### PR DESCRIPTION
This upgrades OPA to 0.59.0.
Fixes #2076
