### PR TITLE
Make the user agree to T&C during registration & record which document they agreed to

### DIFF
--- a/crates/cli/src/commands/server.rs
+++ b/crates/cli/src/commands/server.rs
@@ -140,6 +140,7 @@ impl Options {
         );
 
         let site_config = SiteConfig {
+            tos_uri: config.branding.tos_uri.clone(),
             access_token_ttl: config.experimental.access_token_ttl,
             compat_token_ttl: config.experimental.compat_token_ttl,
         };

--- a/crates/handlers/src/lib.rs
+++ b/crates/handlers/src/lib.rs
@@ -319,6 +319,7 @@ where
     HttpClientFactory: FromRef<S>,
     PasswordManager: FromRef<S>,
     MetadataCache: FromRef<S>,
+    SiteConfig: FromRef<S>,
     BoxClock: FromRequestParts<S>,
     BoxRng: FromRequestParts<S>,
     Policy: FromRequestParts<S>,

--- a/crates/handlers/src/site_config.rs
+++ b/crates/handlers/src/site_config.rs
@@ -13,12 +13,14 @@
 // limitations under the License.
 
 use chrono::Duration;
+use url::Url;
 
 /// Random site configuration we don't now where to put yet.
 #[derive(Debug, Clone)]
 pub struct SiteConfig {
     pub access_token_ttl: Duration,
     pub compat_token_ttl: Duration,
+    pub tos_uri: Option<Url>,
 }
 
 impl Default for SiteConfig {
@@ -26,6 +28,7 @@ impl Default for SiteConfig {
         Self {
             access_token_ttl: Duration::minutes(5),
             compat_token_ttl: Duration::minutes(5),
+            tos_uri: None,
         }
     }
 }

--- a/crates/handlers/src/test_utils.rs
+++ b/crates/handlers/src/test_utils.rs
@@ -119,7 +119,9 @@ impl TestState {
 
         let url_builder = UrlBuilder::new("https://example.com/".parse()?, None, None);
 
-        let site_branding = SiteBranding::new("example.com").with_service_name("Example");
+        let site_branding = SiteBranding::new("example.com")
+            .with_service_name("Example")
+            .with_tos_uri("https://example.com/tos");
 
         let templates = Templates::load(
             workspace_root.join("templates"),
@@ -154,7 +156,10 @@ impl TestState {
 
         let http_client_factory = HttpClientFactory::new().await?;
 
-        let site_config = SiteConfig::default();
+        let site_config = SiteConfig {
+            tos_uri: Some("https://example.com/tos".parse().unwrap()),
+            ..SiteConfig::default()
+        };
 
         let clock = Arc::new(MockClock::default());
         let rng = Arc::new(Mutex::new(ChaChaRng::seed_from_u64(42)));

--- a/crates/storage-pg/.sqlx/query-037fae6964130343453ef607791c4c3deaa01b5aaa091d3a3487caf3e2634daf.json
+++ b/crates/storage-pg/.sqlx/query-037fae6964130343453ef607791c4c3deaa01b5aaa091d3a3487caf3e2634daf.json
@@ -1,0 +1,17 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO user_terms (user_terms_id, user_id, terms_url, created_at)\n            VALUES ($1, $2, $3, $4)\n            ON CONFLICT (user_id, terms_url) DO NOTHING\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid",
+        "Text",
+        "Timestamptz"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "037fae6964130343453ef607791c4c3deaa01b5aaa091d3a3487caf3e2634daf"
+}

--- a/crates/storage-pg/migrations/20240207100003_user_terms.sql
+++ b/crates/storage-pg/migrations/20240207100003_user_terms.sql
@@ -1,0 +1,32 @@
+-- Copyright 2024 The Matrix.org Foundation C.I.C.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- Track when users have accepted the terms of service, and which version they accepted.
+CREATE TABLE user_terms (
+    "user_terms_id" UUID NOT NULL
+        PRIMARY KEY,
+
+    -- The user who accepted the terms of service.
+    "user_id" UUID NOT NULL
+        REFERENCES users (user_id) ON DELETE CASCADE,
+
+    -- The URL of the terms of service that the user accepted.
+    "terms_url" TEXT NOT NULL,
+
+    -- When the user accepted the terms of service.
+    "created_at" TIMESTAMP WITH TIME ZONE NOT NULL,
+
+    -- Unique constraint to ensure that a user can only accept a given version of the terms once.
+    UNIQUE ("user_id", "terms_url")
+);

--- a/crates/storage-pg/src/repository.rs
+++ b/crates/storage-pg/src/repository.rs
@@ -54,7 +54,7 @@ use crate::{
     },
     user::{
         PgBrowserSessionRepository, PgUserEmailRepository, PgUserPasswordRepository,
-        PgUserRepository,
+        PgUserRepository, PgUserTermsRepository,
     },
     DatabaseError,
 };
@@ -177,6 +177,12 @@ where
         &'c mut self,
     ) -> Box<dyn UserPasswordRepository<Error = Self::Error> + 'c> {
         Box::new(PgUserPasswordRepository::new(self.conn.as_mut()))
+    }
+
+    fn user_terms<'c>(
+        &'c mut self,
+    ) -> Box<dyn mas_storage::user::UserTermsRepository<Error = Self::Error> + 'c> {
+        Box::new(PgUserTermsRepository::new(self.conn.as_mut()))
     }
 
     fn browser_session<'c>(

--- a/crates/storage-pg/src/user/mod.rs
+++ b/crates/storage-pg/src/user/mod.rs
@@ -29,13 +29,14 @@ use crate::{tracing::ExecuteExt, DatabaseError};
 mod email;
 mod password;
 mod session;
+mod terms;
 
 #[cfg(test)]
 mod tests;
 
 pub use self::{
     email::PgUserEmailRepository, password::PgUserPasswordRepository,
-    session::PgBrowserSessionRepository,
+    session::PgBrowserSessionRepository, terms::PgUserTermsRepository,
 };
 
 /// An implementation of [`UserRepository`] for a PostgreSQL connection

--- a/crates/storage-pg/src/user/terms.rs
+++ b/crates/storage-pg/src/user/terms.rs
@@ -1,0 +1,82 @@
+// Copyright 2024 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use async_trait::async_trait;
+use mas_data_model::User;
+use mas_storage::{user::UserTermsRepository, Clock};
+use rand::RngCore;
+use sqlx::PgConnection;
+use ulid::Ulid;
+use url::Url;
+use uuid::Uuid;
+
+use crate::{tracing::ExecuteExt, DatabaseError};
+
+/// An implementation of [`UserTermsRepository`] for a PostgreSQL connection
+pub struct PgUserTermsRepository<'c> {
+    conn: &'c mut PgConnection,
+}
+
+impl<'c> PgUserTermsRepository<'c> {
+    /// Create a new [`PgUserTermsRepository`] from an active PostgreSQL
+    /// connection
+    pub fn new(conn: &'c mut PgConnection) -> Self {
+        Self { conn }
+    }
+}
+
+#[async_trait]
+impl<'c> UserTermsRepository for PgUserTermsRepository<'c> {
+    type Error = DatabaseError;
+
+    #[tracing::instrument(
+        name = "db.user_terms.accept_terms",
+        skip_all,
+        fields(
+            db.statement,
+            %user.id,
+            user_terms.id,
+            %user_terms.url = terms_url.as_str(),
+        ),
+        err,
+    )]
+    async fn accept_terms(
+        &mut self,
+        rng: &mut (dyn RngCore + Send),
+        clock: &dyn Clock,
+        user: &User,
+        terms_url: Url,
+    ) -> Result<(), Self::Error> {
+        let created_at = clock.now();
+        let id = Ulid::from_datetime_with_source(created_at.into(), rng);
+        tracing::Span::current().record("user_terms.id", tracing::field::display(id));
+
+        sqlx::query!(
+            r#"
+            INSERT INTO user_terms (user_terms_id, user_id, terms_url, created_at)
+            VALUES ($1, $2, $3, $4)
+            ON CONFLICT (user_id, terms_url) DO NOTHING
+            "#,
+            Uuid::from(id),
+            Uuid::from(user.id),
+            terms_url.as_str(),
+            created_at,
+        )
+        .traced()
+        .execute(&mut *self.conn)
+        .await?;
+
+        Ok(())
+    }
+}

--- a/crates/storage/src/repository.rs
+++ b/crates/storage/src/repository.rs
@@ -30,7 +30,10 @@ use crate::{
         UpstreamOAuthLinkRepository, UpstreamOAuthProviderRepository,
         UpstreamOAuthSessionRepository,
     },
-    user::{BrowserSessionRepository, UserEmailRepository, UserPasswordRepository, UserRepository},
+    user::{
+        BrowserSessionRepository, UserEmailRepository, UserPasswordRepository, UserRepository,
+        UserTermsRepository,
+    },
     MapErr,
 };
 
@@ -146,6 +149,9 @@ pub trait RepositoryAccess: Send {
     fn user_password<'c>(&'c mut self)
         -> Box<dyn UserPasswordRepository<Error = Self::Error> + 'c>;
 
+    /// Get an [`UserTermsRepository`]
+    fn user_terms<'c>(&'c mut self) -> Box<dyn UserTermsRepository<Error = Self::Error> + 'c>;
+
     /// Get a [`BrowserSessionRepository`]
     fn browser_session<'c>(
         &'c mut self,
@@ -231,6 +237,7 @@ mod impls {
         },
         user::{
             BrowserSessionRepository, UserEmailRepository, UserPasswordRepository, UserRepository,
+            UserTermsRepository,
         },
         MapErr, Repository, RepositoryTransaction,
     };
@@ -313,6 +320,10 @@ mod impls {
             &'c mut self,
         ) -> Box<dyn UserPasswordRepository<Error = Self::Error> + 'c> {
             Box::new(MapErr::new(self.inner.user_password(), &mut self.mapper))
+        }
+
+        fn user_terms<'c>(&'c mut self) -> Box<dyn UserTermsRepository<Error = Self::Error> + 'c> {
+            Box::new(MapErr::new(self.inner.user_terms(), &mut self.mapper))
         }
 
         fn browser_session<'c>(
@@ -443,6 +454,10 @@ mod impls {
             &'c mut self,
         ) -> Box<dyn UserPasswordRepository<Error = Self::Error> + 'c> {
             (**self).user_password()
+        }
+
+        fn user_terms<'c>(&'c mut self) -> Box<dyn UserTermsRepository<Error = Self::Error> + 'c> {
+            (**self).user_terms()
         }
 
         fn browser_session<'c>(

--- a/crates/storage/src/user/mod.rs
+++ b/crates/storage/src/user/mod.rs
@@ -24,11 +24,13 @@ use crate::{repository_impl, Clock};
 mod email;
 mod password;
 mod session;
+mod terms;
 
 pub use self::{
     email::{UserEmailFilter, UserEmailRepository},
     password::UserPasswordRepository,
     session::{BrowserSessionFilter, BrowserSessionRepository},
+    terms::UserTermsRepository,
 };
 
 /// A [`UserRepository`] helps interacting with [`User`] saved in the storage

--- a/crates/storage/src/user/terms.rs
+++ b/crates/storage/src/user/terms.rs
@@ -19,7 +19,8 @@ use url::Url;
 
 use crate::{repository_impl, Clock};
 
-/// A [`UserTermsRepository`] helps interacting with the terms of service agreed by a [`User`]
+/// A [`UserTermsRepository`] helps interacting with the terms of service agreed
+/// by a [`User`]
 #[async_trait]
 pub trait UserTermsRepository: Send + Sync {
     /// The error type returned by the repository

--- a/crates/storage/src/user/terms.rs
+++ b/crates/storage/src/user/terms.rs
@@ -1,0 +1,57 @@
+// Copyright 2024 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use async_trait::async_trait;
+use mas_data_model::User;
+use rand_core::RngCore;
+use url::Url;
+
+use crate::{repository_impl, Clock};
+
+/// A [`UserTermsRepository`] helps interacting with the terms of service agreed by a [`User`]
+#[async_trait]
+pub trait UserTermsRepository: Send + Sync {
+    /// The error type returned by the repository
+    type Error;
+
+    /// Accept the terms of service by a [`User`]
+    ///
+    /// # Parameters
+    ///
+    /// * `rng`: A random number generator used to generate IDs
+    /// * `clock`: The clock used to generate timestamps
+    /// * `user`: The [`User`] accepting the terms
+    /// * `terms_url`: The URL of the terms of service the user is accepting
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Self::Error`] if the underlying repository fails
+    async fn accept_terms(
+        &mut self,
+        rng: &mut (dyn RngCore + Send),
+        clock: &dyn Clock,
+        user: &User,
+        terms_url: Url,
+    ) -> Result<(), Self::Error>;
+}
+
+repository_impl!(UserTermsRepository:
+    async fn accept_terms(
+        &mut self,
+        rng: &mut (dyn RngCore + Send),
+        clock: &dyn Clock,
+        user: &User,
+        terms_url: Url,
+    ) -> Result<(), Self::Error>;
+);

--- a/crates/templates/src/context.rs
+++ b/crates/templates/src/context.rs
@@ -493,12 +493,15 @@ pub enum RegisterFormField {
 
     /// The password confirmation field
     PasswordConfirm,
+
+    /// The terms of service agreement field
+    AcceptTerms,
 }
 
 impl FormField for RegisterFormField {
     fn keep(&self) -> bool {
         match self {
-            Self::Username | Self::Email => true,
+            Self::Username | Self::Email | Self::AcceptTerms => true,
             Self::Password | Self::PasswordConfirm => false,
         }
     }
@@ -974,12 +977,15 @@ impl TemplateContext for UpstreamSuggestLink {
 pub enum UpstreamRegisterFormField {
     /// The username field
     Username,
+
+    /// Accept the terms of service
+    AcceptTerms,
 }
 
 impl FormField for UpstreamRegisterFormField {
     fn keep(&self) -> bool {
         match self {
-            Self::Username => true,
+            Self::Username | Self::AcceptTerms => true,
         }
     }
 }

--- a/templates/components/field.html
+++ b/templates/components/field.html
@@ -27,7 +27,7 @@ limitations under the License.
   {%- if value %} value="{{ value }}" {% endif %}
 {%- endmacro %}
 
-{% macro field(label, name, form_state=false, class="") %}
+{% macro field(label, name, form_state=false, class="", inline=false) %}
   {% set field_id = new_id() %}
   {% if not form_state %}
     {% set form_state = {"fields": {}} %}
@@ -41,12 +41,24 @@ limitations under the License.
     "value": state.value,
   } %}
 
-  <div class="cpd-form-field {{ class }}">
-    <label class="cpd-form-label" for="{{ field.id }}"
-      {%- if field.errors is not empty %} data-invalid{% endif -%}
-    >{{ label }}</label>
+  <div class="{% if inline %}cpd-form-inline-field{% else %}cpd-form-field{% endif %} {{ class }}">
+    {% if not inline %}
+      <label class="cpd-form-label" for="{{ field.id }}"
+        {%- if field.errors is not empty %} data-invalid{% endif -%}
+      >{{ label }}</label>
 
-    {{ caller(field) }}
+      {{ caller(field) }}
+    {% else %}
+      <div class="cpd-form-inline-field-control">
+        {{ caller(field) }}
+      </div>
+
+      <div class="cpd-form-inline-field-body">
+        <label class="cpd-form-label" for="{{ field.id }}"
+          {%- if field.errors is not empty %} data-invalid{% endif -%}
+        >{{ label }}</label>
+    {% endif %}
+
 
     {% if field.errors is not empty %}
       {% for error in field.errors %}
@@ -64,6 +76,10 @@ limitations under the License.
           </div>
         {% endif %}
       {% endfor %}
+    {% endif %}
+
+    {% if inline %}
+      </div>
     {% endif %}
   </div>
 {% endmacro %}

--- a/templates/pages/register.html
+++ b/templates/pages/register.html
@@ -56,6 +56,19 @@ limitations under the License.
         <input {{ field.attributes(f) }} class="cpd-text-control" type="password" autocomplete="new-password" required />
       {% endcall %}
 
+      {% if branding.tos_uri %}
+        {% call(f) field.field(label=_("mas.register.terms_of_service", tos_uri=branding.tos_uri), name="accept_terms", form_state=form, inline=true, class="my-4") %}
+          <div class="cpd-form-inline-field-control">
+            <div class="cpd-checkbox-container">
+              <input {{ field.attributes(f) }} class="cpd-checkbox-input" type="checkbox" required />
+              <div class="cpd-checkbox-ui">
+                {{ icon.check() }}
+              </div>
+            </div>
+          </div>
+        {% endcall %}
+      {% endif %}
+
       {{ button.button(text=_("action.continue")) }}
     </form>
 

--- a/templates/pages/upstream_oauth2/do_register.html
+++ b/templates/pages/upstream_oauth2/do_register.html
@@ -140,6 +140,20 @@ limitations under the License.
       </div>
     {% endif %}
 
+    {% if branding.tos_uri %}
+      {% call(f) field.field(label=_("mas.register.terms_of_service", tos_uri=branding.tos_uri), name="accept_terms", form_state=form_state, inline=true, class="my-4") %}
+        <div class="cpd-form-inline-field-control">
+          <div class="cpd-checkbox-container">
+            <input {{ field.attributes(f) }} class="cpd-checkbox-input" type="checkbox" required />
+            <div class="cpd-checkbox-ui">
+              {{ icon.check() }}
+            </div>
+          </div>
+        </div>
+      {% endcall %}
+    {% endif %}
+
+
     {{ button.button(text=_("action.create_account")) }}
   </form>
 

--- a/translations/en.json
+++ b/translations/en.json
@@ -2,15 +2,15 @@
   "action": {
     "cancel": "Cancel",
     "@cancel": {
-      "context": "pages/consent.html:72:11-29, pages/device_consent.html:94:13-31, pages/login.html:100:13-31, pages/policy_violation.html:52:13-31, pages/register.html:64:13-31"
+      "context": "pages/consent.html:72:11-29, pages/device_consent.html:94:13-31, pages/login.html:100:13-31, pages/policy_violation.html:52:13-31, pages/register.html:77:13-31"
     },
     "continue": "Continue",
     "@continue": {
-      "context": "pages/account/emails/add.html:45:26-46, pages/account/emails/verify.html:60:26-46, pages/consent.html:60:28-48, pages/device_consent.html:91:13-33, pages/device_link.html:50:26-46, pages/login.html:62:30-50, pages/reauth.html:40:28-48, pages/register.html:59:28-48, pages/sso.html:45:28-48"
+      "context": "pages/account/emails/add.html:45:26-46, pages/account/emails/verify.html:60:26-46, pages/consent.html:60:28-48, pages/device_consent.html:91:13-33, pages/device_link.html:50:26-46, pages/login.html:62:30-50, pages/reauth.html:40:28-48, pages/register.html:72:28-48, pages/sso.html:45:28-48"
     },
     "create_account": "Create Account",
     "@create_account": {
-      "context": "pages/login.html:72:35-61, pages/upstream_oauth2/do_register.html:143:26-52"
+      "context": "pages/login.html:72:35-61, pages/upstream_oauth2/do_register.html:157:26-52"
     },
     "sign_in": "Sign in",
     "@sign_in": {
@@ -167,11 +167,11 @@
     "errors": {
       "denied_policy": "Denied by policy: %(policy)s",
       "@denied_policy": {
-        "context": "components/errors.html:23:7-58, components/field.html:60:17-68"
+        "context": "components/errors.html:23:7-58, components/field.html:72:17-68"
       },
       "field_required": "This field is required",
       "@field_required": {
-        "context": "components/field.html:56:17-47"
+        "context": "components/field.html:68:17-47"
       },
       "invalid_credentials": "Invalid credentials",
       "@invalid_credentials": {
@@ -183,7 +183,7 @@
       },
       "username_taken": "This username is already taken",
       "@username_taken": {
-        "context": "components/field.html:58:17-47"
+        "context": "components/field.html:70:17-47"
       }
     },
     "login": {
@@ -251,7 +251,7 @@
     },
     "or_separator": "Or",
     "@or_separator": {
-      "context": "components/field.html:75:10-31",
+      "context": "components/field.html:91:10-31",
       "description": "Separator between the login methods"
     },
     "policy_violation": {
@@ -273,7 +273,7 @@
     "register": {
       "call_to_login": "Already have an account?",
       "@call_to_login": {
-        "context": "pages/register.html:74:11-42",
+        "context": "pages/register.html:87:11-42",
         "description": "Displayed on the registration page to suggest to log in instead"
       },
       "create_account": {
@@ -288,7 +288,11 @@
       },
       "sign_in_instead": "Sign in instead",
       "@sign_in_instead": {
-        "context": "pages/register.html:78:31-64"
+        "context": "pages/register.html:91:31-64"
+      },
+      "terms_of_service": "I agree to the <a href=\"%s\" data-kind=\"primary\" class=\"cpd-link\">Terms and Conditions</a>",
+      "@terms_of_service": {
+        "context": "pages/register.html:60:37-97, pages/upstream_oauth2/do_register.html:144:35-95"
       }
     },
     "scope": {


### PR DESCRIPTION
Fixes #22 

If `branding.tos_uri` is set in the config, this adds a mandatory checkbox during registration.
It then records which the URL of the TOS that the user agreed to in a `user_terms` table.

Note that this doesn't force the user to agree to TOS if they change or anything like that, but the DB schema should be flexible enough to implement that in the future.

<table>
<tr>
<td>

![image](https://github.com/matrix-org/matrix-authentication-service/assets/1549952/c86d0987-bb81-41aa-a17a-6afc11d018cf)

</td>
<td>

![image](https://github.com/matrix-org/matrix-authentication-service/assets/1549952/ed81882a-1471-49bd-ba26-6c7610a33ab4)

</td>
</tr>
</table>