### PR TITLE
Automatically run migrations on service startup

### DIFF
--- a/docs/setup/database.md
+++ b/docs/setup/database.md
@@ -51,17 +51,11 @@ database:
 ## Database migrations
 
 The service manages the database schema with embedded migrations.
-Those migrations need to be run before the service can be started, and every time the service is upgraded.
+Those migrations are run automatically when the service starts, but it is also possible to run them manually.
 This is done using the [`database migrate`](../usage/cli/database.md#database-migrate) command:
 
 ```sh
 mas-cli database migrate
-```
-
-It is also possible to run any pending migrations on service start, by setting the `--migrate` option to the [`server`](../usage/cli/server.md#server) command:
-
-```sh
-mas-cli server --migrate
 ```
 
 ## Next steps

--- a/docs/usage/cli/server.md
+++ b/docs/usage/cli/server.md
@@ -8,5 +8,3 @@ INFO mas_cli::server: Starting task scheduler
 INFO mas_core::templates: Loading builtin templates
 INFO mas_cli::server: Listening on http://0.0.0.0:8080
 ```
-
-A `--migrate` flag can be set to automatically run pending database migrations on startup.


### PR DESCRIPTION
Fixes #2305

This changes the default behaviour to always apply migration on service start, and adds a new option to disable this behaviour.
It also refuses to start if there are pending migrations.
