### PR TITLE
Bump Clippy to 1.75 and Rust to 1.76

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -195,8 +195,8 @@ jobs:
 
       - name: Install toolchain
         run: |
-          rustup toolchain install 1.74.0
-          rustup default 1.74.0
+          rustup toolchain install 1.75.0
+          rustup default 1.75.0
           rustup component add clippy
 
       - name: Setup OPA

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,15 +8,15 @@
 # The Debian version and version name must be in sync
 ARG DEBIAN_VERSION=12
 ARG DEBIAN_VERSION_NAME=bookworm
-ARG RUSTC_VERSION=1.74.0
+ARG RUSTC_VERSION=1.76.0
 # XXX: Upgrade to 0.10.0 blocked by https://github.com/ziglang/zig/issues/10915#issuecomment-1354548110
 # XXX: Upgrade to 0.11.0 blocked by https://github.com/rust-cross/cargo-zigbuild/issues/162
 ARG ZIG_VERSION=0.9.1
 ARG NODEJS_VERSION=20.9.0
 ARG OPA_VERSION=0.59.0
-ARG CARGO_AUDITABLE_VERSION=0.6.1
-ARG CARGO_CHEF_VERSION=0.1.62
-ARG CARGO_ZIGBUILD_VERSION=0.17.5
+ARG CARGO_AUDITABLE_VERSION=0.6.2
+ARG CARGO_CHEF_VERSION=0.1.64
+ARG CARGO_ZIGBUILD_VERSION=0.18.3
 
 ##########################################
 ## Build stage that builds the frontend ##

--- a/crates/http/tests/client_layers.rs
+++ b/crates/http/tests/client_layers.rs
@@ -34,7 +34,7 @@ struct Error {
 
 #[tokio::test]
 async fn test_http_errors() {
-    async fn handle<B>(_request: Request<B>) -> Result<Response<String>, Infallible> {
+    async fn handle<B>(_: Request<B>) -> Result<Response<String>, Infallible> {
         let mut res = Response::new(r#"{"error": "invalid_request"}"#.to_owned());
         *res.status_mut() = StatusCode::BAD_REQUEST;
 

--- a/crates/i18n-scan/src/key.rs
+++ b/crates/i18n-scan/src/key.rs
@@ -69,7 +69,7 @@ impl Context {
             });
 
             let key = translatable
-                .key
+                .name
                 .split('.')
                 .chain(if translatable.kind == Kind::Plural {
                     Some("other")
@@ -111,15 +111,15 @@ pub struct Location {
 #[derive(Debug, Clone)]
 pub struct Key {
     kind: Kind,
-    key: String,
+    name: String,
     location: Option<Location>,
 }
 
 impl Key {
-    pub fn new(kind: Kind, key: String) -> Self {
+    pub fn new(kind: Kind, name: String) -> Self {
         Self {
             kind,
-            key,
+            name,
             location: None,
         }
     }

--- a/crates/i18n-scan/src/minijinja.rs
+++ b/crates/i18n-scan/src/minijinja.rs
@@ -122,7 +122,7 @@ fn find_in_call<'a>(
         if var_.id == context.func() {
             let key = call
                 .args
-                .get(0)
+                .first()
                 .and_then(as_const)
                 .and_then(|const_| const_.value.as_str())
                 .ok_or(minijinja::Error::new(

--- a/crates/oidc-client/src/types/client_credentials.rs
+++ b/crates/oidc-client/src/types/client_credentials.rs
@@ -368,6 +368,7 @@ impl RequestClientCredentials {
     }
 }
 
+#[allow(clippy::struct_field_names)] // All the fields start with `client_`
 #[skip_serializing_none]
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub(crate) struct BodyClientCredentials {

--- a/crates/storage-pg/src/user/session.rs
+++ b/crates/storage-pg/src/user/session.rs
@@ -49,6 +49,7 @@ impl<'c> PgBrowserSessionRepository<'c> {
     }
 }
 
+#[allow(clippy::struct_field_names)]
 #[derive(sqlx::FromRow)]
 #[sea_query::enum_def]
 struct SessionLookup {


### PR DESCRIPTION
Clippy 1.76 includes a `blocks_in_conditions` lint which gets triggered by [tracing](https://github.com/tokio-rs/tracing/issues/2876).
So for now, we hold back to 1.75.0.
