### PR TITLE
Fix the zh-Hans translation

### DIFF
--- a/frontend/locales/zh-Hans.json
+++ b/frontend/locales/zh-Hans.json
@@ -19,7 +19,7 @@
   "common": {
     "add": "添加",
     "error": "错误",
-    "loading": "正在加载...",
+    "loading": "加载中...",
     "next": "下一步",
     "previous": "上一步"
   },
@@ -157,7 +157,7 @@
       "make_primary_button": "设为主要",
       "not_verified": "未验证",
       "primary_email": "主电子邮件地址",
-      "retry_button": "Resend code",
+      "retry_button": "重新发送代码",
       "unverified": "未验证"
     },
     "user_email_list": {

--- a/translations/zh-Hans.json
+++ b/translations/zh-Hans.json
@@ -2,7 +2,7 @@
   "action": {
     "cancel": "取消",
     "continue": "继续",
-    "create_account": "",
+    "create_account": "创建账户",
     "sign_in": "登录",
     "sign_out": "注销",
     "submit": "提交"
@@ -24,7 +24,7 @@
   },
   "common": {
     "display_name": "显示名称",
-    "email_address": "电子邮件地址",
+    "email_address": "邮箱地址",
     "mxid": "Matrix ID",
     "password": "密码",
     "password_confirm": "确认密码",


### PR DESCRIPTION
This had the wrong code in localazy, and I think the Localazy download
action doesn't remove old files, so I did that manually.
