### PR TITLE
Do not expose error type from mas-keystore in mas-oidc-client

### DIFF
--- a/crates/oidc-client/src/error.rs
+++ b/crates/oidc-client/src/error.rs
@@ -24,7 +24,6 @@ use mas_jose::{
     jwa::InvalidAlgorithm,
     jwt::{JwtDecodeError, JwtSignatureError, NoKeyWorked},
 };
-use mas_keystore::WrongAlgorithmError;
 use oauth2_types::{
     errors::ClientErrorCode, oidc::ProviderMetadataVerificationError, pkce::CodeChallengeError,
 };
@@ -693,8 +692,8 @@ pub enum CredentialsError {
     JwtClaims(#[from] ClaimError),
 
     /// The key found cannot be used with the algorithm.
-    #[error(transparent)]
-    JwtWrongAlgorithm(#[from] WrongAlgorithmError),
+    #[error("Wrong algorithm for key")]
+    JwtWrongAlgorithm,
 
     /// An error occurred when signing the JWT.
     #[error(transparent)]

--- a/crates/oidc-client/src/types/client_credentials.rs
+++ b/crates/oidc-client/src/types/client_credentials.rs
@@ -340,7 +340,10 @@ impl RequestClientCredentials {
                         let key = keystore
                             .signing_key_for_algorithm(&signing_algorithm)
                             .ok_or(CredentialsError::NoPrivateKeyFound)?;
-                        let signer = key.params().signing_key_for_alg(&signing_algorithm)?;
+                        let signer = key
+                            .params()
+                            .signing_key_for_alg(&signing_algorithm)
+                            .map_err(|_| CredentialsError::JwtWrongAlgorithm)?;
                         let mut header = JsonWebSignatureHeader::new(signing_algorithm);
 
                         if let Some(kid) = key.kid() {


### PR DESCRIPTION
The mas-keystore crate is an optional dependency so setting "default-features" to `false`
results in a compilation error.

Since the enum is exhaustive, the corresponding error variant cannot be behind a cargo feature.

The simple solution here is to stop using the error type from the crate and use a custom variant instead.