### PR TITLE
Remove `manage register` command from docs

### DIFF
--- a/docs/usage/cli/manage.md
+++ b/docs/usage/cli/manage.md
@@ -2,15 +2,6 @@
 
 Includes admin-related subcommands.
 
-## `manage register <username> <password>`
-
-Register a new user
-
-```console
-$ mas-cli manage register johndoe hunter2
-INFO mas_cli::manage: User registered user=User { id: 2, username: "johndoe" }
-```
-
 ## `manage verify-email <username> <email>`
 
 Mark a user email address as verified


### PR DESCRIPTION
`manage register` is not a valid command anymore.

```
mas-cli manage
Manage the instance

Usage: mas-cli manage [OPTIONS] <COMMAND>

Commands:
  verify-email               Mark email address as verified
  set-password               Set a user password
  issue-compatibility-token  Issue a compatibility token
  provision-all-users        Trigger a provisioning job for all users
  kill-sessions              Kill all sessions for a user
  lock-user                  Lock a user
  unlock-user                Unlock a user
  help                       Print this message or the help of the given subcommand(s)

Options:
  -c, --config <CONFIG>  Path to the configuration file
  -h, --help             Print help
```