### PR TITLE
Allow Synapse OIDC provider idp_name to be null

### DIFF
--- a/tools/syn2mas/src/schemas/synapse.mts
+++ b/tools/syn2mas/src/schemas/synapse.mts
@@ -36,7 +36,7 @@ const databaseConfig = z.union([sqlite3DatabaseConfig, psycopg2DatabaseConfig]);
 
 const oidcProviderConfig = z.object({
   idp_id: z.string(),
-  idp_name: z.string(),
+  idp_name: z.string().nullish(),
   issuer: z.string(),
   client_id: z.string(),
   scopes: z.array(z.string()),


### PR DESCRIPTION
It's not required, though technically it should be given if there are multiple providers.

Synapse config loads it defaulted to `OIDC` if not given: https://github.com/matrix-org/synapse/blob/be65a8ec0195955c15fdb179c9158b187638e39a/synapse/config/oidc.py#L299-L299

`syn2mas` uses this schema when loading the Synapse config file and will incorrectly mandate an `idp_name` value is set.