### PR TITLE
Fix docs rename purge to prune

### DIFF
--- a/docs/setup/general.md
+++ b/docs/setup/general.md
@@ -69,18 +69,18 @@ mas-cli config sync
 ```
 
 By default, this will only add new clients and upstream OAuth providers, and will not remove entries that were removed from the configuration file.
-To do so, use the `--purge` option:
+To do so, use the `--prune` option:
 
 ```sh
-mas-cli config sync --purge
+mas-cli config sync --prune
 ```
 
 Before synchronizing the configuration file, it is *recommended* to do it in with the `--dry-run` option to see what will be changed, without committing the changes to the database:
 
 ```sh
 mas-cli config sync --dry-run
-# with the --purge option
-mas-cli config sync --dry-run --purge
+# with the --prune option
+mas-cli config sync --dry-run --prune
 ```
 
 ## Next step


### PR DESCRIPTION
Parameter `purge` seems to be outdated.
[Docs](https://matrix-org.github.io/matrix-authentication-service/setup/general.html#syncing-the-configuration-file-with-the-database)

```
mas-cli config sync --purge
error: unexpected argument '--purge' found

  tip: a similar argument exists: '--prune'

Usage: mas-cli config sync <--prune|--dry-run>
```
