### PR TITLE
Make sure the dummy router finished loading in the test environment

### DIFF
--- a/frontend/src/components/CompatSession.test.tsx
+++ b/frontend/src/components/CompatSession.test.tsx
@@ -14,6 +14,7 @@
 
 // @vitest-environment happy-dom
 
+import { TooltipProvider } from "@vector-im/compound-web";
 import { create } from "react-test-renderer";
 import { Provider } from "urql";
 import { describe, expect, it, beforeAll } from "vitest";
@@ -37,7 +38,7 @@ describe("<CompatSession />", () => {
     lastActiveIp: "1.2.3.4",
     ssoLogin: {
       id: "test-id",
-      redirectUri: "https://element.io",
+      redirectUri: "https://element.io/",
     },
   };
 
@@ -48,11 +49,13 @@ describe("<CompatSession />", () => {
   it("renders an active session", () => {
     const session = makeFragmentData(baseSession, FRAGMENT);
     const component = create(
-      <Provider value={mockClient}>
-        <DummyRouter>
-          <CompatSession session={session} />
-        </DummyRouter>
-      </Provider>,
+      <TooltipProvider>
+        <Provider value={mockClient}>
+          <DummyRouter>
+            <CompatSession session={session} />
+          </DummyRouter>
+        </Provider>
+      </TooltipProvider>,
     );
     expect(component.toJSON()).toMatchSnapshot();
   });
@@ -66,11 +69,13 @@ describe("<CompatSession />", () => {
       FRAGMENT,
     );
     const component = create(
-      <Provider value={mockClient}>
-        <DummyRouter>
-          <CompatSession session={session} />
-        </DummyRouter>
-      </Provider>,
+      <TooltipProvider>
+        <Provider value={mockClient}>
+          <DummyRouter>
+            <CompatSession session={session} />
+          </DummyRouter>
+        </Provider>
+      </TooltipProvider>,
     );
     expect(component.toJSON()).toMatchSnapshot();
   });

--- a/frontend/src/components/Session/__snapshots__/Session.test.tsx.snap
+++ b/frontend/src/components/Session/__snapshots__/Session.test.tsx.snap
@@ -64,7 +64,58 @@ exports[`<Session /> > renders a finished session 1`] = `
 </div>
 `;
 
-exports[`<Session /> > renders an active session 1`] = `null`;
+exports[`<Session /> > renders an active session 1`] = `
+<div
+  className="_block_17898c _session_634806"
+>
+  <svg
+    aria-label="Unknown device type"
+    className="_icon_e677aa"
+    fill="currentColor"
+    height="1em"
+    viewBox="0 0 24 24"
+    width="1em"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M5 21c-.55 0-1.02-.196-1.413-.587A1.926 1.926 0 0 1 3 19V5c0-.55.196-1.02.587-1.413A1.926 1.926 0 0 1 5 3h14c.55 0 1.02.196 1.413.587.39.393.587.863.587 1.413v14c0 .55-.196 1.02-.587 1.413A1.926 1.926 0 0 1 19 21H5Zm0-2h14V5H5v14Z"
+    />
+    <path
+      d="M11 10a1 1 0 1 1 1.479.878c-.31.17-.659.413-.94.741-.286.334-.539.8-.539 1.381a1 1 0 0 0 2 .006.3.3 0 0 1 .057-.085 1.39 1.39 0 0 1 .382-.288A3 3 0 1 0 9 10a1 1 0 1 0 2 0Zm1.999 3.011v-.004.005ZM12 17a1 1 0 1 0 0-2 1 1 0 0 0 0 2Z"
+    />
+  </svg>
+  <div
+    className="_container_634806"
+  >
+    <h6
+      className="_typography_yh5dq_162 _font-body-md-semibold_yh5dq_64 _sessionName_634806"
+      title="session-id"
+    >
+      <a
+        href="/sessions/session-id"
+        onClick={[Function]}
+        onFocus={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        onTouchStart={[Function]}
+        style={{}}
+      >
+        session-id
+      </a>
+    </h6>
+    <p
+      className="_typography_yh5dq_162 _font-body-sm-semibold_yh5dq_45 _sessionMetadata_634806"
+    >
+      Signed in 
+      <time
+        dateTime="2023-06-29T03:35:17Z"
+      >
+        Thu, 29 Jun 2023, 03:35
+      </time>
+    </p>
+  </div>
+</div>
+`;
 
 exports[`<Session /> > renders ip address 1`] = `
 <div

--- a/frontend/src/components/SessionDetail/CompatSessionDetail.test.tsx
+++ b/frontend/src/components/SessionDetail/CompatSessionDetail.test.tsx
@@ -15,6 +15,7 @@
 // @vitest-environment happy-dom
 
 import { render, cleanup } from "@testing-library/react";
+import { TooltipProvider } from "@vector-im/compound-web";
 import { Provider } from "urql";
 import { describe, expect, it, afterEach, beforeAll } from "vitest";
 import { never } from "wonka";
@@ -34,8 +35,10 @@ describe("<CompatSessionDetail>", () => {
     id: "session-id",
     deviceId: "abcd1234",
     createdAt: "2023-06-29T03:35:17.451292+00:00",
+    finishedAt: null,
     lastActiveIp: "1.2.3.4",
     lastActiveAt: "2023-07-29T03:35:17.451292+00:00",
+    userAgent: null,
     ssoLogin: {
       id: "test-id",
       redirectUri: "https://element.io",
@@ -46,17 +49,21 @@ describe("<CompatSessionDetail>", () => {
   afterEach(cleanup);
 
   it("renders a compatability session details", () => {
-    const data = makeFragmentData(baseSession, FRAGMENT);
+    const data = makeFragmentData({ ...baseSession }, FRAGMENT);
 
-    const { container } = render(
-      <Provider value={mockClient}>
-        <DummyRouter>
-          <CompatSessionDetail session={data} />
-        </DummyRouter>
-      </Provider>,
+    const { container, getByText, queryByText } = render(
+      <TooltipProvider>
+        <Provider value={mockClient}>
+          <DummyRouter>
+            <CompatSessionDetail session={data} />
+          </DummyRouter>
+        </Provider>
+      </TooltipProvider>,
     );
 
     expect(container).toMatchSnapshot();
+    expect(queryByText("Finished")).toBeFalsy();
+    expect(getByText("End session")).toBeTruthy();
   });
 
   it("renders a compatability session without an ssoLogin", () => {
@@ -68,7 +75,7 @@ describe("<CompatSessionDetail>", () => {
       FRAGMENT,
     );
 
-    const { container } = render(
+    const { container, getByText, queryByText } = render(
       <Provider value={mockClient}>
         <DummyRouter>
           <CompatSessionDetail session={data} />
@@ -77,6 +84,8 @@ describe("<CompatSessionDetail>", () => {
     );
 
     expect(container).toMatchSnapshot();
+    expect(queryByText("Finished")).toBeFalsy();
+    expect(getByText("End session")).toBeTruthy();
   });
 
   it("renders a finished compatability session details", () => {
@@ -88,7 +97,7 @@ describe("<CompatSessionDetail>", () => {
       FRAGMENT,
     );
 
-    const { getByText, queryByText } = render(
+    const { container, getByText, queryByText } = render(
       <Provider value={mockClient}>
         <DummyRouter>
           <CompatSessionDetail session={data} />
@@ -96,8 +105,8 @@ describe("<CompatSessionDetail>", () => {
       </Provider>,
     );
 
+    expect(container).toMatchSnapshot();
     expect(getByText("Finished")).toBeTruthy();
-    // no end session button
-    expect(queryByText("End session")).toBeFalsy();
+    expect(queryByText("Sign out")).toBeFalsy();
   });
 });

--- a/frontend/src/components/SessionDetail/OAuth2SessionDetail.test.tsx
+++ b/frontend/src/components/SessionDetail/OAuth2SessionDetail.test.tsx
@@ -15,6 +15,7 @@
 // @vitest-environment happy-dom
 
 import { render, cleanup } from "@testing-library/react";
+import { TooltipProvider } from "@vector-im/compound-web";
 import { Provider } from "urql";
 import { describe, expect, it, afterEach, beforeAll } from "vitest";
 import { never } from "wonka";
@@ -35,13 +36,16 @@ describe("<OAuth2SessionDetail>", () => {
     scope:
       "openid urn:matrix:org.matrix.msc2967.client:api:* urn:matrix:org.matrix.msc2967.client:device:abcd1234",
     createdAt: "2023-06-29T03:35:17.451292+00:00",
+    finishedAt: null,
     lastActiveAt: "2023-07-29T03:35:17.451292+00:00",
     lastActiveIp: "1.2.3.4",
+    userAgent: null,
     client: {
       id: "test-id",
       clientId: "test-client-id",
       clientName: "Element",
       clientUri: "https://element.io",
+      logoUri: null,
     },
   };
 
@@ -51,15 +55,19 @@ describe("<OAuth2SessionDetail>", () => {
   it("renders session details", () => {
     const data = makeFragmentData(baseSession, FRAGMENT);
 
-    const { container } = render(
-      <Provider value={mockClient}>
-        <DummyRouter>
-          <OAuth2SessionDetail session={data} />
-        </DummyRouter>
-      </Provider>,
+    const { asFragment, getByText, queryByText } = render(
+      <TooltipProvider>
+        <Provider value={mockClient}>
+          <DummyRouter>
+            <OAuth2SessionDetail session={data} />
+          </DummyRouter>
+        </Provider>
+      </TooltipProvider>,
     );
 
-    expect(container).toMatchSnapshot();
+    expect(asFragment()).toMatchSnapshot();
+    expect(queryByText("Finished")).toBeFalsy();
+    expect(getByText("End session")).toBeTruthy();
   });
 
   it("renders a finished session details", () => {
@@ -71,16 +79,18 @@ describe("<OAuth2SessionDetail>", () => {
       FRAGMENT,
     );
 
-    const { getByText, queryByText } = render(
-      <Provider value={mockClient}>
-        <DummyRouter>
-          <OAuth2SessionDetail session={data} />
-        </DummyRouter>
-      </Provider>,
+    const { asFragment, getByText, queryByText } = render(
+      <TooltipProvider>
+        <Provider value={mockClient}>
+          <DummyRouter>
+            <OAuth2SessionDetail session={data} />
+          </DummyRouter>
+        </Provider>
+      </TooltipProvider>,
     );
 
+    expect(asFragment()).toMatchSnapshot();
     expect(getByText("Finished")).toBeTruthy();
-    // no end session button
     expect(queryByText("End session")).toBeFalsy();
   });
 });

--- a/frontend/src/components/SessionDetail/__snapshots__/CompatSessionDetail.test.tsx.snap
+++ b/frontend/src/components/SessionDetail/__snapshots__/CompatSessionDetail.test.tsx.snap
@@ -1,6 +1,200 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`<CompatSessionDetail> > renders a compatability session details 1`] = `<div />`;
+exports[`<CompatSessionDetail> > renders a compatability session details 1`] = `
+<div>
+  <div
+    class="_blockList_f8cc7f"
+  >
+    <header
+      class="_header_92353c"
+    >
+      <a
+        class="_backButton_92353c"
+        href="/sessions"
+      >
+        <svg
+          class="cpd-icon"
+          fill="currentColor"
+          height="1em"
+          viewBox="0 0 24 24"
+          width="1em"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M12.207 5.293a1 1 0 0 1 0 1.414L7.914 11H18.5a1 1 0 1 1 0 2H7.914l4.293 4.293a1 1 0 0 1-1.414 1.414l-6-6a1 1 0 0 1 0-1.414l6-6a1 1 0 0 1 1.414 0Z"
+          />
+        </svg>
+      </a>
+      <h3
+        class="_typography_yh5dq_162 _font-heading-md-semibold_yh5dq_121"
+      >
+        abcd1234
+      </h3>
+    </header>
+    <div
+      class="_block_17898c"
+    >
+      <h6
+        class="_typography_yh5dq_162 _font-body-md-semibold_yh5dq_64"
+      >
+        Session
+      </h6>
+      <ul
+        class="_list_040867"
+      >
+        <li
+          class="_detailRow_040867"
+        >
+          <p
+            class="_typography_yh5dq_162 _font-body-sm-semibold_yh5dq_45 _detailLabel_040867"
+          >
+            ID
+          </p>
+          <p
+            class="_typography_yh5dq_162 _font-body-sm-regular_yh5dq_40 _detailValue_040867"
+          >
+            <code>
+              session-id
+            </code>
+          </p>
+        </li>
+        <li
+          class="_detailRow_040867"
+        >
+          <p
+            class="_typography_yh5dq_162 _font-body-sm-semibold_yh5dq_45 _detailLabel_040867"
+          >
+            Device ID
+          </p>
+          <p
+            class="_typography_yh5dq_162 _font-body-sm-regular_yh5dq_40 _detailValue_040867"
+          >
+            <code>
+              abcd1234
+            </code>
+          </p>
+        </li>
+        <li
+          class="_detailRow_040867"
+        >
+          <p
+            class="_typography_yh5dq_162 _font-body-sm-semibold_yh5dq_45 _detailLabel_040867"
+          >
+            Signed in
+          </p>
+          <p
+            class="_typography_yh5dq_162 _font-body-sm-regular_yh5dq_40 _detailValue_040867"
+          >
+            <time
+              datetime="2023-06-29T03:35:17Z"
+            >
+              Thu, 29 Jun 2023, 03:35
+            </time>
+          </p>
+        </li>
+        <li
+          class="_detailRow_040867"
+        >
+          <p
+            class="_typography_yh5dq_162 _font-body-sm-semibold_yh5dq_45 _detailLabel_040867"
+          >
+            Last Active
+          </p>
+          <p
+            class="_typography_yh5dq_162 _font-body-sm-regular_yh5dq_40 _detailValue_040867"
+          >
+            <span
+              title="Sat, 29 Jul 2023, 03:35"
+            >
+              Inactive for 90+ days
+            </span>
+          </p>
+        </li>
+        <li
+          class="_detailRow_040867"
+        >
+          <p
+            class="_typography_yh5dq_162 _font-body-sm-semibold_yh5dq_45 _detailLabel_040867"
+          >
+            IP Address
+          </p>
+          <p
+            class="_typography_yh5dq_162 _font-body-sm-regular_yh5dq_40 _detailValue_040867"
+          >
+            <code>
+              1.2.3.4
+            </code>
+          </p>
+        </li>
+      </ul>
+    </div>
+    <div
+      class="_block_17898c"
+    >
+      <h6
+        class="_typography_yh5dq_162 _font-body-md-semibold_yh5dq_64"
+      >
+        Client
+      </h6>
+      <ul
+        class="_list_040867"
+      >
+        <li
+          class="_detailRow_040867"
+        >
+          <p
+            class="_typography_yh5dq_162 _font-body-sm-semibold_yh5dq_45 _detailLabel_040867"
+          >
+            Name
+          </p>
+          <p
+            class="_typography_yh5dq_162 _font-body-sm-regular_yh5dq_40 _detailValue_040867"
+          >
+            element.io
+          </p>
+        </li>
+        <li
+          class="_detailRow_040867"
+        >
+          <p
+            class="_typography_yh5dq_162 _font-body-sm-semibold_yh5dq_45 _detailLabel_040867"
+          >
+            Uri
+          </p>
+          <p
+            class="_typography_yh5dq_162 _font-body-sm-regular_yh5dq_40 _detailValue_040867"
+          >
+            <a
+              class="_link_1mzip_17 _externalLink_a97355"
+              data-kind="primary"
+              href="https://element.io"
+              rel="noreferrer noopener"
+              target="_blank"
+            >
+              https://element.io
+            </a>
+          </p>
+        </li>
+      </ul>
+    </div>
+    <button
+      aria-controls="radix-:r0:"
+      aria-disabled="false"
+      aria-expanded="false"
+      aria-haspopup="dialog"
+      class="_button_dyfp8_17 _destructive_dyfp8_99"
+      data-kind="secondary"
+      data-size="sm"
+      data-state="closed"
+      role="button"
+      tabindex="0"
+      type="button"
+    >
+      End session
+    </button>
+  </div>
+</div>
+`;
 
 exports[`<CompatSessionDetail> > renders a compatability session without an ssoLogin 1`] = `
 <div>
@@ -131,7 +325,7 @@ exports[`<CompatSessionDetail> > renders a compatability session without an ssoL
       </ul>
     </div>
     <button
-      aria-controls="radix-:r0:"
+      aria-controls="radix-:r3:"
       aria-disabled="false"
       aria-expanded="false"
       aria-haspopup="dialog"
@@ -145,6 +339,205 @@ exports[`<CompatSessionDetail> > renders a compatability session without an ssoL
     >
       End session
     </button>
+  </div>
+</div>
+`;
+
+exports[`<CompatSessionDetail> > renders a finished compatability session details 1`] = `
+<div>
+  <div
+    class="_blockList_f8cc7f"
+  >
+    <header
+      class="_header_92353c"
+    >
+      <a
+        class="_backButton_92353c"
+        href="/sessions"
+      >
+        <svg
+          class="cpd-icon"
+          fill="currentColor"
+          height="1em"
+          viewBox="0 0 24 24"
+          width="1em"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M12.207 5.293a1 1 0 0 1 0 1.414L7.914 11H18.5a1 1 0 1 1 0 2H7.914l4.293 4.293a1 1 0 0 1-1.414 1.414l-6-6a1 1 0 0 1 0-1.414l6-6a1 1 0 0 1 1.414 0Z"
+          />
+        </svg>
+      </a>
+      <h3
+        class="_typography_yh5dq_162 _font-heading-md-semibold_yh5dq_121"
+      >
+        abcd1234
+      </h3>
+    </header>
+    <div
+      class="_block_17898c"
+    >
+      <h6
+        class="_typography_yh5dq_162 _font-body-md-semibold_yh5dq_64"
+      >
+        Session
+      </h6>
+      <ul
+        class="_list_040867"
+      >
+        <li
+          class="_detailRow_040867"
+        >
+          <p
+            class="_typography_yh5dq_162 _font-body-sm-semibold_yh5dq_45 _detailLabel_040867"
+          >
+            ID
+          </p>
+          <p
+            class="_typography_yh5dq_162 _font-body-sm-regular_yh5dq_40 _detailValue_040867"
+          >
+            <code>
+              session-id
+            </code>
+          </p>
+        </li>
+        <li
+          class="_detailRow_040867"
+        >
+          <p
+            class="_typography_yh5dq_162 _font-body-sm-semibold_yh5dq_45 _detailLabel_040867"
+          >
+            Device ID
+          </p>
+          <p
+            class="_typography_yh5dq_162 _font-body-sm-regular_yh5dq_40 _detailValue_040867"
+          >
+            <code>
+              abcd1234
+            </code>
+          </p>
+        </li>
+        <li
+          class="_detailRow_040867"
+        >
+          <p
+            class="_typography_yh5dq_162 _font-body-sm-semibold_yh5dq_45 _detailLabel_040867"
+          >
+            Signed in
+          </p>
+          <p
+            class="_typography_yh5dq_162 _font-body-sm-regular_yh5dq_40 _detailValue_040867"
+          >
+            <time
+              datetime="2023-06-29T03:35:17Z"
+            >
+              Thu, 29 Jun 2023, 03:35
+            </time>
+          </p>
+        </li>
+        <li
+          class="_detailRow_040867"
+        >
+          <p
+            class="_typography_yh5dq_162 _font-body-sm-semibold_yh5dq_45 _detailLabel_040867"
+          >
+            Finished
+          </p>
+          <p
+            class="_typography_yh5dq_162 _font-body-sm-regular_yh5dq_40 _detailValue_040867"
+          >
+            <time
+              datetime="2023-07-29T03:35:17Z"
+            >
+              Sat, 29 Jul 2023, 03:35
+            </time>
+          </p>
+        </li>
+        <li
+          class="_detailRow_040867"
+        >
+          <p
+            class="_typography_yh5dq_162 _font-body-sm-semibold_yh5dq_45 _detailLabel_040867"
+          >
+            Last Active
+          </p>
+          <p
+            class="_typography_yh5dq_162 _font-body-sm-regular_yh5dq_40 _detailValue_040867"
+          >
+            <span
+              title="Sat, 29 Jul 2023, 03:35"
+            >
+              Inactive for 90+ days
+            </span>
+          </p>
+        </li>
+        <li
+          class="_detailRow_040867"
+        >
+          <p
+            class="_typography_yh5dq_162 _font-body-sm-semibold_yh5dq_45 _detailLabel_040867"
+          >
+            IP Address
+          </p>
+          <p
+            class="_typography_yh5dq_162 _font-body-sm-regular_yh5dq_40 _detailValue_040867"
+          >
+            <code>
+              1.2.3.4
+            </code>
+          </p>
+        </li>
+      </ul>
+    </div>
+    <div
+      class="_block_17898c"
+    >
+      <h6
+        class="_typography_yh5dq_162 _font-body-md-semibold_yh5dq_64"
+      >
+        Client
+      </h6>
+      <ul
+        class="_list_040867"
+      >
+        <li
+          class="_detailRow_040867"
+        >
+          <p
+            class="_typography_yh5dq_162 _font-body-sm-semibold_yh5dq_45 _detailLabel_040867"
+          >
+            Name
+          </p>
+          <p
+            class="_typography_yh5dq_162 _font-body-sm-regular_yh5dq_40 _detailValue_040867"
+          >
+            element.io
+          </p>
+        </li>
+        <li
+          class="_detailRow_040867"
+        >
+          <p
+            class="_typography_yh5dq_162 _font-body-sm-semibold_yh5dq_45 _detailLabel_040867"
+          >
+            Uri
+          </p>
+          <p
+            class="_typography_yh5dq_162 _font-body-sm-regular_yh5dq_40 _detailValue_040867"
+          >
+            <a
+              class="_link_1mzip_17 _externalLink_a97355"
+              data-kind="primary"
+              href="https://element.io"
+              rel="noreferrer noopener"
+              target="_blank"
+            >
+              https://element.io
+            </a>
+          </p>
+        </li>
+      </ul>
+    </div>
   </div>
 </div>
 `;

--- a/frontend/src/components/SessionDetail/__snapshots__/OAuth2SessionDetail.test.tsx.snap
+++ b/frontend/src/components/SessionDetail/__snapshots__/OAuth2SessionDetail.test.tsx.snap
@@ -1,3 +1,486 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`<OAuth2SessionDetail> > renders session details 1`] = `<div />`;
+exports[`<OAuth2SessionDetail> > renders a finished session details 1`] = `
+<DocumentFragment>
+  <div
+    class="_blockList_f8cc7f"
+  >
+    <header
+      class="_header_92353c"
+    >
+      <a
+        class="_backButton_92353c"
+        href="/sessions"
+      >
+        <svg
+          class="cpd-icon"
+          fill="currentColor"
+          height="1em"
+          viewBox="0 0 24 24"
+          width="1em"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M12.207 5.293a1 1 0 0 1 0 1.414L7.914 11H18.5a1 1 0 1 1 0 2H7.914l4.293 4.293a1 1 0 0 1-1.414 1.414l-6-6a1 1 0 0 1 0-1.414l6-6a1 1 0 0 1 1.414 0Z"
+          />
+        </svg>
+      </a>
+      <h3
+        class="_typography_yh5dq_162 _font-heading-md-semibold_yh5dq_121"
+      >
+        abcd1234
+      </h3>
+    </header>
+    <div
+      class="_block_17898c"
+    >
+      <h6
+        class="_typography_yh5dq_162 _font-body-md-semibold_yh5dq_64"
+      >
+        Session
+      </h6>
+      <ul
+        class="_list_040867"
+      >
+        <li
+          class="_detailRow_040867"
+        >
+          <p
+            class="_typography_yh5dq_162 _font-body-sm-semibold_yh5dq_45 _detailLabel_040867"
+          >
+            ID
+          </p>
+          <p
+            class="_typography_yh5dq_162 _font-body-sm-regular_yh5dq_40 _detailValue_040867"
+          >
+            <code>
+              session-id
+            </code>
+          </p>
+        </li>
+        <li
+          class="_detailRow_040867"
+        >
+          <p
+            class="_typography_yh5dq_162 _font-body-sm-semibold_yh5dq_45 _detailLabel_040867"
+          >
+            Device ID
+          </p>
+          <p
+            class="_typography_yh5dq_162 _font-body-sm-regular_yh5dq_40 _detailValue_040867"
+          >
+            <code>
+              abcd1234
+            </code>
+          </p>
+        </li>
+        <li
+          class="_detailRow_040867"
+        >
+          <p
+            class="_typography_yh5dq_162 _font-body-sm-semibold_yh5dq_45 _detailLabel_040867"
+          >
+            Signed in
+          </p>
+          <p
+            class="_typography_yh5dq_162 _font-body-sm-regular_yh5dq_40 _detailValue_040867"
+          >
+            <time
+              datetime="2023-06-29T03:35:17Z"
+            >
+              Thu, 29 Jun 2023, 03:35
+            </time>
+          </p>
+        </li>
+        <li
+          class="_detailRow_040867"
+        >
+          <p
+            class="_typography_yh5dq_162 _font-body-sm-semibold_yh5dq_45 _detailLabel_040867"
+          >
+            Finished
+          </p>
+          <p
+            class="_typography_yh5dq_162 _font-body-sm-regular_yh5dq_40 _detailValue_040867"
+          >
+            <time
+              datetime="2023-07-29T03:35:17Z"
+            >
+              Sat, 29 Jul 2023, 03:35
+            </time>
+          </p>
+        </li>
+        <li
+          class="_detailRow_040867"
+        >
+          <p
+            class="_typography_yh5dq_162 _font-body-sm-semibold_yh5dq_45 _detailLabel_040867"
+          >
+            Last Active
+          </p>
+          <p
+            class="_typography_yh5dq_162 _font-body-sm-regular_yh5dq_40 _detailValue_040867"
+          >
+            <span
+              title="Sat, 29 Jul 2023, 03:35"
+            >
+              Inactive for 90+ days
+            </span>
+          </p>
+        </li>
+        <li
+          class="_detailRow_040867"
+        >
+          <p
+            class="_typography_yh5dq_162 _font-body-sm-semibold_yh5dq_45 _detailLabel_040867"
+          >
+            IP Address
+          </p>
+          <p
+            class="_typography_yh5dq_162 _font-body-sm-regular_yh5dq_40 _detailValue_040867"
+          >
+            <code>
+              1.2.3.4
+            </code>
+          </p>
+        </li>
+        <li
+          class="_detailRow_040867"
+        >
+          <p
+            class="_typography_yh5dq_162 _font-body-sm-semibold_yh5dq_45 _detailLabel_040867"
+          >
+            Scopes
+          </p>
+          <p
+            class="_typography_yh5dq_162 _font-body-sm-regular_yh5dq_40 _detailValue_040867"
+          >
+            <span>
+              <code>
+                openid
+              </code>
+              <code>
+                urn:matrix:org.matrix.msc2967.client:api:*
+              </code>
+              <code>
+                urn:matrix:org.matrix.msc2967.client:device:abcd1234
+              </code>
+            </span>
+          </p>
+        </li>
+      </ul>
+    </div>
+    <div
+      class="_block_17898c"
+    >
+      <h6
+        class="_typography_yh5dq_162 _font-body-md-semibold_yh5dq_64"
+      >
+        <a
+          class="_link_1mzip_17"
+          data-kind="primary"
+          href="/clients/test-id"
+          rel="noreferrer noopener"
+        >
+          Client
+        </a>
+      </h6>
+      <ul
+        class="_list_040867"
+      >
+        <li
+          class="_detailRow_040867"
+        >
+          <p
+            class="_typography_yh5dq_162 _font-body-sm-semibold_yh5dq_45 _detailLabel_040867"
+          >
+            Name
+          </p>
+          <p
+            class="_typography_yh5dq_162 _font-body-sm-regular_yh5dq_40 _detailValue_040867"
+          >
+            Element
+          </p>
+        </li>
+        <li
+          class="_detailRow_040867"
+        >
+          <p
+            class="_typography_yh5dq_162 _font-body-sm-semibold_yh5dq_45 _detailLabel_040867"
+          >
+            ID
+          </p>
+          <p
+            class="_typography_yh5dq_162 _font-body-sm-regular_yh5dq_40 _detailValue_040867"
+          >
+            <code>
+              test-client-id
+            </code>
+          </p>
+        </li>
+        <li
+          class="_detailRow_040867"
+        >
+          <p
+            class="_typography_yh5dq_162 _font-body-sm-semibold_yh5dq_45 _detailLabel_040867"
+          >
+            Uri
+          </p>
+          <p
+            class="_typography_yh5dq_162 _font-body-sm-regular_yh5dq_40 _detailValue_040867"
+          >
+            <a
+              href="https://element.io"
+              rel="noreferrer"
+              target="_blank"
+            >
+              https://element.io
+            </a>
+          </p>
+        </li>
+      </ul>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`<OAuth2SessionDetail> > renders session details 1`] = `
+<DocumentFragment>
+  <div
+    class="_blockList_f8cc7f"
+  >
+    <header
+      class="_header_92353c"
+    >
+      <a
+        class="_backButton_92353c"
+        href="/sessions"
+      >
+        <svg
+          class="cpd-icon"
+          fill="currentColor"
+          height="1em"
+          viewBox="0 0 24 24"
+          width="1em"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M12.207 5.293a1 1 0 0 1 0 1.414L7.914 11H18.5a1 1 0 1 1 0 2H7.914l4.293 4.293a1 1 0 0 1-1.414 1.414l-6-6a1 1 0 0 1 0-1.414l6-6a1 1 0 0 1 1.414 0Z"
+          />
+        </svg>
+      </a>
+      <h3
+        class="_typography_yh5dq_162 _font-heading-md-semibold_yh5dq_121"
+      >
+        abcd1234
+      </h3>
+    </header>
+    <div
+      class="_block_17898c"
+    >
+      <h6
+        class="_typography_yh5dq_162 _font-body-md-semibold_yh5dq_64"
+      >
+        Session
+      </h6>
+      <ul
+        class="_list_040867"
+      >
+        <li
+          class="_detailRow_040867"
+        >
+          <p
+            class="_typography_yh5dq_162 _font-body-sm-semibold_yh5dq_45 _detailLabel_040867"
+          >
+            ID
+          </p>
+          <p
+            class="_typography_yh5dq_162 _font-body-sm-regular_yh5dq_40 _detailValue_040867"
+          >
+            <code>
+              session-id
+            </code>
+          </p>
+        </li>
+        <li
+          class="_detailRow_040867"
+        >
+          <p
+            class="_typography_yh5dq_162 _font-body-sm-semibold_yh5dq_45 _detailLabel_040867"
+          >
+            Device ID
+          </p>
+          <p
+            class="_typography_yh5dq_162 _font-body-sm-regular_yh5dq_40 _detailValue_040867"
+          >
+            <code>
+              abcd1234
+            </code>
+          </p>
+        </li>
+        <li
+          class="_detailRow_040867"
+        >
+          <p
+            class="_typography_yh5dq_162 _font-body-sm-semibold_yh5dq_45 _detailLabel_040867"
+          >
+            Signed in
+          </p>
+          <p
+            class="_typography_yh5dq_162 _font-body-sm-regular_yh5dq_40 _detailValue_040867"
+          >
+            <time
+              datetime="2023-06-29T03:35:17Z"
+            >
+              Thu, 29 Jun 2023, 03:35
+            </time>
+          </p>
+        </li>
+        <li
+          class="_detailRow_040867"
+        >
+          <p
+            class="_typography_yh5dq_162 _font-body-sm-semibold_yh5dq_45 _detailLabel_040867"
+          >
+            Last Active
+          </p>
+          <p
+            class="_typography_yh5dq_162 _font-body-sm-regular_yh5dq_40 _detailValue_040867"
+          >
+            <span
+              title="Sat, 29 Jul 2023, 03:35"
+            >
+              Inactive for 90+ days
+            </span>
+          </p>
+        </li>
+        <li
+          class="_detailRow_040867"
+        >
+          <p
+            class="_typography_yh5dq_162 _font-body-sm-semibold_yh5dq_45 _detailLabel_040867"
+          >
+            IP Address
+          </p>
+          <p
+            class="_typography_yh5dq_162 _font-body-sm-regular_yh5dq_40 _detailValue_040867"
+          >
+            <code>
+              1.2.3.4
+            </code>
+          </p>
+        </li>
+        <li
+          class="_detailRow_040867"
+        >
+          <p
+            class="_typography_yh5dq_162 _font-body-sm-semibold_yh5dq_45 _detailLabel_040867"
+          >
+            Scopes
+          </p>
+          <p
+            class="_typography_yh5dq_162 _font-body-sm-regular_yh5dq_40 _detailValue_040867"
+          >
+            <span>
+              <code>
+                openid
+              </code>
+              <code>
+                urn:matrix:org.matrix.msc2967.client:api:*
+              </code>
+              <code>
+                urn:matrix:org.matrix.msc2967.client:device:abcd1234
+              </code>
+            </span>
+          </p>
+        </li>
+      </ul>
+    </div>
+    <div
+      class="_block_17898c"
+    >
+      <h6
+        class="_typography_yh5dq_162 _font-body-md-semibold_yh5dq_64"
+      >
+        <a
+          class="_link_1mzip_17"
+          data-kind="primary"
+          href="/clients/test-id"
+          rel="noreferrer noopener"
+        >
+          Client
+        </a>
+      </h6>
+      <ul
+        class="_list_040867"
+      >
+        <li
+          class="_detailRow_040867"
+        >
+          <p
+            class="_typography_yh5dq_162 _font-body-sm-semibold_yh5dq_45 _detailLabel_040867"
+          >
+            Name
+          </p>
+          <p
+            class="_typography_yh5dq_162 _font-body-sm-regular_yh5dq_40 _detailValue_040867"
+          >
+            Element
+          </p>
+        </li>
+        <li
+          class="_detailRow_040867"
+        >
+          <p
+            class="_typography_yh5dq_162 _font-body-sm-semibold_yh5dq_45 _detailLabel_040867"
+          >
+            ID
+          </p>
+          <p
+            class="_typography_yh5dq_162 _font-body-sm-regular_yh5dq_40 _detailValue_040867"
+          >
+            <code>
+              test-client-id
+            </code>
+          </p>
+        </li>
+        <li
+          class="_detailRow_040867"
+        >
+          <p
+            class="_typography_yh5dq_162 _font-body-sm-semibold_yh5dq_45 _detailLabel_040867"
+          >
+            Uri
+          </p>
+          <p
+            class="_typography_yh5dq_162 _font-body-sm-regular_yh5dq_40 _detailValue_040867"
+          >
+            <a
+              href="https://element.io"
+              rel="noreferrer"
+              target="_blank"
+            >
+              https://element.io
+            </a>
+          </p>
+        </li>
+      </ul>
+    </div>
+    <button
+      aria-controls="radix-:r0:"
+      aria-disabled="false"
+      aria-expanded="false"
+      aria-haspopup="dialog"
+      class="_button_dyfp8_17 _destructive_dyfp8_99"
+      data-kind="secondary"
+      data-size="sm"
+      data-state="closed"
+      role="button"
+      tabindex="0"
+      type="button"
+    >
+      End session
+    </button>
+  </div>
+</DocumentFragment>
+`;

--- a/frontend/src/components/SessionDetail/__snapshots__/SessionHeader.test.tsx.snap
+++ b/frontend/src/components/SessionDetail/__snapshots__/SessionHeader.test.tsx.snap
@@ -1,3 +1,33 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`<SessionHeader /> > renders a session header 1`] = `<div />`;
+exports[`<SessionHeader /> > renders a session header 1`] = `
+<div>
+  <header
+    class="_header_92353c"
+  >
+    <a
+      class="_backButton_92353c active"
+      data-status="active"
+      href="/"
+    >
+      <svg
+        class="cpd-icon"
+        fill="currentColor"
+        height="1em"
+        viewBox="0 0 24 24"
+        width="1em"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M12.207 5.293a1 1 0 0 1 0 1.414L7.914 11H18.5a1 1 0 1 1 0 2H7.914l4.293 4.293a1 1 0 0 1-1.414 1.414l-6-6a1 1 0 0 1 0-1.414l6-6a1 1 0 0 1 1.414 0Z"
+        />
+      </svg>
+    </a>
+    <h3
+      class="_typography_yh5dq_162 _font-heading-md-semibold_yh5dq_121"
+    >
+      Chrome on iOS
+    </h3>
+  </header>
+</div>
+`;

--- a/frontend/src/components/UserSessionsOverview/__snapshots__/BrowserSessionsOverview.test.tsx.snap
+++ b/frontend/src/components/UserSessionsOverview/__snapshots__/BrowserSessionsOverview.test.tsx.snap
@@ -1,6 +1,35 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`BrowserSessionsOverview > renders with no browser sessions 1`] = `<div />`;
+exports[`BrowserSessionsOverview > renders with no browser sessions 1`] = `
+<div>
+  <div
+    class="_block_17898c _sessionListBlock_c5c17e"
+  >
+    <div
+      class="_sessionListBlockInfo_c5c17e"
+    >
+      <h5
+        class="_typography_yh5dq_162 _font-body-lg-semibold_yh5dq_83"
+      >
+        Browsers
+      </h5>
+      <p
+        class="_typography_yh5dq_162 _font-body-md-regular_yh5dq_59"
+      >
+        0 active sessions
+      </p>
+    </div>
+    <a
+      class="_link_1mzip_17"
+      data-kind="primary"
+      href="/sessions/browsers"
+      rel="noreferrer noopener"
+    >
+      View all
+    </a>
+  </div>
+</div>
+`;
 
 exports[`BrowserSessionsOverview > renders with sessions 1`] = `
 <div>

--- a/frontend/src/components/__snapshots__/CompatSession.test.tsx.snap
+++ b/frontend/src/components/__snapshots__/CompatSession.test.tsx.snap
@@ -79,4 +79,90 @@ exports[`<CompatSession /> > renders a finished session 1`] = `
 </div>
 `;
 
-exports[`<CompatSession /> > renders an active session 1`] = `null`;
+exports[`<CompatSession /> > renders an active session 1`] = `
+<div
+  className="_block_17898c _session_634806"
+>
+  <svg
+    aria-label="Unknown device type"
+    className="_icon_e677aa"
+    fill="currentColor"
+    height="1em"
+    viewBox="0 0 24 24"
+    width="1em"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M5 21c-.55 0-1.02-.196-1.413-.587A1.926 1.926 0 0 1 3 19V5c0-.55.196-1.02.587-1.413A1.926 1.926 0 0 1 5 3h14c.55 0 1.02.196 1.413.587.39.393.587.863.587 1.413v14c0 .55-.196 1.02-.587 1.413A1.926 1.926 0 0 1 19 21H5Zm0-2h14V5H5v14Z"
+    />
+    <path
+      d="M11 10a1 1 0 1 1 1.479.878c-.31.17-.659.413-.94.741-.286.334-.539.8-.539 1.381a1 1 0 0 0 2 .006.3.3 0 0 1 .057-.085 1.39 1.39 0 0 1 .382-.288A3 3 0 1 0 9 10a1 1 0 1 0 2 0Zm1.999 3.011v-.004.005ZM12 17a1 1 0 1 0 0-2 1 1 0 0 0 0 2Z"
+    />
+  </svg>
+  <div
+    className="_container_634806"
+  >
+    <h6
+      className="_typography_yh5dq_162 _font-body-md-semibold_yh5dq_64 _sessionName_634806"
+      title="session-id"
+    >
+      <a
+        href="/sessions/session-id"
+        onClick={[Function]}
+        onFocus={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        onTouchStart={[Function]}
+        style={{}}
+      >
+        abcd1234
+      </a>
+    </h6>
+    <p
+      className="_typography_yh5dq_162 _font-body-sm-semibold_yh5dq_45 _sessionMetadata_634806"
+    >
+      Signed in 
+      <time
+        dateTime="2023-06-29T03:35:17Z"
+      >
+        Thu, 29 Jun 2023, 03:35
+      </time>
+    </p>
+    <p
+      className="_typography_yh5dq_162 _font-body-sm-regular_yh5dq_40 _sessionMetadata_634806"
+    >
+      1.2.3.4
+    </p>
+    <p
+      className="_typography_yh5dq_162 _font-body-sm-regular_yh5dq_40 _sessionMetadata_634806"
+    >
+       
+      <span
+        className="_typography_yh5dq_162 _font-body-sm-semibold_yh5dq_45 _sessionMetadata_634806"
+      >
+        element.io
+      </span>
+    </p>
+    <div
+      className="_sessionActions_634806"
+    >
+      <button
+        aria-controls="radix-:r0:"
+        aria-disabled={false}
+        aria-expanded={false}
+        aria-haspopup="dialog"
+        className="_button_dyfp8_17 _destructive_dyfp8_99"
+        data-kind="secondary"
+        data-size="sm"
+        data-state="closed"
+        onClick={[Function]}
+        role="button"
+        tabIndex={0}
+        type="button"
+      >
+        End session
+      </button>
+    </div>
+  </div>
+</div>
+`;

--- a/frontend/src/components/__snapshots__/OAuth2Session.test.tsx.snap
+++ b/frontend/src/components/__snapshots__/OAuth2Session.test.tsx.snap
@@ -76,7 +76,90 @@ exports[`<OAuth2Session /> > renders a finished session 1`] = `
 </div>
 `;
 
-exports[`<OAuth2Session /> > renders an active session 1`] = `null`;
+exports[`<OAuth2Session /> > renders an active session 1`] = `
+<div
+  className="_block_17898c _session_634806"
+>
+  <svg
+    aria-label="Computer"
+    className="_icon_e677aa"
+    fill="currentColor"
+    height="1em"
+    viewBox="0 0 24 24"
+    width="1em"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M4 18c-.55 0-1.02-.196-1.413-.587A1.926 1.926 0 0 1 2 16V5c0-.55.196-1.02.587-1.413A1.926 1.926 0 0 1 4 3h16c.55 0 1.02.196 1.413.587.39.393.587.863.587 1.413v11c0 .55-.196 1.02-.587 1.413A1.926 1.926 0 0 1 20 18H4Zm0-2h16V5H4v11Zm-2 5a.967.967 0 0 1-.712-.288A.968.968 0 0 1 1 20c0-.283.096-.52.288-.712A.967.967 0 0 1 2 19h20c.283 0 .52.096.712.288.192.191.288.429.288.712s-.096.52-.288.712A.968.968 0 0 1 22 21H2Z"
+    />
+  </svg>
+  <div
+    className="_container_634806"
+  >
+    <h6
+      className="_typography_yh5dq_162 _font-body-md-semibold_yh5dq_64 _sessionName_634806"
+      title="session-id"
+    >
+      <a
+        href="/sessions/session-id"
+        onClick={[Function]}
+        onFocus={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        onTouchStart={[Function]}
+        style={{}}
+      >
+        abcd1234
+      </a>
+    </h6>
+    <p
+      className="_typography_yh5dq_162 _font-body-sm-semibold_yh5dq_45 _sessionMetadata_634806"
+    >
+      Signed in 
+      <time
+        dateTime="2023-06-29T03:35:17Z"
+      >
+        Thu, 29 Jun 2023, 03:35
+      </time>
+    </p>
+    <p
+      className="_typography_yh5dq_162 _font-body-sm-regular_yh5dq_40 _sessionMetadata_634806"
+    >
+      1.2.3.4
+    </p>
+    <p
+      className="_typography_yh5dq_162 _font-body-sm-regular_yh5dq_40 _sessionMetadata_634806"
+    >
+       
+      <span
+        className="_typography_yh5dq_162 _font-body-sm-semibold_yh5dq_45 _sessionMetadata_634806"
+      >
+        Element
+      </span>
+    </p>
+    <div
+      className="_sessionActions_634806"
+    >
+      <button
+        aria-controls="radix-:r0:"
+        aria-disabled={false}
+        aria-expanded={false}
+        aria-haspopup="dialog"
+        className="_button_dyfp8_17 _destructive_dyfp8_99"
+        data-kind="secondary"
+        data-size="sm"
+        data-state="closed"
+        onClick={[Function]}
+        role="button"
+        tabIndex={0}
+        type="button"
+      >
+        End session
+      </button>
+    </div>
+  </div>
+</div>
+`;
 
 exports[`<OAuth2Session /> > renders correct icon for a native session 1`] = `
 <div

--- a/frontend/src/test-utils/router.tsx
+++ b/frontend/src/test-utils/router.tsx
@@ -19,6 +19,7 @@ import {
   createRoute,
   createRouter,
 } from "@tanstack/react-router";
+import { beforeAll } from "vitest";
 
 const rootRoute = createRootRoute();
 const index = createRoute({ getParentRoute: () => rootRoute, path: "/" });
@@ -28,6 +29,10 @@ const router = createRouter({
   history: createMemoryHistory(),
   routeTree: rootRoute,
 });
+
+const routerReady = router.load();
+// Make sure the router is ready before running any tests
+beforeAll(async () => await routerReady);
 
 export const DummyRouter: React.FC<React.PropsWithChildren> = ({
   children,


### PR DESCRIPTION
I can't figure out why it was the case, maybe a bug in @tanstack/router, but sometimes the router would render an empty `<div>` instead of its children.
This adds a `router.load()` call in the router test utility, and exports a `routerReady` promise which resolves when the router is ready to be used.

The big diff is because we had empty snapshots because of this. 🤦 
