### PR TITLE
Warn loudly about encrypted appservices being unsupported

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ You can learn more about Matrix and OIDC at [areweoidcyet.com](https://areweoidc
 - Authentication methods:
   - ✅ Upstream OIDC
   - 🚧 Local password
+  - ‼️ [Application Services login](https://matrix-org.github.io/matrix-authentication-service/as-login.html) (**Encrypted bridges**)
 - Migration support
   - ✅ Compatibility layer for legacy Matrix authentication
   - ✅ Advisor on migration readiness

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -33,3 +33,7 @@
 - [Contributing](./development/contributing.md)
 - [Architecture](./development/architecture.md)
 - [Database](./development/database.md)
+
+---
+
+[Application Services login](./as-login.md)

--- a/docs/as-login.md
+++ b/docs/as-login.md
@@ -1,0 +1,7 @@
+# About Application Services login
+
+Encrypted Application Services/Bridges currently leverage the `m.login.application_service` login type to create devices for users.
+This API is *not* available in the Matrix Authentication Service.
+
+We're working on a solution to support this use case, but in the meantime, this means **encrypted bridges will work with the Matrix Authentication Service.**
+A workaround is to disable E2EE support in your bridge setup.


### PR DESCRIPTION
Place in the docs is probably not the best, but at least there is a somewhat big warning in the README now