### PR TITLE
fix(register.rego): increase allowed username length to 64

### DIFF
--- a/policies/register.rego
+++ b/policies/register.rego
@@ -19,7 +19,7 @@ violation[{"field": "username", "msg": "username too short"}] {
 }
 
 violation[{"field": "username", "msg": "username too long"}] {
-	count(input.username) >= 15
+	count(input.username) >= 64
 }
 
 violation[{"field": "username", "msg": "username contains invalid characters"}] {

--- a/policies/register.rego
+++ b/policies/register.rego
@@ -19,7 +19,7 @@ violation[{"field": "username", "msg": "username too short"}] {
 }
 
 violation[{"field": "username", "msg": "username too long"}] {
-	count(input.username) >= 64
+	count(input.username) > 64
 }
 
 violation[{"field": "username", "msg": "username contains invalid characters"}] {

--- a/policies/register_test.rego
+++ b/policies/register_test.rego
@@ -45,7 +45,7 @@ test_short_username {
 }
 
 test_long_username {
-	not allow with input as {"username": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "registration_method": "upstream-oauth2"}
+	not allow with input as {"username": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "registration_method": "upstream-oauth2"}
 }
 
 test_invalid_username {


### PR DESCRIPTION
This PR addresses the issue https://github.com/matrix-org/matrix-authentication-service/issues/2454

## Reason

The current username limit of 14 characters feels arbitrary and I did not find any reason for that limit.

I checked the following components:
- **MAS Database**: The column `username` in `users` is of type `text` and hence not limiting the username length.
- **Synapse**:  To test a long username, I  created a new account on matrix.org with a username that is 64 characters long. It worked without any issues.