### PR TITLE
Add Electron user-agent parsing for Element Desktop/Nightly

### DIFF
--- a/crates/data-model/src/user_agent.rs
+++ b/crates/data-model/src/user_agent.rs
@@ -84,7 +84,7 @@ impl UserAgent {
         let regex = regex::Regex::new(r"(?m)\w+/[\w.]+").unwrap();
         let omit_keys = ["Mozilla", "AppleWebKit", "Chrome", "Electron", "Safari"];
         return regex
-            .find_iter(&user_agent)
+            .find_iter(user_agent)
             .map(|caps| caps.as_str().split_once('/').unwrap())
             .find(|pair| !omit_keys.contains(&pair.0));
     }

--- a/crates/data-model/src/user_agent.rs
+++ b/crates/data-model/src/user_agent.rs
@@ -209,14 +209,8 @@ impl UserAgent {
             let omit_keys = ["Mozilla", "AppleWebKit", "Chrome", "Electron", "Safari"];
             let app = regex
                 .find_iter(&user_agent)
-                .map(|caps| caps.as_str().split_once("/").unwrap())
-                .find_map(|pair| {
-                    if !omit_keys.contains(&pair.0) {
-                        Some(pair)
-                    } else {
-                        None
-                    }
-                })
+                .map(|caps| caps.as_str().split_once('/').unwrap())
+                .find(|pair| !omit_keys.contains(&pair.0))
                 .unwrap();
             result.name = app.0;
             result.version = app.1;

--- a/crates/data-model/src/user_agent.rs
+++ b/crates/data-model/src/user_agent.rs
@@ -210,7 +210,13 @@ impl UserAgent {
             let app = regex
                 .find_iter(&user_agent)
                 .map(|caps| caps.as_str().split_once("/").unwrap())
-                .find_map(|pair| if !omit_keys.contains(&pair.0) { Some(pair) } else { None })
+                .find_map(|pair| {
+                    if !omit_keys.contains(&pair.0) {
+                        Some(pair)
+                    } else {
+                        None
+                    }
+                })
                 .unwrap();
             result.name = app.0;
             result.version = app.1;

--- a/crates/data-model/src/user_agent.rs
+++ b/crates/data-model/src/user_agent.rs
@@ -203,6 +203,19 @@ impl UserAgent {
             result.os_version = version.into();
         }
 
+        // Special handling for Electron applications e.g. Element Desktop
+        if user_agent.contains("Electron/") {
+            let regex = regex::Regex::new(r"(?m)\w+/[\w.]+").unwrap();
+            let omit_keys = ["Mozilla", "AppleWebKit", "Chrome", "Electron", "Safari"];
+            let app = regex
+                .find_iter(&user_agent)
+                .map(|caps| caps.as_str().split_once("/").unwrap())
+                .find_map(|pair| if !omit_keys.contains(&pair.0) { Some(pair) } else { None })
+                .unwrap();
+            result.name = app.0;
+            result.version = app.1;
+        }
+
         Self {
             name: (result.name != VALUE_UNKNOWN).then(|| result.name.to_owned()),
             version: (result.version != VALUE_UNKNOWN).then(|| result.version.to_owned()),


### PR DESCRIPTION
```
 ~/W/matrix-authentication-service   t3chguy/compat-scopes *…  echo "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) ElementNightly/2024030801 Chrome/120.0.60
99.291 Electron/28.2.5 Safari/537.36" | cargo run --quiet -p mas-data-model --example ua-parser
UserAgent { name: Some("ElementNightly"), version: Some("2024030801"), os: Some("macOS"), os_version: None, model: None, device_type: Pc, raw: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) ElementNightly/2024030801 Chrome/120.0.6099.291 Electron/28.2.5 Safari/537.36" }
 ~/W/matrix-authentication-service   t3chguy/compat-scopes *…  echo "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Element/1.11.59 Chrome/120.0.6099.291 Electron/28.2.6 Saf
ari/537.36" | cargo run --quiet -p mas-data-model --example ua-parser
UserAgent { name: Some("Element"), version: Some("1.11.59"), os: Some("Linux"), os_version: None, model: None, device_type: Pc, raw: "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Element/1.11.59 Chrome/120.0.6099.291 Electron/28.2.6 Safari/537.36" }
```