### PR TITLE
Prepare workspace to publish OIDC crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3256,7 +3256,6 @@ dependencies = [
  "bytes",
  "chrono",
  "form_urlencoded",
- "futures",
  "futures-util",
  "headers",
  "http 0.2.11",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,36 @@ broken_intra_doc_links = "deny"
 
 [workspace.dependencies]
 
+# Workspace crates
+# TODO: we need to automate the publishing of the workspace crates and version bumps
+mas-axum-utils = { path = "./crates/axum-utils/", version = "=0.7.0" }
+mas-cli = { path = "./crates/cli/", version = "=0.7.0" }
+mas-config = { path = "./crates/config/", version = "=0.7.0" }
+mas-data-model = { path = "./crates/data-model/", version = "=0.7.0" }
+mas-email = { path = "./crates/email/", version = "=0.7.0" }
+mas-graphql = { path = "./crates/graphql/", version = "=0.7.0" }
+mas-handlers = { path = "./crates/handlers/", version = "=0.7.0" }
+mas-http = { path = "./crates/http/", version = "=0.7.0" }
+mas-i18n = { path = "./crates/i18n/", version = "=0.7.0" }
+mas-i18n-scan = { path = "./crates/i18n-scan/", version = "=0.7.0" }
+mas-iana = { path = "./crates/iana/", version = "=0.7.0" }
+mas-iana-codegen = { path = "./crates/iana-codegen/", version = "=0.7.0" }
+mas-jose = { path = "./crates/jose/", version = "=0.7.0" }
+mas-keystore = { path = "./crates/keystore/", version = "=0.7.0" }
+mas-listener = { path = "./crates/listener/", version = "=0.7.0" }
+mas-matrix = { path = "./crates/matrix/", version = "=0.7.0" }
+mas-matrix-synapse = { path = "./crates/matrix-synapse/", version = "=0.7.0" }
+mas-oidc-client = { path = "./crates/oidc-client/", version = "=0.7.0" }
+mas-policy = { path = "./crates/policy/", version = "=0.7.0" }
+mas-router = { path = "./crates/router/", version = "=0.7.0" }
+mas-spa = { path = "./crates/spa/", version = "=0.7.0" }
+mas-storage = { path = "./crates/storage/", version = "=0.7.0" }
+mas-storage-pg = { path = "./crates/storage-pg/", version = "=0.7.0" }
+mas-tasks = { path = "./crates/tasks/", version = "=0.7.0" }
+mas-templates = { path = "./crates/templates/", version = "=0.7.0" }
+mas-tower = { path = "./crates/tower/", version = "=0.7.0" }
+oauth2-types = { path = "./crates/oauth2-types/", version = "=0.7.0" }
+
 # High-level error handling
 [workspace.dependencies.anyhow]
 version = "1.0.75"

--- a/crates/axum-utils/Cargo.toml
+++ b/crates/axum-utils/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
+publish = false
 
 [lints]
 workspace = true
@@ -35,14 +36,14 @@ tracing.workspace = true
 url.workspace = true
 ulid.workspace = true
 
-oauth2-types = { path = "../oauth2-types" }
-mas-data-model = { path = "../data-model" }
-mas-http = { path = "../http", features = ["client"] }
-mas-iana = { path = "../iana" }
-mas-jose = { path = "../jose" }
-mas-keystore = { path = "../keystore" }
-mas-storage = { path = "../storage" }
-mas-templates = { path = "../templates" }
+oauth2-types.workspace = true
+mas-data-model.workspace = true
+mas-http = { workspace = true, features = ["client"] }
+mas-iana.workspace = true
+mas-jose.workspace = true
+mas-keystore.workspace = true
+mas-storage.workspace = true
+mas-templates.workspace = true
 
 [features]
 native-roots = ["mas-http/native-roots"]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
+publish = false
 
 [lints]
 workspace = true
@@ -51,27 +52,27 @@ sentry = { version = "0.31.8", default-features = false, features = ["backtrace"
 sentry-tracing = "0.31.8"
 sentry-tower = { version = "0.31.8", features = ["http"] }
 
-mas-config = { path = "../config" }
-mas-data-model = { path = "../data-model" }
-mas-email = { path = "../email" }
-mas-graphql = { path = "../graphql" }
-mas-handlers = { path = "../handlers", default-features = false }
-mas-http = { path = "../http", default-features = false, features = ["axum", "client"] }
-mas-i18n = { path = "../i18n" }
-mas-iana = { path = "../iana" }
-mas-keystore = { path = "../keystore" }
-mas-listener = { path = "../listener" }
-mas-matrix = { path = "../matrix" }
-mas-matrix-synapse = { path = "../matrix-synapse" }
-mas-policy = { path = "../policy" }
-mas-router = { path = "../router" }
-mas-spa = { path = "../spa" }
-mas-storage = { path = "../storage" }
-mas-storage-pg = { path = "../storage-pg" }
-mas-tasks = { path = "../tasks" }
-mas-templates = { path = "../templates" }
-mas-tower = { path = "../tower" }
-oauth2-types = { path = "../oauth2-types" }
+mas-config.workspace = true
+mas-data-model.workspace = true
+mas-email.workspace = true
+mas-graphql.workspace = true
+mas-handlers = { workspace = true, default-features = false }
+mas-http = { workspace = true, default-features = false, features = ["axum", "client"] }
+mas-i18n.workspace = true
+mas-iana.workspace = true
+mas-keystore.workspace = true
+mas-listener.workspace = true
+mas-matrix.workspace = true
+mas-matrix-synapse.workspace = true
+mas-policy.workspace = true
+mas-router.workspace = true
+mas-spa.workspace = true
+mas-storage.workspace = true
+mas-storage-pg.workspace = true
+mas-tasks.workspace = true
+mas-templates.workspace = true
+mas-tower.workspace = true
+oauth2-types.workspace = true
 
 [features]
 default = ["webpki-roots", "policy-cache"]

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
+publish = false
 
 [lints]
 workspace = true
@@ -37,9 +38,9 @@ rand_chacha = "0.3.1"
 
 indoc = "2.0.4"
 
-mas-jose = { path = "../jose" }
-mas-keystore = { path = "../keystore" }
-mas-iana = { path = "../iana" }
+mas-jose.workspace = true
+mas-keystore.workspace = true
+mas-iana.workspace = true
 
 [features]
 docker = []

--- a/crates/data-model/Cargo.toml
+++ b/crates/data-model/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
+publish = false
 
 [lints]
 workspace = true
@@ -20,6 +21,6 @@ ulid.workspace = true
 rand.workspace = true
 rand_chacha = "0.3.1"
 
-mas-iana = { path = "../iana" }
-mas-jose = { path = "../jose" }
-oauth2-types = { path = "../oauth2-types" }
+mas-iana.workspace = true
+mas-jose.workspace = true
+oauth2-types.workspace = true

--- a/crates/email/Cargo.toml
+++ b/crates/email/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
+publish = false
 
 [lints]
 workspace = true
@@ -16,7 +17,7 @@ tracing.workspace = true
 thiserror.workspace = true
 headers = "0.3.9"
 
-mas-templates = { path = "../templates" }
+mas-templates.workspace = true
 
 [dependencies.lettre]
 version = "0.11.2"

--- a/crates/graphql/Cargo.toml
+++ b/crates/graphql/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
+publish = false
 
 [lints]
 workspace = true
@@ -24,11 +25,11 @@ tower = { version = "0.4.13", features = ["util"] }
 ulid.workspace = true
 url.workspace = true
 
-oauth2-types = { path = "../oauth2-types" }
-mas-data-model = { path = "../data-model" }
-mas-matrix = { path = "../matrix" }
-mas-policy = { path = "../policy" }
-mas-storage = { path = "../storage" }
+oauth2-types.workspace = true
+mas-data-model.workspace = true
+mas-matrix.workspace = true
+mas-policy.workspace = true
+mas-storage.workspace = true
 
 [[bin]]
 name = "schema"

--- a/crates/handlers/Cargo.toml
+++ b/crates/handlers/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
+publish = false
 
 [lints]
 workspace = true
@@ -67,23 +68,23 @@ rand_chacha = "0.3.1"
 headers = "0.3.9"
 ulid.workspace = true
 
-mas-axum-utils = { path = "../axum-utils", default-features = false }
-mas-data-model = { path = "../data-model" }
-mas-graphql = { path = "../graphql" }
-mas-http = { path = "../http", default-features = false }
-mas-i18n = { path = "../i18n" }
-mas-iana = { path = "../iana" }
-mas-jose = { path = "../jose" }
-mas-keystore = { path = "../keystore" }
-mas-matrix = { path = "../matrix" }
-mas-oidc-client = { path = "../oidc-client" }
-mas-policy = { path = "../policy" }
-mas-router = { path = "../router" }
-mas-spa = { path = "../spa" }
-mas-storage = { path = "../storage" }
-mas-storage-pg = { path = "../storage-pg" }
-mas-templates = { path = "../templates" }
-oauth2-types = { path = "../oauth2-types" }
+mas-axum-utils = { workspace = true, default-features = false }
+mas-data-model.workspace = true
+mas-graphql.workspace = true
+mas-http = { workspace = true, default-features = false }
+mas-i18n.workspace = true
+mas-iana.workspace = true
+mas-jose.workspace = true
+mas-keystore.workspace = true
+mas-matrix.workspace = true
+mas-oidc-client.workspace = true
+mas-policy.workspace = true
+mas-router.workspace = true
+mas-spa.workspace = true
+mas-storage.workspace = true
+mas-storage-pg.workspace = true
+mas-templates.workspace = true
+oauth2-types.workspace = true
 
 [dev-dependencies]
 insta = "1.34.0"

--- a/crates/http/Cargo.toml
+++ b/crates/http/Cargo.toml
@@ -34,7 +34,7 @@ tracing.workspace = true
 tracing-opentelemetry.workspace = true
 webpki-roots = { version = "0.25.3", optional = true }
 
-mas-tower = { path = "../tower" }
+mas-tower.workspace = true
 
 [dev-dependencies]
 anyhow.workspace = true

--- a/crates/i18n-scan/Cargo.toml
+++ b/crates/i18n-scan/Cargo.toml
@@ -6,6 +6,7 @@ authors.workspace = true
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true
+publish = false
 
 [lints]
 workspace = true
@@ -19,4 +20,4 @@ tracing-subscriber.workspace = true
 tracing.workspace = true
 walkdir = "2.4.0"
 
-mas-i18n = { path = "../i18n" }
+mas-i18n.workspace = true

--- a/crates/i18n/Cargo.toml
+++ b/crates/i18n/Cargo.toml
@@ -6,6 +6,7 @@ authors.workspace = true
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true
+publish = false
 
 [lints]
 workspace = true

--- a/crates/iana-codegen/Cargo.toml
+++ b/crates/iana-codegen/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
+publish = false
 
 [lints]
 workspace = true

--- a/crates/jose/Cargo.toml
+++ b/crates/jose/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
+publish = false
 
 [lints]
 workspace = true
@@ -34,7 +35,7 @@ thiserror.workspace = true
 tracing.workspace = true
 url.workspace = true
 
-mas-iana = { path = "../iana" }
+mas-iana.workspace = true
 
 [dev-dependencies]
 insta = { version = "1.34.0" }

--- a/crates/keystore/Cargo.toml
+++ b/crates/keystore/Cargo.toml
@@ -31,8 +31,8 @@ generic-array = "0.14.7"
 chacha20poly1305 = { version = "0.10.1", features = ["std"] }
 base64ct = "1.6.0"
 
-mas-iana = { path = "../iana" }
-mas-jose = { path = "../jose" }
+mas-iana.workspace = true
+mas-jose.workspace = true
 
 [dev-dependencies]
 insta = { version = "1.34.0", features = ["yaml"] }

--- a/crates/listener/Cargo.toml
+++ b/crates/listener/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
+publish = false
 
 [lints]
 workspace = true

--- a/crates/matrix-synapse/Cargo.toml
+++ b/crates/matrix-synapse/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
+publish = false
 
 [lints]
 workspace = true
@@ -19,6 +20,6 @@ tower = { version = "0.4.13", features = ["util"] }
 tracing.workspace = true
 url.workspace = true
 
-mas-axum-utils = { path = "../axum-utils" }
-mas-http = { path = "../http" }
-mas-matrix = { path = "../matrix" }
+mas-axum-utils.workspace = true
+mas-http.workspace = true
+mas-matrix.workspace = true

--- a/crates/matrix/Cargo.toml
+++ b/crates/matrix/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
+publish = false
 
 [lints]
 workspace = true

--- a/crates/oauth2-types/Cargo.toml
+++ b/crates/oauth2-types/Cargo.toml
@@ -23,8 +23,8 @@ sha2 = "0.10.8"
 data-encoding = "2.5.0"
 thiserror.workspace = true
 
-mas-iana = { path = "../iana" }
-mas-jose = { path = "../jose" }
+mas-iana.workspace = true
+mas-jose.workspace = true
 
 [dev-dependencies]
 assert_matches = "1.5.0"

--- a/crates/oidc-client/Cargo.toml
+++ b/crates/oidc-client/Cargo.toml
@@ -27,7 +27,6 @@ base64ct = { version = "1.6.0", features = ["std"] }
 bytes = "1.5.0"
 chrono.workspace = true
 form_urlencoded = "1.2.1"
-futures = "0.3.29"
 futures-util = "0.3.29"
 headers = "0.3.9"
 http.workspace = true
@@ -45,11 +44,11 @@ tower = { version = "0.4.13", features = ["full"] }
 tracing.workspace = true
 url.workspace = true
 
-mas-http = { path = "../http" }
-mas-iana = { path = "../iana" }
-mas-jose = { path = "../jose" }
-mas-keystore = { path = "../keystore", optional = true }
-oauth2-types = { path = "../oauth2-types" }
+mas-http.workspace = true
+mas-iana.workspace = true
+mas-jose.workspace = true
+mas-keystore = { workspace = true, optional = true }
+oauth2-types.workspace = true
 
 # Default http service
 http-body = { version = "0.4.5", optional = true }
@@ -71,6 +70,6 @@ optional = true
 [dev-dependencies]
 assert_matches = "1.5.0"
 bitflags = "2.4.1"
-mas-keystore = { path = "../keystore" }
+mas-keystore.workspace = true
 rand_chacha = "0.3.1"
 wiremock = "0.5.21"

--- a/crates/policy/Cargo.toml
+++ b/crates/policy/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
+publish = false
 
 [lints]
 workspace = true
@@ -21,8 +22,8 @@ tokio = { version = "1.34.0", features = ["io-util", "rt"] }
 tracing.workspace = true
 wasmtime = { version = "15.0.0", default-features = false, features = ["async", "cranelift"] }
 
-mas-data-model = { path = "../data-model" }
-oauth2-types = { path = "../oauth2-types" }
+mas-data-model.workspace = true
+oauth2-types.workspace = true
 
 [dev-dependencies]
 tokio = { version = "1.34.0", features = ["fs", "rt", "macros"] }

--- a/crates/router/Cargo.toml
+++ b/crates/router/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
+publish = false
 
 [lints]
 workspace = true

--- a/crates/spa/Cargo.toml
+++ b/crates/spa/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
+publish = false
 
 [lints]
 workspace = true

--- a/crates/storage-pg/Cargo.toml
+++ b/crates/storage-pg/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
+publish = false
 
 [lints]
 workspace = true
@@ -28,8 +29,8 @@ url.workspace = true
 uuid = "1.6.1"
 ulid = { workspace = true, features = ["uuid"] }
 
-oauth2-types = { path = "../oauth2-types" }
-mas-storage = { path = "../storage" }
-mas-data-model = { path = "../data-model" }
-mas-iana = { path = "../iana" }
-mas-jose = { path = "../jose" }
+oauth2-types.workspace = true
+mas-storage.workspace = true
+mas-data-model.workspace = true
+mas-iana.workspace = true
+mas-jose.workspace = true

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
+publish = false
 
 [lints]
 workspace = true
@@ -26,7 +27,7 @@ tracing-opentelemetry.workspace = true
 url.workspace = true
 ulid.workspace = true
 
-oauth2-types = { path = "../oauth2-types" }
-mas-data-model = { path = "../data-model" }
-mas-iana = { path = "../iana" }
-mas-jose = { path = "../jose" }
+oauth2-types.workspace = true
+mas-data-model.workspace = true
+mas-iana.workspace = true
+mas-jose.workspace = true

--- a/crates/tasks/Cargo.toml
+++ b/crates/tasks/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
+publish = false
 
 [lints]
 workspace = true
@@ -33,11 +34,11 @@ url.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 
-mas-data-model = { path = "../data-model" }
-mas-email = { path = "../email" }
-mas-i18n = { path = "../i18n" }
-mas-matrix = { path = "../matrix" }
-mas-storage = { path = "../storage" }
-mas-storage-pg = { path = "../storage-pg" }
-mas-templates = { path = "../templates" }
-mas-tower = { path = "../tower" }
+mas-data-model.workspace = true
+mas-email.workspace = true
+mas-i18n.workspace = true
+mas-matrix.workspace = true
+mas-storage.workspace = true
+mas-storage-pg.workspace = true
+mas-templates.workspace = true
+mas-tower.workspace = true

--- a/crates/templates/Cargo.toml
+++ b/crates/templates/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
+publish = false
 
 [lints]
 workspace = true
@@ -32,8 +33,8 @@ http.workspace = true
 ulid.workspace = true
 rand.workspace = true
 
-oauth2-types = { path = "../oauth2-types" }
-mas-data-model = { path = "../data-model" }
-mas-i18n = { path = "../i18n" }
-mas-router = { path = "../router" }
-mas-spa = { path = "../spa" }
+oauth2-types.workspace = true
+mas-data-model.workspace = true
+mas-i18n.workspace = true
+mas-router.workspace = true
+mas-spa.workspace = true


### PR DESCRIPTION
This prepare the publishing of a subset of crates on crates.io, by:

 - marking with `publish = false` crates we don't want to publish yet
 - set all the internal dependencies on the workspace level, with an exact version