### PR TITLE
syn2mas: Skip access tokens that don't have a device ID

### DIFF
--- a/docs/setup/migration.md
+++ b/docs/setup/migration.md
@@ -8,11 +8,10 @@ Features that are provided to support this include:
 
 - Ability to import existing password hashes from Synapse
 - Ability to import existing sessions and devices
-- Ability to import existing access tokens
+- Ability to import existing access tokens linked to devices (ie not including short-lived admin puppeted access tokens)
 - Ability to import existing upstream IdP subject ID mappings
 - Provides a compatibility layer for legacy Matrix authentication
 
-If
 There will be tools to help with the migration process itself. But these aren't quite ready yet.
 
 ## Preparing for the migration

--- a/tools/syn2mas/src/advisor.mts
+++ b/tools/syn2mas/src/advisor.mts
@@ -161,7 +161,7 @@ export async function advisor(): Promise<void> {
   );
   if (accessTokensWithoutDeviceId > 0) {
     error(
-      `Synapse database contains ${accessTokensWithoutDeviceId} access tokens without an associated device_id which aren't supported during migration`,
+      `Synapse database contains ${accessTokensWithoutDeviceId} access tokens without an associated device_id which will be skipped during migration`,
     );
   }
 

--- a/tools/syn2mas/src/migrate.mts
+++ b/tools/syn2mas/src/migrate.mts
@@ -337,16 +337,11 @@ export async function migrate(): Promise<void> {
       const synapseAccessTokens = await synapse
         .select("*")
         .from<SAccessToken>("access_tokens")
-        .where({ user_id: user.name });
+        .where({ user_id: user.name })
+        // Skip tokens without devices.
+        // These can be for example short-lived tokens created by puppeting a user over the Synapse admin API.
+        .whereNotNull("device_id");
       for (const accessToken of synapseAccessTokens) {
-        if (!accessToken.device_id) {
-          warningsForUser += 1;
-          warn(
-            `Skipping access token ${accessToken.token} for user ${user.name} with no device_id`,
-          );
-          continue;
-        }
-
         const tokenCreatedAt = accessToken.last_validated
           ? new Date(parseInt(`${accessToken.last_validated}`))
           : masUser.created_at;

--- a/tools/syn2mas/src/types/SAccessToken.d.ts
+++ b/tools/syn2mas/src/types/SAccessToken.d.ts
@@ -32,7 +32,7 @@ CREATE TABLE access_tokens (
 export interface SAccessToken {
   id: Id<SAccessToken>;
   user_id: SynapseUserId;
-  device_id?: string;
+  device_id: string;
   token: string;
   valid_until_ms?: number;
   puppets_user_id?: SynapseUserId;


### PR DESCRIPTION
These can't be migrated. They are likely enirely valid tokens created by puppeting a user via the Synapse admin api. Treating them as fatal errors will make it impossible to migrate any host that has ever used this admin API feature.