### PR TITLE
Ask Homeserver for username availability upon registration

### DIFF
--- a/crates/cli/src/app_state.rs
+++ b/crates/cli/src/app_state.rs
@@ -21,10 +21,12 @@ use axum::{
 use ipnetwork::IpNetwork;
 use mas_handlers::{
     passwords::PasswordManager, ActivityTracker, BoundActivityTracker, CookieManager, ErrorWrapper,
-    HttpClientFactory, MatrixHomeserver, MetadataCache, SiteConfig,
+    HttpClientFactory, MetadataCache, SiteConfig,
 };
 use mas_i18n::Translator;
 use mas_keystore::{Encrypter, Keystore};
+use mas_matrix::BoxHomeserverConnection;
+use mas_matrix_synapse::SynapseConnection;
 use mas_policy::{Policy, PolicyFactory};
 use mas_router::UrlBuilder;
 use mas_storage::{BoxClock, BoxRepository, BoxRng, Repository, SystemClock};
@@ -45,7 +47,7 @@ pub struct AppState {
     pub cookie_manager: CookieManager,
     pub encrypter: Encrypter,
     pub url_builder: UrlBuilder,
-    pub homeserver: MatrixHomeserver,
+    pub homeserver_connection: SynapseConnection,
     pub policy_factory: Arc<PolicyFactory>,
     pub graphql_schema: mas_graphql::Schema,
     pub http_client_factory: HttpClientFactory,
@@ -177,12 +179,6 @@ impl FromRef<AppState> for UrlBuilder {
     }
 }
 
-impl FromRef<AppState> for MatrixHomeserver {
-    fn from_ref(input: &AppState) -> Self {
-        input.homeserver.clone()
-    }
-}
-
 impl FromRef<AppState> for HttpClientFactory {
     fn from_ref(input: &AppState) -> Self {
         input.http_client_factory.clone()
@@ -210,6 +206,12 @@ impl FromRef<AppState> for MetadataCache {
 impl FromRef<AppState> for SiteConfig {
     fn from_ref(input: &AppState) -> Self {
         input.site_config.clone()
+    }
+}
+
+impl FromRef<AppState> for BoxHomeserverConnection {
+    fn from_ref(input: &AppState) -> Self {
+        Box::new(input.homeserver_connection.clone())
     }
 }
 

--- a/crates/handlers/src/compat/mod.rs
+++ b/crates/handlers/src/compat/mod.rs
@@ -22,22 +22,6 @@ pub(crate) mod login_sso_redirect;
 pub(crate) mod logout;
 pub(crate) mod refresh;
 
-#[derive(Debug, Clone)]
-pub struct MatrixHomeserver(String);
-
-impl MatrixHomeserver {
-    #[must_use]
-    pub const fn new(hs: String) -> Self {
-        Self(hs)
-    }
-}
-
-impl std::fmt::Display for MatrixHomeserver {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.0.fmt(f)
-    }
-}
-
 #[derive(Debug, Serialize)]
 struct MatrixError {
     errcode: &'static str,

--- a/crates/handlers/src/lib.rs
+++ b/crates/handlers/src/lib.rs
@@ -320,6 +320,7 @@ where
     PasswordManager: FromRef<S>,
     MetadataCache: FromRef<S>,
     SiteConfig: FromRef<S>,
+    BoxHomeserverConnection: FromRef<S>,
     BoxClock: FromRequestParts<S>,
     BoxRng: FromRequestParts<S>,
     Policy: FromRequestParts<S>,

--- a/crates/handlers/src/lib.rs
+++ b/crates/handlers/src/lib.rs
@@ -43,6 +43,7 @@ use hyper::{
 use mas_axum_utils::{cookies::CookieJar, FancyError};
 use mas_http::CorsLayerExt;
 use mas_keystore::{Encrypter, Keystore};
+use mas_matrix::BoxHomeserverConnection;
 use mas_policy::Policy;
 use mas_router::{Route, UrlBuilder};
 use mas_storage::{BoxClock, BoxRepository, BoxRng};
@@ -88,7 +89,6 @@ pub use mas_axum_utils::{
 
 pub use self::{
     activity_tracker::{ActivityTracker, Bound as BoundActivityTracker},
-    compat::MatrixHomeserver,
     graphql::schema as graphql_schema,
     preferred_language::PreferredLanguage,
     site_config::SiteConfig,
@@ -253,7 +253,7 @@ where
     S: Clone + Send + Sync + 'static,
     UrlBuilder: FromRef<S>,
     SiteConfig: FromRef<S>,
-    MatrixHomeserver: FromRef<S>,
+    BoxHomeserverConnection: FromRef<S>,
     PasswordManager: FromRef<S>,
     BoundActivityTracker: FromRequestParts<S>,
     BoxRepository: FromRequestParts<S>,

--- a/crates/matrix-synapse/src/lib.rs
+++ b/crates/matrix-synapse/src/lib.rs
@@ -22,6 +22,7 @@ use url::Url;
 
 static SYNAPSE_AUTH_PROVIDER: &str = "oauth-delegated";
 
+#[derive(Clone)]
 pub struct SynapseConnection {
     homeserver: String,
     endpoint: Url,

--- a/crates/matrix/src/lib.rs
+++ b/crates/matrix/src/lib.rs
@@ -219,6 +219,17 @@ pub trait HomeserverConnection: Send + Sync {
     /// be provisioned.
     async fn provision_user(&self, request: &ProvisionRequest) -> Result<bool, Self::Error>;
 
+    /// Check whether a given username is available on the homeserver.
+    ///
+    /// # Parameters
+    ///
+    /// * `localpart` - The localpart to check.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the homeserver is unreachable.
+    async fn is_localpart_available(&self, localpart: &str) -> Result<bool, Self::Error>;
+
     /// Create a device for a user on the homeserver.
     ///
     /// # Parameters
@@ -310,6 +321,10 @@ impl<T: HomeserverConnection + Send + Sync + ?Sized> HomeserverConnection for &T
 
     async fn provision_user(&self, request: &ProvisionRequest) -> Result<bool, Self::Error> {
         (**self).provision_user(request).await
+    }
+
+    async fn is_localpart_available(&self, localpart: &str) -> Result<bool, Self::Error> {
+        (**self).is_localpart_available(localpart).await
     }
 
     async fn create_device(&self, mxid: &str, device_id: &str) -> Result<(), Self::Error> {

--- a/frontend/schema.graphql
+++ b/frontend/schema.graphql
@@ -72,6 +72,14 @@ input AddUserInput {
   The username of the user to add.
   """
   username: String!
+  """
+  Skip checking with the homeserver whether the username is valid.
+
+  Use this with caution! The main reason to use this, is when a user used
+  by an application service needs to exist in MAS to craft special
+  tokens (like with admin access) for them
+  """
+  skipHomeserverCheck: Boolean
 }
 
 """
@@ -100,6 +108,10 @@ enum AddUserStatus {
   The user already exists.
   """
   EXISTS
+  """
+  The username is reserved.
+  """
+  RESERVED
   """
   The username is invalid.
   """

--- a/frontend/src/gql/graphql.ts
+++ b/frontend/src/gql/graphql.ts
@@ -76,6 +76,14 @@ export enum AddEmailStatus {
 
 /** The input for the `addUser` mutation. */
 export type AddUserInput = {
+  /**
+   * Skip checking with the homeserver whether the username is valid.
+   *
+   * Use this with caution! The main reason to use this, is when a user used
+   * by an application service needs to exist in MAS to craft special
+   * tokens (like with admin access) for them
+   */
+  skipHomeserverCheck?: InputMaybe<Scalars["Boolean"]["input"]>;
   /** The username of the user to add. */
   username: Scalars["String"]["input"];
 };
@@ -97,6 +105,8 @@ export enum AddUserStatus {
   Exists = "EXISTS",
   /** The username is invalid. */
   Invalid = "INVALID",
+  /** The username is reserved. */
+  Reserved = "RESERVED",
 }
 
 /** The input for the `allowUserCrossSigningReset` mutation. */


### PR DESCRIPTION
Fixes #2376 

Whenever MAS register a user, from the registration form, the upstream OAuth 2.0 registration or the GraphQL API, it now ask the homeserver whether the username is available.
This makes sure a user doesn't accidentally register with a username used by an internal account or by an application service.

This check can be bypassed on the GraphQL API by administrators using the new `skipHomeserverCheck` flag.

This can be reviewed commit-by-commit.