### PR TITLE
Cleanup configuration handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3023,6 +3023,7 @@ dependencies = [
  "camino",
  "clap",
  "dotenvy",
+ "figment",
  "httpdate",
  "hyper",
  "ipnetwork",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3084,7 +3084,6 @@ name = "mas-config"
 version = "0.8.0"
 dependencies = [
  "anyhow",
- "async-trait",
  "camino",
  "chrono",
  "figment",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,11 @@ features = ["serde", "clock"]
 version = "4.5.3"
 features = ["derive"]
 
+# Configuration loading
+[workspace.dependencies.figment]
+version = "0.10.15"
+features = ["env", "yaml", "test"]
+
 # HTTP headers
 [workspace.dependencies.headers]
 version = "0.3.9"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -17,6 +17,7 @@ axum = "0.6.20"
 camino.workspace = true
 clap.workspace = true
 dotenvy = "0.15.7"
+figment.workspace = true
 httpdate = "1.0.3"
 hyper.workspace = true
 ipnetwork = "0.20.0"

--- a/crates/cli/src/commands/database.rs
+++ b/crates/cli/src/commands/database.rs
@@ -14,7 +14,8 @@
 
 use anyhow::Context;
 use clap::Parser;
-use mas_config::DatabaseConfig;
+use figment::Figment;
+use mas_config::{ConfigurationSection, DatabaseConfig};
 use mas_storage_pg::MIGRATOR;
 use tracing::{info_span, Instrument};
 
@@ -33,9 +34,9 @@ enum Subcommand {
 }
 
 impl Options {
-    pub async fn run(self, root: &super::Options) -> anyhow::Result<()> {
+    pub async fn run(self, figment: &Figment) -> anyhow::Result<()> {
         let _span = info_span!("cli.database.migrate").entered();
-        let config: DatabaseConfig = root.load_config()?;
+        let config = DatabaseConfig::extract(figment)?;
         let mut conn = database_connection_from_config(&config).await?;
 
         // Run pending migrations

--- a/crates/cli/src/commands/debug.rs
+++ b/crates/cli/src/commands/debug.rs
@@ -13,8 +13,9 @@
 // limitations under the License.
 
 use clap::Parser;
+use figment::Figment;
 use hyper::{Response, Uri};
-use mas_config::PolicyConfig;
+use mas_config::{ConfigurationSection, PolicyConfig};
 use mas_handlers::HttpClientFactory;
 use mas_http::HttpServiceExt;
 use tokio::io::AsyncWriteExt;
@@ -65,7 +66,7 @@ fn print_headers(parts: &hyper::http::response::Parts) {
 
 impl Options {
     #[tracing::instrument(skip_all)]
-    pub async fn run(self, root: &super::Options) -> anyhow::Result<()> {
+    pub async fn run(self, figment: &Figment) -> anyhow::Result<()> {
         use Subcommand as SC;
         let http_client_factory = HttpClientFactory::new();
         match self.subcommand {
@@ -120,7 +121,7 @@ impl Options {
 
             SC::Policy => {
                 let _span = info_span!("cli.debug.policy").entered();
-                let config: PolicyConfig = root.load_config()?;
+                let config = PolicyConfig::extract(figment)?;
                 info!("Loading and compiling the policy module");
                 let policy_factory = policy_factory_from_config(&config).await?;
 

--- a/crates/cli/src/commands/doctor.rs
+++ b/crates/cli/src/commands/doctor.rs
@@ -19,7 +19,8 @@
 
 use anyhow::Context;
 use clap::Parser;
-use mas_config::RootConfig;
+use figment::Figment;
+use mas_config::{ConfigurationSection, RootConfig};
 use mas_handlers::HttpClientFactory;
 use mas_http::HttpServiceExt;
 use tower::{Service, ServiceExt};
@@ -34,11 +35,11 @@ pub(super) struct Options {}
 
 impl Options {
     #[allow(clippy::too_many_lines)]
-    pub async fn run(self, root: &super::Options) -> anyhow::Result<()> {
+    pub async fn run(self, figment: &Figment) -> anyhow::Result<()> {
         let _span = info_span!("cli.doctor").entered();
         info!("💡 Running diagnostics, make sure that both MAS and Synapse are running, and that MAS is using the same configuration files as this tool.");
 
-        let config: RootConfig = root.load_config()?;
+        let config = RootConfig::extract(figment)?;
 
         // We'll need an HTTP client
         let http_client_factory = HttpClientFactory::new();

--- a/crates/cli/src/commands/templates.rs
+++ b/crates/cli/src/commands/templates.rs
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 use clap::Parser;
-use mas_config::{BrandingConfig, MatrixConfig, TemplatesConfig};
+use figment::Figment;
+use mas_config::{BrandingConfig, ConfigurationSection, MatrixConfig, TemplatesConfig};
 use mas_storage::{Clock, SystemClock};
 use rand::SeedableRng;
 use tracing::info_span;
@@ -33,15 +34,15 @@ enum Subcommand {
 }
 
 impl Options {
-    pub async fn run(self, root: &super::Options) -> anyhow::Result<()> {
+    pub async fn run(self, figment: &Figment) -> anyhow::Result<()> {
         use Subcommand as SC;
         match self.subcommand {
             SC::Check => {
                 let _span = info_span!("cli.templates.check").entered();
 
-                let template_config: TemplatesConfig = root.load_config()?;
-                let branding_config: BrandingConfig = root.load_config()?;
-                let matrix_config: MatrixConfig = root.load_config()?;
+                let template_config = TemplatesConfig::extract(figment)?;
+                let branding_config = BrandingConfig::extract(figment)?;
+                let matrix_config = MatrixConfig::extract(figment)?;
 
                 let clock = SystemClock::default();
                 // XXX: we should disallow SeedableRng::from_entropy

--- a/crates/cli/src/commands/worker.rs
+++ b/crates/cli/src/commands/worker.rs
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 use clap::Parser;
-use mas_config::AppConfig;
+use figment::Figment;
+use mas_config::{AppConfig, ConfigurationSection};
 use mas_handlers::HttpClientFactory;
 use mas_matrix_synapse::SynapseConnection;
 use mas_router::UrlBuilder;
@@ -29,9 +30,9 @@ use crate::util::{database_pool_from_config, mailer_from_config, templates_from_
 pub(super) struct Options {}
 
 impl Options {
-    pub async fn run(self, root: &super::Options) -> anyhow::Result<()> {
+    pub async fn run(self, figment: &Figment) -> anyhow::Result<()> {
         let span = info_span!("cli.worker.init").entered();
-        let config: AppConfig = root.load_config()?;
+        let config = AppConfig::extract(figment)?;
 
         // Connect to the database
         info!("Connecting to the database");

--- a/crates/cli/src/server.rs
+++ b/crates/cli/src/server.rs
@@ -48,7 +48,7 @@ use rustls::ServerConfig;
 use sentry_tower::{NewSentryLayer, SentryHttpLayer};
 use tower::Layer;
 use tower_http::{services::ServeDir, set_header::SetResponseHeaderLayer};
-use tracing::{warn, Span};
+use tracing::Span;
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 
 use crate::app_state::AppState;
@@ -243,12 +243,6 @@ where
                     format!("{connection:?}")
                 }),
             ),
-
-            #[allow(deprecated)]
-            mas_config::HttpResource::Spa { .. } => {
-                warn!("The SPA HTTP resource is deprecated");
-                router
-            }
         }
     }
 

--- a/crates/cli/src/sync.rs
+++ b/crates/cli/src/sync.rs
@@ -259,10 +259,10 @@ pub async fn config_sync(
                 continue;
             }
 
-            let client_secret = client.client_secret();
+            let client_secret = client.client_secret.as_deref();
             let client_auth_method = client.client_auth_method();
-            let jwks = client.jwks();
-            let jwks_uri = client.jwks_uri();
+            let jwks = client.jwks.as_ref();
+            let jwks_uri = client.jwks_uri.as_ref();
 
             // TODO: should be moved somewhere else
             let encrypted_client_secret = client_secret

--- a/crates/cli/src/util.rs
+++ b/crates/cli/src/util.rs
@@ -114,13 +114,9 @@ pub async fn policy_factory_from_config(
         password: config.password_entrypoint.clone(),
     };
 
-    PolicyFactory::load(
-        policy_file,
-        config.data.clone().unwrap_or_default(),
-        entrypoints,
-    )
-    .await
-    .context("failed to load the policy")
+    PolicyFactory::load(policy_file, config.data.clone(), entrypoints)
+        .await
+        .context("failed to load the policy")
 }
 
 pub async fn templates_from_config(

--- a/crates/cli/src/util.rs
+++ b/crates/cli/src/util.rs
@@ -41,11 +41,11 @@ pub async fn password_manager_from_config(
         .load()
         .await?
         .into_iter()
-        .map(|(version, algorithm, secret)| {
+        .map(|(version, algorithm, cost, secret)| {
             use mas_handlers::passwords::Hasher;
             let hasher = match algorithm {
                 mas_config::PasswordAlgorithm::Pbkdf2 => Hasher::pbkdf2(secret),
-                mas_config::PasswordAlgorithm::Bcrypt { cost } => Hasher::bcrypt(cost, secret),
+                mas_config::PasswordAlgorithm::Bcrypt => Hasher::bcrypt(cost, secret),
                 mas_config::PasswordAlgorithm::Argon2id => Hasher::argon2id(secret),
             };
 

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -14,7 +14,6 @@ workspace = true
 [dependencies]
 tokio = { version = "1.36.0", features = ["fs", "rt"] }
 tracing.workspace = true
-async-trait.workspace = true
 
 thiserror.workspace = true
 anyhow.workspace = true

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -21,7 +21,7 @@ anyhow.workspace = true
 
 camino = { workspace = true, features = ["serde1"] }
 chrono.workspace = true
-figment = { version = "0.10.15", features = ["env", "yaml", "test"] }
+figment.workspace = true
 ipnetwork = { version = "0.20.0", features = ["serde", "schemars"] }
 schemars.workspace = true
 ulid.workspace = true

--- a/crates/config/src/schema.rs
+++ b/crates/config/src/schema.rs
@@ -16,36 +16,27 @@
 
 use schemars::{
     gen::SchemaGenerator,
-    schema::{InstanceType, NumberValidation, Schema, SchemaObject},
+    schema::{InstanceType, Schema, SchemaObject},
+    JsonSchema,
 };
 
-/// A network port
-pub fn port(_gen: &mut SchemaGenerator) -> Schema {
-    Schema::Object(SchemaObject {
-        instance_type: Some(InstanceType::Integer.into()),
-        number: Some(Box::new(NumberValidation {
-            minimum: Some(1.0),
-            maximum: Some(65535.0),
-            ..NumberValidation::default()
-        })),
-        ..SchemaObject::default()
-    })
+/// A network hostname
+pub struct Hostname;
+
+impl JsonSchema for Hostname {
+    fn schema_name() -> String {
+        "Hostname".to_string()
+    }
+
+    fn json_schema(gen: &mut SchemaGenerator) -> Schema {
+        hostname(gen)
+    }
 }
 
-/// A network hostname
-pub fn hostname(_gen: &mut SchemaGenerator) -> Schema {
+fn hostname(_gen: &mut SchemaGenerator) -> Schema {
     Schema::Object(SchemaObject {
         instance_type: Some(InstanceType::String.into()),
         format: Some("hostname".to_owned()),
-        ..SchemaObject::default()
-    })
-}
-
-/// An email address
-pub fn mailbox(_gen: &mut SchemaGenerator) -> Schema {
-    Schema::Object(SchemaObject {
-        instance_type: Some(InstanceType::String.into()),
-        format: Some("email".to_owned()),
         ..SchemaObject::default()
     })
 }

--- a/crates/config/src/sections/branding.rs
+++ b/crates/config/src/sections/branding.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use async_trait::async_trait;
-use rand::Rng;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use url::Url;
@@ -24,38 +22,42 @@ use crate::ConfigurationSection;
 #[derive(Clone, Debug, Deserialize, JsonSchema, Serialize, Default)]
 pub struct BrandingConfig {
     /// A human-readable name. Defaults to the server's address.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub service_name: Option<String>,
 
     /// Link to a privacy policy, displayed in the footer of web pages and
     /// emails. It is also advertised to clients through the `op_policy_uri`
     /// OIDC provider metadata.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub policy_uri: Option<Url>,
 
     /// Link to a terms of service document, displayed in the footer of web
     /// pages and emails. It is also advertised to clients through the
     /// `op_tos_uri` OIDC provider metadata.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub tos_uri: Option<Url>,
 
     /// Legal imprint, displayed in the footer in the footer of web pages and
     /// emails.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub imprint: Option<String>,
 
     /// Logo displayed in some web pages.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub logo_uri: Option<Url>,
 }
 
-#[async_trait]
+impl BrandingConfig {
+    /// Returns true if the configuration is the default one
+    pub(crate) fn is_default(&self) -> bool {
+        self.service_name.is_none()
+            && self.policy_uri.is_none()
+            && self.tos_uri.is_none()
+            && self.imprint.is_none()
+            && self.logo_uri.is_none()
+    }
+}
+
 impl ConfigurationSection for BrandingConfig {
     const PATH: Option<&'static str> = Some("branding");
-
-    async fn generate<R>(_rng: R) -> anyhow::Result<Self>
-    where
-        R: Rng + Send,
-    {
-        Ok(Self::default())
-    }
-
-    fn test() -> Self {
-        Self::default()
-    }
 }

--- a/crates/config/src/sections/branding.rs
+++ b/crates/config/src/sections/branding.rs
@@ -46,9 +46,7 @@ pub struct BrandingConfig {
 
 #[async_trait]
 impl ConfigurationSection for BrandingConfig {
-    fn path() -> &'static str {
-        "branding"
-    }
+    const PATH: Option<&'static str> = Some("branding");
 
     async fn generate<R>(_rng: R) -> anyhow::Result<Self>
     where

--- a/crates/config/src/sections/clients.rs
+++ b/crates/config/src/sections/clients.rs
@@ -14,11 +14,9 @@
 
 use std::ops::Deref;
 
-use async_trait::async_trait;
 use figment::Figment;
 use mas_iana::oauth::OAuthClientAuthenticationMethod;
 use mas_jose::jwk::PublicJsonWebKeySet;
-use rand::Rng;
 use schemars::JsonSchema;
 use serde::{de::Error, Deserialize, Serialize};
 use ulid::Ulid;
@@ -211,6 +209,13 @@ impl ClientConfig {
 #[serde(transparent)]
 pub struct ClientsConfig(#[schemars(with = "Vec::<ClientConfig>")] Vec<ClientConfig>);
 
+impl ClientsConfig {
+    /// Returns true if all fields are at their default values
+    pub(crate) fn is_default(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
 impl Deref for ClientsConfig {
     type Target = Vec<ClientConfig>;
 
@@ -228,16 +233,8 @@ impl IntoIterator for ClientsConfig {
     }
 }
 
-#[async_trait]
 impl ConfigurationSection for ClientsConfig {
     const PATH: Option<&'static str> = Some("clients");
-
-    async fn generate<R>(_rng: R) -> anyhow::Result<Self>
-    where
-        R: Rng + Send,
-    {
-        Ok(Self::default())
-    }
 
     fn validate(&self, figment: &Figment) -> Result<(), figment::error::Error> {
         for (index, client) in self.0.iter().enumerate() {
@@ -252,10 +249,6 @@ impl ConfigurationSection for ClientsConfig {
         }
 
         Ok(())
-    }
-
-    fn test() -> Self {
-        Self::default()
     }
 }
 

--- a/crates/config/src/sections/clients.rs
+++ b/crates/config/src/sections/clients.rs
@@ -201,7 +201,10 @@ impl ConfigurationSection for ClientsConfig {
 mod tests {
     use std::str::FromStr;
 
-    use figment::Jail;
+    use figment::{
+        providers::{Format, Yaml},
+        Figment, Jail,
+    };
 
     use super::*;
 
@@ -249,7 +252,9 @@ mod tests {
                 "#,
             )?;
 
-            let config = ClientsConfig::load_from_file("config.yaml")?;
+            let config = Figment::new()
+                .merge(Yaml::file("config.yaml"))
+                .extract_inner::<ClientsConfig>("clients")?;
 
             assert_eq!(config.0.len(), 5);
 

--- a/crates/config/src/sections/clients.rs
+++ b/crates/config/src/sections/clients.rs
@@ -12,16 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::ops::{Deref, DerefMut};
+use std::ops::Deref;
 
 use async_trait::async_trait;
+use figment::Figment;
 use mas_iana::oauth::OAuthClientAuthenticationMethod;
 use mas_jose::jwk::PublicJsonWebKeySet;
 use rand::Rng;
 use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
-use serde_with::skip_serializing_none;
-use thiserror::Error;
+use serde::{de::Error, Deserialize, Serialize};
 use ulid::Ulid;
 use url::Url;
 
@@ -41,40 +40,42 @@ impl From<PublicJsonWebKeySet> for JwksOrJwksUri {
 }
 
 /// Authentication method used by clients
-#[derive(JsonSchema, Serialize, Deserialize, Clone, Debug)]
-#[serde(tag = "client_auth_method", rename_all = "snake_case")]
+#[derive(JsonSchema, Serialize, Deserialize, Copy, Clone, Debug)]
+#[serde(rename_all = "snake_case")]
 pub enum ClientAuthMethodConfig {
     /// `none`: No authentication
     None,
 
     /// `client_secret_basic`: `client_id` and `client_secret` used as basic
     /// authorization credentials
-    ClientSecretBasic {
-        /// The client secret
-        client_secret: String,
-    },
+    ClientSecretBasic,
 
     /// `client_secret_post`: `client_id` and `client_secret` sent in the
     /// request body
-    ClientSecretPost {
-        /// The client secret
-        client_secret: String,
-    },
+    ClientSecretPost,
 
     /// `client_secret_basic`: a `client_assertion` sent in the request body and
     /// signed using the `client_secret`
-    ClientSecretJwt {
-        /// The client secret
-        client_secret: String,
-    },
+    ClientSecretJwt,
 
     /// `client_secret_basic`: a `client_assertion` sent in the request body and
     /// signed by an asymmetric key
-    PrivateKeyJwt(JwksOrJwksUri),
+    PrivateKeyJwt,
+}
+
+impl std::fmt::Display for ClientAuthMethodConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ClientAuthMethodConfig::None => write!(f, "none"),
+            ClientAuthMethodConfig::ClientSecretBasic => write!(f, "client_secret_basic"),
+            ClientAuthMethodConfig::ClientSecretPost => write!(f, "client_secret_post"),
+            ClientAuthMethodConfig::ClientSecretJwt => write!(f, "client_secret_jwt"),
+            ClientAuthMethodConfig::PrivateKeyJwt => write!(f, "private_key_jwt"),
+        }
+    }
 }
 
 /// An OAuth 2.0 client configuration
-#[skip_serializing_none]
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct ClientConfig {
     /// The client ID
@@ -86,67 +87,121 @@ pub struct ClientConfig {
     pub client_id: Ulid,
 
     /// Authentication method used for this client
-    #[serde(flatten)]
-    pub client_auth_method: ClientAuthMethodConfig,
+    client_auth_method: ClientAuthMethodConfig,
+
+    /// The client secret, used by the `client_secret_basic`,
+    /// `client_secret_post` and `client_secret_jwt` authentication methods
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub client_secret: Option<String>,
+
+    /// The JSON Web Key Set (JWKS) used by the `private_key_jwt` authentication
+    /// method. Mutually exclusive with `jwks_uri`
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub jwks: Option<PublicJsonWebKeySet>,
+
+    /// The URL of the JSON Web Key Set (JWKS) used by the `private_key_jwt`
+    /// authentication method. Mutually exclusive with `jwks`
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub jwks_uri: Option<Url>,
 
     /// List of allowed redirect URIs
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub redirect_uris: Vec<Url>,
 }
 
-#[derive(Debug, Error)]
-#[error("Invalid redirect URI")]
-pub struct InvalidRedirectUriError;
-
 impl ClientConfig {
-    #[doc(hidden)]
-    #[must_use]
-    pub fn client_secret(&self) -> Option<&str> {
-        match &self.client_auth_method {
-            ClientAuthMethodConfig::ClientSecretPost { client_secret }
-            | ClientAuthMethodConfig::ClientSecretBasic { client_secret }
-            | ClientAuthMethodConfig::ClientSecretJwt { client_secret } => Some(client_secret),
-            _ => None,
+    fn validate(&self) -> Result<(), figment::error::Error> {
+        let auth_method = self.client_auth_method;
+        match self.client_auth_method {
+            ClientAuthMethodConfig::PrivateKeyJwt => {
+                if self.jwks.is_none() && self.jwks_uri.is_none() {
+                    let error = figment::error::Error::custom(
+                        "jwks or jwks_uri is required for private_key_jwt",
+                    );
+                    return Err(error.with_path("client_auth_method"));
+                }
+
+                if self.jwks.is_some() && self.jwks_uri.is_some() {
+                    let error =
+                        figment::error::Error::custom("jwks and jwks_uri are mutually exclusive");
+                    return Err(error.with_path("jwks"));
+                }
+
+                if self.client_secret.is_some() {
+                    let error = figment::error::Error::custom(
+                        "client_secret is not allowed with private_key_jwt",
+                    );
+                    return Err(error.with_path("client_secret"));
+                }
+            }
+
+            ClientAuthMethodConfig::ClientSecretPost
+            | ClientAuthMethodConfig::ClientSecretBasic
+            | ClientAuthMethodConfig::ClientSecretJwt => {
+                if self.client_secret.is_none() {
+                    let error = figment::error::Error::custom(format!(
+                        "client_secret is required for {auth_method}"
+                    ));
+                    return Err(error.with_path("client_auth_method"));
+                }
+
+                if self.jwks.is_some() {
+                    let error = figment::error::Error::custom(format!(
+                        "jwks is not allowed with {auth_method}"
+                    ));
+                    return Err(error.with_path("jwks"));
+                }
+
+                if self.jwks_uri.is_some() {
+                    let error = figment::error::Error::custom(format!(
+                        "jwks_uri is not allowed with {auth_method}"
+                    ));
+                    return Err(error.with_path("jwks_uri"));
+                }
+            }
+
+            ClientAuthMethodConfig::None => {
+                if self.client_secret.is_some() {
+                    let error = figment::error::Error::custom(
+                        "client_secret is not allowed with none authentication method",
+                    );
+                    return Err(error.with_path("client_secret"));
+                }
+
+                if self.jwks.is_some() {
+                    let error = figment::error::Error::custom(
+                        "jwks is not allowed with none authentication method",
+                    );
+                    return Err(error);
+                }
+
+                if self.jwks_uri.is_some() {
+                    let error = figment::error::Error::custom(
+                        "jwks_uri is not allowed with none authentication method",
+                    );
+                    return Err(error);
+                }
+            }
         }
+
+        Ok(())
     }
 
-    #[doc(hidden)]
+    /// Authentication method used for this client
     #[must_use]
     pub fn client_auth_method(&self) -> OAuthClientAuthenticationMethod {
-        match &self.client_auth_method {
+        match self.client_auth_method {
             ClientAuthMethodConfig::None => OAuthClientAuthenticationMethod::None,
-            ClientAuthMethodConfig::ClientSecretBasic { .. } => {
+            ClientAuthMethodConfig::ClientSecretBasic => {
                 OAuthClientAuthenticationMethod::ClientSecretBasic
             }
-            ClientAuthMethodConfig::ClientSecretPost { .. } => {
+            ClientAuthMethodConfig::ClientSecretPost => {
                 OAuthClientAuthenticationMethod::ClientSecretPost
             }
-            ClientAuthMethodConfig::ClientSecretJwt { .. } => {
+            ClientAuthMethodConfig::ClientSecretJwt => {
                 OAuthClientAuthenticationMethod::ClientSecretJwt
             }
-            ClientAuthMethodConfig::PrivateKeyJwt(_) => {
-                OAuthClientAuthenticationMethod::PrivateKeyJwt
-            }
-        }
-    }
-
-    #[doc(hidden)]
-    #[must_use]
-    pub fn jwks(&self) -> Option<&PublicJsonWebKeySet> {
-        match &self.client_auth_method {
-            ClientAuthMethodConfig::PrivateKeyJwt(JwksOrJwksUri::Jwks(jwks)) => Some(jwks),
-            _ => None,
-        }
-    }
-
-    #[doc(hidden)]
-    #[must_use]
-    pub fn jwks_uri(&self) -> Option<&Url> {
-        match &self.client_auth_method {
-            ClientAuthMethodConfig::PrivateKeyJwt(JwksOrJwksUri::JwksUri(jwks_uri)) => {
-                Some(jwks_uri)
-            }
-            _ => None,
+            ClientAuthMethodConfig::PrivateKeyJwt => OAuthClientAuthenticationMethod::PrivateKeyJwt,
         }
     }
 }
@@ -154,19 +209,13 @@ impl ClientConfig {
 /// List of OAuth 2.0/OIDC clients config
 #[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
 #[serde(transparent)]
-pub struct ClientsConfig(Vec<ClientConfig>);
+pub struct ClientsConfig(#[schemars(with = "Vec::<ClientConfig>")] Vec<ClientConfig>);
 
 impl Deref for ClientsConfig {
     type Target = Vec<ClientConfig>;
 
     fn deref(&self) -> &Self::Target {
         &self.0
-    }
-}
-
-impl DerefMut for ClientsConfig {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
     }
 }
 
@@ -188,6 +237,21 @@ impl ConfigurationSection for ClientsConfig {
         R: Rng + Send,
     {
         Ok(Self::default())
+    }
+
+    fn validate(&self, figment: &Figment) -> Result<(), figment::error::Error> {
+        for (index, client) in self.0.iter().enumerate() {
+            client.validate().map_err(|mut err| {
+                // Save the error location information in the error
+                err.metadata = figment.find_metadata(Self::PATH.unwrap()).cloned();
+                err.profile = Some(figment::Profile::Default);
+                err.path.insert(0, Self::PATH.unwrap().to_owned());
+                err.path.insert(1, format!("{index}"));
+                err
+            })?;
+        }
+
+        Ok(())
     }
 
     fn test() -> Self {

--- a/crates/config/src/sections/clients.rs
+++ b/crates/config/src/sections/clients.rs
@@ -181,9 +181,7 @@ impl IntoIterator for ClientsConfig {
 
 #[async_trait]
 impl ConfigurationSection for ClientsConfig {
-    fn path() -> &'static str {
-        "clients"
-    }
+    const PATH: Option<&'static str> = Some("clients");
 
     async fn generate<R>(_rng: R) -> anyhow::Result<Self>
     where

--- a/crates/config/src/sections/database.rs
+++ b/crates/config/src/sections/database.rs
@@ -14,9 +14,7 @@
 
 use std::{num::NonZeroU32, time::Duration};
 
-use async_trait::async_trait;
 use camino::Utf8PathBuf;
-use rand::Rng;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
@@ -150,16 +148,8 @@ pub struct DatabaseConfig {
     pub max_lifetime: Option<Duration>,
 }
 
-#[async_trait]
 impl ConfigurationSection for DatabaseConfig {
     const PATH: Option<&'static str> = Some("database");
-
-    async fn generate<R>(_rng: R) -> anyhow::Result<Self>
-    where
-        R: Rng + Send,
-    {
-        Ok(Self::default())
-    }
 
     fn validate(&self, figment: &figment::Figment) -> Result<(), figment::error::Error> {
         let metadata = figment.find_metadata(Self::PATH.unwrap());
@@ -184,10 +174,6 @@ impl ConfigurationSection for DatabaseConfig {
         }
 
         Ok(())
-    }
-
-    fn test() -> Self {
-        Self::default()
     }
 }
 

--- a/crates/config/src/sections/database.rs
+++ b/crates/config/src/sections/database.rs
@@ -164,7 +164,10 @@ impl ConfigurationSection for DatabaseConfig {
 
 #[cfg(test)]
 mod tests {
-    use figment::Jail;
+    use figment::{
+        providers::{Format, Yaml},
+        Figment, Jail,
+    };
 
     use super::*;
 
@@ -179,7 +182,9 @@ mod tests {
                 ",
             )?;
 
-            let config = DatabaseConfig::load_from_file("config.yaml")?;
+            let config = Figment::new()
+                .merge(Yaml::file("config.yaml"))
+                .extract_inner::<DatabaseConfig>("database")?;
 
             assert_eq!(
                 config.options,

--- a/crates/config/src/sections/database.rs
+++ b/crates/config/src/sections/database.rs
@@ -146,9 +146,7 @@ pub struct DatabaseConfig {
 
 #[async_trait]
 impl ConfigurationSection for DatabaseConfig {
-    fn path() -> &'static str {
-        "database"
-    }
+    const PATH: Option<&'static str> = Some("database");
 
     async fn generate<R>(_rng: R) -> anyhow::Result<Self>
     where

--- a/crates/config/src/sections/email.rs
+++ b/crates/config/src/sections/email.rs
@@ -128,9 +128,7 @@ impl Default for EmailConfig {
 
 #[async_trait]
 impl ConfigurationSection for EmailConfig {
-    fn path() -> &'static str {
-        "email"
-    }
+    const PATH: Option<&'static str> = Some("email");
 
     async fn generate<R>(_rng: R) -> anyhow::Result<Self>
     where

--- a/crates/config/src/sections/email.rs
+++ b/crates/config/src/sections/email.rs
@@ -19,7 +19,7 @@ use std::num::NonZeroU16;
 use async_trait::async_trait;
 use rand::Rng;
 use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
+use serde::{de::Error, Deserialize, Serialize};
 
 use super::ConfigurationSection;
 
@@ -47,55 +47,27 @@ pub enum EmailSmtpMode {
 }
 
 /// What backend should be used when sending emails
-#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
-#[serde(tag = "transport", rename_all = "snake_case")]
-pub enum EmailTransportConfig {
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, JsonSchema, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum EmailTransportKind {
     /// Don't send emails anywhere
+    #[default]
     Blackhole,
 
     /// Send emails via an SMTP relay
-    Smtp {
-        /// Connection mode to the relay
-        mode: EmailSmtpMode,
-
-        /// Hostname to connect to
-        #[schemars(with = "crate::schema::Hostname")]
-        hostname: String,
-
-        /// Port to connect to. Default is 25 for plain, 465 for TLS and 587 for
-        /// StartTLS
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        port: Option<NonZeroU16>,
-
-        /// Set of credentials to use
-        #[serde(flatten, default)]
-        credentials: Option<Credentials>,
-    },
+    Smtp,
 
     /// Send emails by calling sendmail
-    Sendmail {
-        /// Command to execute
-        #[serde(default = "default_sendmail_command")]
-        command: String,
-    },
-
-    /// Send emails via the AWS SESv2 API
-    #[deprecated(note = "The AWS SESv2 backend has be removed.")]
-    AwsSes,
-}
-
-impl Default for EmailTransportConfig {
-    fn default() -> Self {
-        Self::Blackhole
-    }
+    Sendmail,
 }
 
 fn default_email() -> String {
     r#""Authentication Service" <root@localhost>"#.to_owned()
 }
 
-fn default_sendmail_command() -> String {
-    "sendmail".to_owned()
+#[allow(clippy::unnecessary_wraps)]
+fn default_sendmail_command() -> Option<String> {
+    Some("sendmail".to_owned())
 }
 
 /// Configuration related to sending emails
@@ -112,8 +84,85 @@ pub struct EmailConfig {
     pub reply_to: String,
 
     /// What backend should be used when sending emails
-    #[serde(flatten, default)]
-    pub transport: EmailTransportConfig,
+    transport: EmailTransportKind,
+
+    /// SMTP transport: Connection mode to the relay
+    #[serde(skip_serializing_if = "Option::is_none")]
+    mode: Option<EmailSmtpMode>,
+
+    /// SMTP transport: Hostname to connect to
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schemars(with = "Option<crate::schema::Hostname>")]
+    hostname: Option<String>,
+
+    /// SMTP transport: Port to connect to. Default is 25 for plain, 465 for TLS
+    /// and 587 for StartTLS
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schemars(range(min = 1, max = 65535))]
+    port: Option<NonZeroU16>,
+
+    /// SMTP transport: Username for use to authenticate when connecting to the
+    /// SMTP server
+    ///
+    /// Must be set if the `password` field is set
+    #[serde(skip_serializing_if = "Option::is_none")]
+    username: Option<String>,
+
+    /// SMTP transport: Password for use to authenticate when connecting to the
+    /// SMTP server
+    ///
+    /// Must be set if the `username` field is set
+    #[serde(skip_serializing_if = "Option::is_none")]
+    password: Option<String>,
+
+    /// Sendmail transport: Command to use to send emails
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schemars(default = "default_sendmail_command")]
+    command: Option<String>,
+}
+
+impl EmailConfig {
+    /// What backend should be used when sending emails
+    #[must_use]
+    pub fn transport(&self) -> EmailTransportKind {
+        self.transport
+    }
+
+    /// Connection mode to the relay
+    #[must_use]
+    pub fn mode(&self) -> Option<EmailSmtpMode> {
+        self.mode
+    }
+
+    /// Hostname to connect to
+    #[must_use]
+    pub fn hostname(&self) -> Option<&str> {
+        self.hostname.as_deref()
+    }
+
+    /// Port to connect to
+    #[must_use]
+    pub fn port(&self) -> Option<NonZeroU16> {
+        self.port
+    }
+
+    /// Username for use to authenticate when connecting to the SMTP server
+    #[must_use]
+    pub fn username(&self) -> Option<&str> {
+        self.username.as_deref()
+    }
+
+    /// Password for use to authenticate when connecting to the SMTP server
+    #[must_use]
+    pub fn password(&self) -> Option<&str> {
+        self.password.as_deref()
+    }
+
+    /// Command to use to send emails
+    #[must_use]
+    pub fn command(&self) -> Option<&str> {
+        self.command.as_deref()
+    }
 }
 
 impl Default for EmailConfig {
@@ -121,7 +170,13 @@ impl Default for EmailConfig {
         Self {
             from: default_email(),
             reply_to: default_email(),
-            transport: EmailTransportConfig::Blackhole,
+            transport: EmailTransportKind::Blackhole,
+            mode: None,
+            hostname: None,
+            port: None,
+            username: None,
+            password: None,
+            command: None,
         }
     }
 }
@@ -135,6 +190,98 @@ impl ConfigurationSection for EmailConfig {
         R: Rng + Send,
     {
         Ok(Self::default())
+    }
+
+    fn validate(&self, figment: &figment::Figment) -> Result<(), figment::error::Error> {
+        let metadata = figment.find_metadata(Self::PATH.unwrap());
+
+        let error_on_field = |mut error: figment::error::Error, field: &'static str| {
+            error.metadata = metadata.cloned();
+            error.profile = Some(figment::Profile::Default);
+            error.path = vec![Self::PATH.unwrap().to_owned(), field.to_owned()];
+            error
+        };
+
+        let missing_field = |field: &'static str| {
+            error_on_field(figment::error::Error::missing_field(field), field)
+        };
+
+        let unexpected_field = |field: &'static str, expected_fields: &'static [&'static str]| {
+            error_on_field(
+                figment::error::Error::unknown_field(field, expected_fields),
+                field,
+            )
+        };
+
+        match self.transport {
+            EmailTransportKind::Blackhole => {}
+
+            EmailTransportKind::Smtp => {
+                match (self.username.is_some(), self.password.is_some()) {
+                    (true, true) | (false, false) => {}
+                    (true, false) => {
+                        return Err(missing_field("password"));
+                    }
+                    (false, true) => {
+                        return Err(missing_field("username"));
+                    }
+                }
+
+                if self.mode.is_none() {
+                    return Err(missing_field("mode"));
+                }
+
+                if self.hostname.is_none() {
+                    return Err(missing_field("hostname"));
+                }
+
+                if self.command.is_some() {
+                    return Err(unexpected_field(
+                        "command",
+                        &[
+                            "from",
+                            "reply_to",
+                            "transport",
+                            "mode",
+                            "hostname",
+                            "port",
+                            "username",
+                            "password",
+                        ],
+                    ));
+                }
+            }
+
+            EmailTransportKind::Sendmail => {
+                let expected_fields = &["from", "reply_to", "transport", "command"];
+
+                if self.command.is_none() {
+                    return Err(missing_field("command"));
+                }
+
+                if self.mode.is_some() {
+                    return Err(unexpected_field("mode", expected_fields));
+                }
+
+                if self.hostname.is_some() {
+                    return Err(unexpected_field("hostname", expected_fields));
+                }
+
+                if self.port.is_some() {
+                    return Err(unexpected_field("port", expected_fields));
+                }
+
+                if self.username.is_some() {
+                    return Err(unexpected_field("username", expected_fields));
+                }
+
+                if self.password.is_some() {
+                    return Err(unexpected_field("password", expected_fields));
+                }
+            }
+        }
+
+        Ok(())
     }
 
     fn test() -> Self {

--- a/crates/config/src/sections/email.rs
+++ b/crates/config/src/sections/email.rs
@@ -16,8 +16,6 @@
 
 use std::num::NonZeroU16;
 
-use async_trait::async_trait;
-use rand::Rng;
 use schemars::JsonSchema;
 use serde::{de::Error, Deserialize, Serialize};
 
@@ -181,16 +179,8 @@ impl Default for EmailConfig {
     }
 }
 
-#[async_trait]
 impl ConfigurationSection for EmailConfig {
     const PATH: Option<&'static str> = Some("email");
-
-    async fn generate<R>(_rng: R) -> anyhow::Result<Self>
-    where
-        R: Rng + Send,
-    {
-        Ok(Self::default())
-    }
 
     fn validate(&self, figment: &figment::Figment) -> Result<(), figment::error::Error> {
         let metadata = figment.find_metadata(Self::PATH.unwrap());
@@ -282,9 +272,5 @@ impl ConfigurationSection for EmailConfig {
         }
 
         Ok(())
-    }
-
-    fn test() -> Self {
-        Self::default()
     }
 }

--- a/crates/config/src/sections/email.rs
+++ b/crates/config/src/sections/email.rs
@@ -59,7 +59,7 @@ pub enum EmailTransportConfig {
         mode: EmailSmtpMode,
 
         /// Hostname to connect to
-        #[schemars(schema_with = "crate::schema::hostname")]
+        #[schemars(with = "crate::schema::Hostname")]
         hostname: String,
 
         /// Port to connect to. Default is 25 for plain, 465 for TLS and 587 for
@@ -103,12 +103,12 @@ fn default_sendmail_command() -> String {
 pub struct EmailConfig {
     /// Email address to use as From when sending emails
     #[serde(default = "default_email")]
-    #[schemars(schema_with = "crate::schema::mailbox")]
+    #[schemars(email)]
     pub from: String,
 
     /// Email address to use as Reply-To when sending emails
     #[serde(default = "default_email")]
-    #[schemars(schema_with = "crate::schema::mailbox")]
+    #[schemars(email)]
     pub reply_to: String,
 
     /// What backend should be used when sending emails

--- a/crates/config/src/sections/experimental.rs
+++ b/crates/config/src/sections/experimental.rs
@@ -56,9 +56,7 @@ impl Default for ExperimentalConfig {
 
 #[async_trait]
 impl ConfigurationSection for ExperimentalConfig {
-    fn path() -> &'static str {
-        "experimental"
-    }
+    const PATH: Option<&'static str> = Some("experimental");
 
     async fn generate<R>(_rng: R) -> anyhow::Result<Self>
     where

--- a/crates/config/src/sections/http.rs
+++ b/crates/config/src/sections/http.rs
@@ -394,9 +394,7 @@ impl Default for HttpConfig {
 
 #[async_trait]
 impl ConfigurationSection for HttpConfig {
-    fn path() -> &'static str {
-        "http"
-    }
+    const PATH: Option<&'static str> = Some("http");
 
     async fn generate<R>(_rng: R) -> anyhow::Result<Self>
     where

--- a/crates/config/src/sections/matrix.rs
+++ b/crates/config/src/sections/matrix.rs
@@ -50,9 +50,7 @@ pub struct MatrixConfig {
 
 #[async_trait]
 impl ConfigurationSection for MatrixConfig {
-    fn path() -> &'static str {
-        "matrix"
-    }
+    const PATH: Option<&'static str> = Some("matrix");
 
     async fn generate<R>(mut rng: R) -> anyhow::Result<Self>
     where

--- a/crates/config/src/sections/matrix.rs
+++ b/crates/config/src/sections/matrix.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use async_trait::async_trait;
 use rand::{
     distributions::{Alphanumeric, DistString},
     Rng,
@@ -48,22 +47,23 @@ pub struct MatrixConfig {
     pub endpoint: Url,
 }
 
-#[async_trait]
 impl ConfigurationSection for MatrixConfig {
     const PATH: Option<&'static str> = Some("matrix");
+}
 
-    async fn generate<R>(mut rng: R) -> anyhow::Result<Self>
+impl MatrixConfig {
+    pub(crate) fn generate<R>(mut rng: R) -> Self
     where
         R: Rng + Send,
     {
-        Ok(Self {
+        Self {
             homeserver: default_homeserver(),
             secret: Alphanumeric.sample_string(&mut rng, 32),
             endpoint: default_endpoint(),
-        })
+        }
     }
 
-    fn test() -> Self {
+    pub(crate) fn test() -> Self {
         Self {
             homeserver: default_homeserver(),
             secret: "test".to_owned(),

--- a/crates/config/src/sections/matrix.rs
+++ b/crates/config/src/sections/matrix.rs
@@ -76,7 +76,10 @@ impl ConfigurationSection for MatrixConfig {
 
 #[cfg(test)]
 mod tests {
-    use figment::Jail;
+    use figment::{
+        providers::{Format, Yaml},
+        Figment, Jail,
+    };
 
     use super::*;
 
@@ -92,10 +95,12 @@ mod tests {
                 ",
             )?;
 
-            let config = MatrixConfig::load_from_file("config.yaml")?;
+            let config = Figment::new()
+                .merge(Yaml::file("config.yaml"))
+                .extract_inner::<MatrixConfig>("matrix")?;
 
-            assert_eq!(config.homeserver, "matrix.org".to_owned());
-            assert_eq!(config.secret, "test".to_owned());
+            assert_eq!(&config.homeserver, "matrix.org");
+            assert_eq!(&config.secret, "test");
 
             Ok(())
         });

--- a/crates/config/src/sections/mod.rs
+++ b/crates/config/src/sections/mod.rs
@@ -35,7 +35,7 @@ pub use self::{
     branding::BrandingConfig,
     clients::{ClientAuthMethodConfig, ClientConfig, ClientsConfig},
     database::DatabaseConfig,
-    email::{EmailConfig, EmailSmtpMode, EmailTransportConfig},
+    email::{EmailConfig, EmailSmtpMode, EmailTransportKind},
     experimental::ExperimentalConfig,
     http::{
         BindConfig as HttpBindConfig, HttpConfig, ListenerConfig as HttpListenerConfig,

--- a/crates/config/src/sections/mod.rs
+++ b/crates/config/src/sections/mod.rs
@@ -34,7 +34,7 @@ mod upstream_oauth2;
 pub use self::{
     branding::BrandingConfig,
     clients::{ClientAuthMethodConfig, ClientConfig, ClientsConfig},
-    database::{ConnectConfig as DatabaseConnectConfig, DatabaseConfig},
+    database::DatabaseConfig,
     email::{EmailConfig, EmailSmtpMode, EmailTransportConfig},
     experimental::ExperimentalConfig,
     http::{
@@ -137,6 +137,24 @@ impl ConfigurationSection for RootConfig {
         })
     }
 
+    fn validate(&self, figment: &figment::Figment) -> Result<(), figment::error::Error> {
+        self.clients.validate(figment)?;
+        self.http.validate(figment)?;
+        self.database.validate(figment)?;
+        self.telemetry.validate(figment)?;
+        self.templates.validate(figment)?;
+        self.email.validate(figment)?;
+        self.passwords.validate(figment)?;
+        self.secrets.validate(figment)?;
+        self.matrix.validate(figment)?;
+        self.policy.validate(figment)?;
+        self.upstream_oauth2.validate(figment)?;
+        self.branding.validate(figment)?;
+        self.experimental.validate(figment)?;
+
+        Ok(())
+    }
+
     fn test() -> Self {
         Self {
             clients: ClientsConfig::test(),
@@ -207,6 +225,21 @@ impl ConfigurationSection for AppConfig {
             branding: BrandingConfig::generate(&mut rng).await?,
             experimental: ExperimentalConfig::generate(&mut rng).await?,
         })
+    }
+
+    fn validate(&self, figment: &figment::Figment) -> Result<(), figment::error::Error> {
+        self.http.validate(figment)?;
+        self.database.validate(figment)?;
+        self.templates.validate(figment)?;
+        self.email.validate(figment)?;
+        self.passwords.validate(figment)?;
+        self.secrets.validate(figment)?;
+        self.matrix.validate(figment)?;
+        self.policy.validate(figment)?;
+        self.branding.validate(figment)?;
+        self.experimental.validate(figment)?;
+
+        Ok(())
     }
 
     fn test() -> Self {

--- a/crates/config/src/sections/mod.rs
+++ b/crates/config/src/sections/mod.rs
@@ -46,8 +46,8 @@ pub use self::{
     policy::PolicyConfig,
     secrets::SecretsConfig,
     telemetry::{
-        MetricsConfig, MetricsExporterConfig, Propagator, TelemetryConfig, TracingConfig,
-        TracingExporterConfig,
+        MetricsConfig, MetricsExporterKind, Propagator, TelemetryConfig, TracingConfig,
+        TracingExporterKind,
     },
     templates::TemplatesConfig,
     upstream_oauth2::{

--- a/crates/config/src/sections/mod.rs
+++ b/crates/config/src/sections/mod.rs
@@ -116,10 +116,6 @@ pub struct RootConfig {
 
 #[async_trait]
 impl ConfigurationSection for RootConfig {
-    fn path() -> &'static str {
-        ""
-    }
-
     async fn generate<R>(mut rng: R) -> anyhow::Result<Self>
     where
         R: Rng + Send,
@@ -195,10 +191,6 @@ pub struct AppConfig {
 
 #[async_trait]
 impl ConfigurationSection for AppConfig {
-    fn path() -> &'static str {
-        ""
-    }
-
     async fn generate<R>(mut rng: R) -> anyhow::Result<Self>
     where
         R: Rng + Send,
@@ -251,10 +243,6 @@ pub struct SyncConfig {
 
 #[async_trait]
 impl ConfigurationSection for SyncConfig {
-    fn path() -> &'static str {
-        ""
-    }
-
     async fn generate<R>(mut rng: R) -> anyhow::Result<Self>
     where
         R: Rng + Send,

--- a/crates/config/src/sections/mod.rs
+++ b/crates/config/src/sections/mod.rs
@@ -53,8 +53,7 @@ pub use self::{
     upstream_oauth2::{
         ClaimsImports as UpstreamOAuth2ClaimsImports, DiscoveryMode as UpstreamOAuth2DiscoveryMode,
         EmailImportPreference as UpstreamOAuth2EmailImportPreference,
-        ImportAction as UpstreamOAuth2ImportAction,
-        ImportPreference as UpstreamOAuth2ImportPreference, PkceMethod as UpstreamOAuth2PkceMethod,
+        ImportAction as UpstreamOAuth2ImportAction, PkceMethod as UpstreamOAuth2PkceMethod,
         SetEmailVerification as UpstreamOAuth2SetEmailVerification, UpstreamOAuth2Config,
     },
 };

--- a/crates/config/src/sections/passwords.rs
+++ b/crates/config/src/sections/passwords.rs
@@ -57,9 +57,7 @@ impl Default for PasswordsConfig {
 
 #[async_trait]
 impl ConfigurationSection for PasswordsConfig {
-    fn path() -> &'static str {
-        "passwords"
-    }
+    const PATH: Option<&'static str> = Some("passwords");
 
     async fn generate<R>(_rng: R) -> anyhow::Result<Self>
     where

--- a/crates/config/src/sections/passwords.rs
+++ b/crates/config/src/sections/passwords.rs
@@ -13,9 +13,7 @@
 // limitations under the License.
 
 use anyhow::bail;
-use async_trait::async_trait;
 use camino::Utf8PathBuf;
-use rand::Rng;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -55,16 +53,8 @@ impl Default for PasswordsConfig {
     }
 }
 
-#[async_trait]
 impl ConfigurationSection for PasswordsConfig {
     const PATH: Option<&'static str> = Some("passwords");
-
-    async fn generate<R>(_rng: R) -> anyhow::Result<Self>
-    where
-        R: Rng + Send,
-    {
-        Ok(Self::default())
-    }
 
     fn validate(&self, figment: &figment::Figment) -> Result<(), figment::Error> {
         let annotate = |mut error: figment::Error| {
@@ -94,10 +84,6 @@ impl ConfigurationSection for PasswordsConfig {
         }
 
         Ok(())
-    }
-
-    fn test() -> Self {
-        Self::default()
     }
 }
 

--- a/crates/config/src/sections/policy.rs
+++ b/crates/config/src/sections/policy.rs
@@ -56,6 +56,10 @@ fn default_email_endpoint() -> String {
     "email/violation".to_owned()
 }
 
+fn default_data() -> serde_json::Value {
+    serde_json::json!({})
+}
+
 /// Application secrets
 #[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
@@ -86,8 +90,8 @@ pub struct PolicyConfig {
     pub email_entrypoint: String,
 
     /// Arbitrary data to pass to the policy
-    #[serde(default)]
-    pub data: Option<serde_json::Value>,
+    #[serde(default = "default_data")]
+    pub data: serde_json::Value,
 }
 
 impl Default for PolicyConfig {
@@ -99,7 +103,7 @@ impl Default for PolicyConfig {
             authorization_grant_entrypoint: default_authorization_grant_endpoint(),
             password_entrypoint: default_password_endpoint(),
             email_entrypoint: default_email_endpoint(),
-            data: None,
+            data: default_data(),
         }
     }
 }

--- a/crates/config/src/sections/policy.rs
+++ b/crates/config/src/sections/policy.rs
@@ -12,9 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use async_trait::async_trait;
 use camino::Utf8PathBuf;
-use rand::Rng;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
@@ -36,28 +34,56 @@ fn default_policy_path() -> Utf8PathBuf {
     "./share/policy.wasm".into()
 }
 
-fn default_client_registration_endpoint() -> String {
+fn is_default_policy_path(value: &Utf8PathBuf) -> bool {
+    *value == default_policy_path()
+}
+
+fn default_client_registration_entrypoint() -> String {
     "client_registration/violation".to_owned()
 }
 
-fn default_register_endpoint() -> String {
+fn is_default_client_registration_entrypoint(value: &String) -> bool {
+    *value == default_client_registration_entrypoint()
+}
+
+fn default_register_entrypoint() -> String {
     "register/violation".to_owned()
 }
 
-fn default_authorization_grant_endpoint() -> String {
+fn is_default_register_entrypoint(value: &String) -> bool {
+    *value == default_register_entrypoint()
+}
+
+fn default_authorization_grant_entrypoint() -> String {
     "authorization_grant/violation".to_owned()
 }
 
-fn default_password_endpoint() -> String {
+fn is_default_authorization_grant_entrypoint(value: &String) -> bool {
+    *value == default_authorization_grant_entrypoint()
+}
+
+fn default_password_entrypoint() -> String {
     "password/violation".to_owned()
 }
 
-fn default_email_endpoint() -> String {
+fn is_default_password_entrypoint(value: &String) -> bool {
+    *value == default_password_entrypoint()
+}
+
+fn default_email_entrypoint() -> String {
     "email/violation".to_owned()
+}
+
+fn is_default_email_entrypoint(value: &String) -> bool {
+    *value == default_email_entrypoint()
 }
 
 fn default_data() -> serde_json::Value {
     serde_json::json!({})
+}
+
+fn is_default_data(value: &serde_json::Value) -> bool {
+    *value == default_data()
 }
 
 /// Application secrets
@@ -65,32 +91,50 @@ fn default_data() -> serde_json::Value {
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct PolicyConfig {
     /// Path to the WASM module
-    #[serde(default = "default_policy_path")]
+    #[serde(
+        default = "default_policy_path",
+        skip_serializing_if = "is_default_policy_path"
+    )]
     #[schemars(with = "String")]
     pub wasm_module: Utf8PathBuf,
 
     /// Entrypoint to use when evaluating client registrations
-    #[serde(default = "default_client_registration_endpoint")]
+    #[serde(
+        default = "default_client_registration_entrypoint",
+        skip_serializing_if = "is_default_client_registration_entrypoint"
+    )]
     pub client_registration_entrypoint: String,
 
     /// Entrypoint to use when evaluating user registrations
-    #[serde(default = "default_register_endpoint")]
+    #[serde(
+        default = "default_register_entrypoint",
+        skip_serializing_if = "is_default_register_entrypoint"
+    )]
     pub register_entrypoint: String,
 
     /// Entrypoint to use when evaluating authorization grants
-    #[serde(default = "default_authorization_grant_endpoint")]
+    #[serde(
+        default = "default_authorization_grant_entrypoint",
+        skip_serializing_if = "is_default_authorization_grant_entrypoint"
+    )]
     pub authorization_grant_entrypoint: String,
 
     /// Entrypoint to use when changing password
-    #[serde(default = "default_password_endpoint")]
+    #[serde(
+        default = "default_password_entrypoint",
+        skip_serializing_if = "is_default_password_entrypoint"
+    )]
     pub password_entrypoint: String,
 
     /// Entrypoint to use when adding an email address
-    #[serde(default = "default_email_endpoint")]
+    #[serde(
+        default = "default_email_entrypoint",
+        skip_serializing_if = "is_default_email_entrypoint"
+    )]
     pub email_entrypoint: String,
 
     /// Arbitrary data to pass to the policy
-    #[serde(default = "default_data")]
+    #[serde(default = "default_data", skip_serializing_if = "is_default_data")]
     pub data: serde_json::Value,
 }
 
@@ -98,28 +142,29 @@ impl Default for PolicyConfig {
     fn default() -> Self {
         Self {
             wasm_module: default_policy_path(),
-            client_registration_entrypoint: default_client_registration_endpoint(),
-            register_entrypoint: default_register_endpoint(),
-            authorization_grant_entrypoint: default_authorization_grant_endpoint(),
-            password_entrypoint: default_password_endpoint(),
-            email_entrypoint: default_email_endpoint(),
+            client_registration_entrypoint: default_client_registration_entrypoint(),
+            register_entrypoint: default_register_entrypoint(),
+            authorization_grant_entrypoint: default_authorization_grant_entrypoint(),
+            password_entrypoint: default_password_entrypoint(),
+            email_entrypoint: default_email_entrypoint(),
             data: default_data(),
         }
     }
 }
 
-#[async_trait]
+impl PolicyConfig {
+    /// Returns true if the configuration is the default one
+    pub(crate) fn is_default(&self) -> bool {
+        is_default_policy_path(&self.wasm_module)
+            && is_default_client_registration_entrypoint(&self.client_registration_entrypoint)
+            && is_default_register_entrypoint(&self.register_entrypoint)
+            && is_default_authorization_grant_entrypoint(&self.authorization_grant_entrypoint)
+            && is_default_password_entrypoint(&self.password_entrypoint)
+            && is_default_email_entrypoint(&self.email_entrypoint)
+            && is_default_data(&self.data)
+    }
+}
+
 impl ConfigurationSection for PolicyConfig {
     const PATH: Option<&'static str> = Some("policy");
-
-    async fn generate<R>(_rng: R) -> anyhow::Result<Self>
-    where
-        R: Rng + Send,
-    {
-        Ok(Self::default())
-    }
-
-    fn test() -> Self {
-        Self::default()
-    }
 }

--- a/crates/config/src/sections/policy.rs
+++ b/crates/config/src/sections/policy.rs
@@ -106,9 +106,7 @@ impl Default for PolicyConfig {
 
 #[async_trait]
 impl ConfigurationSection for PolicyConfig {
-    fn path() -> &'static str {
-        "policy"
-    }
+    const PATH: Option<&'static str> = Some("policy");
 
     async fn generate<R>(_rng: R) -> anyhow::Result<Self>
     where

--- a/crates/config/src/sections/secrets.rs
+++ b/crates/config/src/sections/secrets.rs
@@ -139,9 +139,7 @@ impl SecretsConfig {
 
 #[async_trait]
 impl ConfigurationSection for SecretsConfig {
-    fn path() -> &'static str {
-        "secrets"
-    }
+    const PATH: Option<&'static str> = Some("secrets");
 
     #[tracing::instrument(skip_all)]
     async fn generate<R>(mut rng: R) -> anyhow::Result<Self>

--- a/crates/config/src/sections/telemetry.rs
+++ b/crates/config/src/sections/telemetry.rs
@@ -145,9 +145,7 @@ pub struct TelemetryConfig {
 
 #[async_trait]
 impl ConfigurationSection for TelemetryConfig {
-    fn path() -> &'static str {
-        "telemetry"
-    }
+    const PATH: Option<&'static str> = Some("telemetry");
 
     async fn generate<R>(_rng: R) -> anyhow::Result<Self>
     where

--- a/crates/config/src/sections/templates.rs
+++ b/crates/config/src/sections/templates.rs
@@ -96,9 +96,7 @@ impl Default for TemplatesConfig {
 
 #[async_trait]
 impl ConfigurationSection for TemplatesConfig {
-    fn path() -> &'static str {
-        "templates"
-    }
+    const PATH: Option<&'static str> = Some("templates");
 
     async fn generate<R>(_rng: R) -> anyhow::Result<Self>
     where

--- a/crates/config/src/sections/upstream_oauth2.rs
+++ b/crates/config/src/sections/upstream_oauth2.rs
@@ -14,9 +14,7 @@
 
 use std::collections::BTreeMap;
 
-use async_trait::async_trait;
 use mas_iana::{jose::JsonWebSignatureAlg, oauth::OAuthClientAuthenticationMethod};
-use rand::Rng;
 use schemars::JsonSchema;
 use serde::{de::Error, Deserialize, Serialize};
 use serde_with::skip_serializing_none;
@@ -32,16 +30,15 @@ pub struct UpstreamOAuth2Config {
     pub providers: Vec<Provider>,
 }
 
-#[async_trait]
+impl UpstreamOAuth2Config {
+    /// Returns true if the configuration is the default one
+    pub(crate) fn is_default(&self) -> bool {
+        self.providers.is_empty()
+    }
+}
+
 impl ConfigurationSection for UpstreamOAuth2Config {
     const PATH: Option<&'static str> = Some("upstream_oauth2");
-
-    async fn generate<R>(_rng: R) -> anyhow::Result<Self>
-    where
-        R: Rng + Send,
-    {
-        Ok(Self::default())
-    }
 
     fn validate(&self, figment: &figment::Figment) -> Result<(), figment::Error> {
         for (index, provider) in self.providers.iter().enumerate() {
@@ -94,10 +91,6 @@ impl ConfigurationSection for UpstreamOAuth2Config {
         }
 
         Ok(())
-    }
-
-    fn test() -> Self {
-        Self::default()
     }
 }
 

--- a/crates/config/src/sections/upstream_oauth2.rs
+++ b/crates/config/src/sections/upstream_oauth2.rs
@@ -34,9 +34,7 @@ pub struct UpstreamOAuth2Config {
 
 #[async_trait]
 impl ConfigurationSection for UpstreamOAuth2Config {
-    fn path() -> &'static str {
-        "upstream_oauth2"
-    }
+    const PATH: Option<&'static str> = Some("upstream_oauth2");
 
     async fn generate<R>(_rng: R) -> anyhow::Result<Self>
     where

--- a/crates/config/src/util.rs
+++ b/crates/config/src/util.rs
@@ -29,17 +29,29 @@ pub trait ConfigurationSection: Sized + DeserializeOwned + Serialize {
     where
         R: Rng + Send;
 
+    /// Validate the configuration section
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the configuration is invalid
+    fn validate(&self, _figment: &Figment) -> Result<(), FigmentError> {
+        Ok(())
+    }
+
     /// Extract configuration from a Figment instance.
     ///
     /// # Errors
     ///
     /// Returns an error if the configuration could not be loaded
     fn extract(figment: &Figment) -> Result<Self, FigmentError> {
-        if let Some(path) = Self::PATH {
-            figment.extract_inner(path)
+        let this: Self = if let Some(path) = Self::PATH {
+            figment.extract_inner(path)?
         } else {
-            figment.extract()
-        }
+            figment.extract()?
+        };
+
+        this.validate(figment)?;
+        Ok(this)
     }
 
     /// Generate config used in unit tests

--- a/crates/config/src/util.rs
+++ b/crates/config/src/util.rs
@@ -22,7 +22,7 @@ use serde::{de::DeserializeOwned, Serialize};
 /// of the config and generate the sample config.
 pub trait ConfigurationSection: Sized + DeserializeOwned + Serialize {
     /// Specify where this section should live relative to the root.
-    fn path() -> &'static str;
+    const PATH: Option<&'static str> = None;
 
     /// Generate a sample configuration for this section.
     async fn generate<R>(rng: R) -> anyhow::Result<Self>
@@ -35,7 +35,11 @@ pub trait ConfigurationSection: Sized + DeserializeOwned + Serialize {
     ///
     /// Returns an error if the configuration could not be loaded
     fn extract(figment: &Figment) -> Result<Self, FigmentError> {
-        figment.extract_inner(Self::path())
+        if let Some(path) = Self::PATH {
+            figment.extract_inner(path)
+        } else {
+            figment.extract()
+        }
     }
 
     /// Generate config used in unit tests

--- a/crates/config/src/util.rs
+++ b/crates/config/src/util.rs
@@ -12,22 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use async_trait::async_trait;
 use figment::{error::Error as FigmentError, Figment};
-use rand::Rng;
-use serde::{de::DeserializeOwned, Serialize};
+use serde::de::DeserializeOwned;
 
-#[async_trait]
 /// Trait implemented by all configuration section to help loading specific part
 /// of the config and generate the sample config.
-pub trait ConfigurationSection: Sized + DeserializeOwned + Serialize {
+pub trait ConfigurationSection: Sized + DeserializeOwned {
     /// Specify where this section should live relative to the root.
     const PATH: Option<&'static str> = None;
-
-    /// Generate a sample configuration for this section.
-    async fn generate<R>(rng: R) -> anyhow::Result<Self>
-    where
-        R: Rng + Send;
 
     /// Validate the configuration section
     ///
@@ -53,7 +45,4 @@ pub trait ConfigurationSection: Sized + DeserializeOwned + Serialize {
         this.validate(figment)?;
         Ok(this)
     }
-
-    /// Generate config used in unit tests
-    fn test() -> Self;
 }

--- a/crates/email/src/transport.rs
+++ b/crates/email/src/transport.rs
@@ -92,10 +92,13 @@ impl Transport {
 
     /// Construct a Sendmail transport
     #[must_use]
-    pub fn sendmail(command: impl Into<OsString>) -> Self {
-        Self::new(TransportInner::Sendmail(
-            AsyncSendmailTransport::new_with_command(command),
-        ))
+    pub fn sendmail(command: Option<impl Into<OsString>>) -> Self {
+        let transport = if let Some(command) = command {
+            AsyncSendmailTransport::new_with_command(command)
+        } else {
+            AsyncSendmailTransport::new()
+        };
+        Self::new(TransportInner::Sendmail(transport))
     }
 }
 

--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -1612,108 +1612,13 @@
       }
     },
     "Provider": {
-      "description": "Authentication methods used against the OAuth 2.0 provider",
       "type": "object",
-      "oneOf": [
-        {
-          "description": "`none`: No authentication",
-          "type": "object",
-          "required": [
-            "token_endpoint_auth_method"
-          ],
-          "properties": {
-            "token_endpoint_auth_method": {
-              "type": "string",
-              "enum": [
-                "none"
-              ]
-            }
-          }
-        },
-        {
-          "description": "`client_secret_basic`: `client_id` and `client_secret` used as basic authorization credentials",
-          "type": "object",
-          "required": [
-            "client_secret",
-            "token_endpoint_auth_method"
-          ],
-          "properties": {
-            "token_endpoint_auth_method": {
-              "type": "string",
-              "enum": [
-                "client_secret_basic"
-              ]
-            },
-            "client_secret": {
-              "type": "string"
-            }
-          }
-        },
-        {
-          "description": "`client_secret_post`: `client_id` and `client_secret` sent in the request body",
-          "type": "object",
-          "required": [
-            "client_secret",
-            "token_endpoint_auth_method"
-          ],
-          "properties": {
-            "token_endpoint_auth_method": {
-              "type": "string",
-              "enum": [
-                "client_secret_post"
-              ]
-            },
-            "client_secret": {
-              "type": "string"
-            }
-          }
-        },
-        {
-          "description": "`client_secret_basic`: a `client_assertion` sent in the request body and signed using the `client_secret`",
-          "type": "object",
-          "required": [
-            "client_secret",
-            "token_endpoint_auth_method"
-          ],
-          "properties": {
-            "token_endpoint_auth_method": {
-              "type": "string",
-              "enum": [
-                "client_secret_jwt"
-              ]
-            },
-            "client_secret": {
-              "type": "string"
-            },
-            "token_endpoint_auth_signing_alg": {
-              "$ref": "#/definitions/JsonWebSignatureAlg"
-            }
-          }
-        },
-        {
-          "description": "`client_secret_basic`: a `client_assertion` sent in the request body and signed by an asymmetric key",
-          "type": "object",
-          "required": [
-            "token_endpoint_auth_method"
-          ],
-          "properties": {
-            "token_endpoint_auth_method": {
-              "type": "string",
-              "enum": [
-                "private_key_jwt"
-              ]
-            },
-            "token_endpoint_auth_signing_alg": {
-              "$ref": "#/definitions/JsonWebSignatureAlg"
-            }
-          }
-        }
-      ],
       "required": [
         "client_id",
         "id",
         "issuer",
-        "scope"
+        "scope",
+        "token_endpoint_auth_method"
       ],
       "properties": {
         "id": {
@@ -1737,13 +1642,32 @@
           "description": "The client ID to use when authenticating with the provider",
           "type": "string"
         },
+        "client_secret": {
+          "description": "The client secret to use when authenticating with the provider\n\nUsed by the `client_secret_basic`, `client_secret_post`, and `client_secret_jwt` methods",
+          "type": "string"
+        },
+        "token_endpoint_auth_method": {
+          "description": "The method to authenticate the client with the provider",
+          "allOf": [
+            {
+              "$ref": "#/definitions/TokenAuthMethod"
+            }
+          ]
+        },
+        "token_endpoint_auth_signing_alg": {
+          "description": "The JWS algorithm to use when authenticating the client with the provider\n\nUsed by the `client_secret_jwt` and `private_key_jwt` methods",
+          "allOf": [
+            {
+              "$ref": "#/definitions/JsonWebSignatureAlg"
+            }
+          ]
+        },
         "scope": {
           "description": "The scopes to request from the provider",
           "type": "string"
         },
         "discovery_mode": {
-          "description": "How to discover the provider's configuration\n\nDefaults to use OIDC discovery with strict metadata verification",
-          "default": "oidc",
+          "description": "How to discover the provider's configuration\n\nDefaults to `oidc`, which uses OIDC discovery with strict metadata verification",
           "allOf": [
             {
               "$ref": "#/definitions/DiscoveryMode"
@@ -1752,7 +1676,6 @@
         },
         "pkce_method": {
           "description": "Whether to use proof key for code exchange (PKCE) when requesting and exchanging the token.\n\nDefaults to `auto`, which uses PKCE if the provider supports it.",
-          "default": "auto",
           "allOf": [
             {
               "$ref": "#/definitions/PkceMethod"
@@ -1776,24 +1699,6 @@
         },
         "claims_imports": {
           "description": "How claims should be imported from the `id_token` provided by the provider",
-          "default": {
-            "subject": {
-              "template": null
-            },
-            "localpart": {
-              "action": "ignore",
-              "template": null
-            },
-            "displayname": {
-              "action": "ignore",
-              "template": null
-            },
-            "email": {
-              "action": "ignore",
-              "template": null,
-              "set_email_verification": "import"
-            }
-          },
           "allOf": [
             {
               "$ref": "#/definitions/ClaimsImports"
@@ -1802,13 +1707,52 @@
         },
         "additional_authorization_parameters": {
           "description": "Additional parameters to include in the authorization request\n\nOrders of the keys are not preserved.",
-          "default": {},
           "type": "object",
           "additionalProperties": {
             "type": "string"
           }
         }
       }
+    },
+    "TokenAuthMethod": {
+      "description": "Authentication methods used against the OAuth 2.0 provider",
+      "oneOf": [
+        {
+          "description": "`none`: No authentication",
+          "type": "string",
+          "enum": [
+            "none"
+          ]
+        },
+        {
+          "description": "`client_secret_basic`: `client_id` and `client_secret` used as basic authorization credentials",
+          "type": "string",
+          "enum": [
+            "client_secret_basic"
+          ]
+        },
+        {
+          "description": "`client_secret_post`: `client_id` and `client_secret` sent in the request body",
+          "type": "string",
+          "enum": [
+            "client_secret_post"
+          ]
+        },
+        {
+          "description": "`client_secret_jwt`: a `client_assertion` sent in the request body and signed using the `client_secret`",
+          "type": "string",
+          "enum": [
+            "client_secret_jwt"
+          ]
+        },
+        {
+          "description": "`private_key_jwt`: a `client_assertion` sent in the request body and signed by an asymmetric key",
+          "type": "string",
+          "enum": [
+            "private_key_jwt"
+          ]
+        }
+      ]
     },
     "DiscoveryMode": {
       "description": "How to discover the provider's configuration",
@@ -1868,9 +1812,6 @@
       "properties": {
         "subject": {
           "description": "How to determine the subject of the user",
-          "default": {
-            "template": null
-          },
           "allOf": [
             {
               "$ref": "#/definitions/SubjectImportPreference"
@@ -1879,10 +1820,6 @@
         },
         "localpart": {
           "description": "Import the localpart of the MXID",
-          "default": {
-            "action": "ignore",
-            "template": null
-          },
           "allOf": [
             {
               "$ref": "#/definitions/LocalpartImportPreference"
@@ -1891,10 +1828,6 @@
         },
         "displayname": {
           "description": "Import the displayname of the user.",
-          "default": {
-            "action": "ignore",
-            "template": null
-          },
           "allOf": [
             {
               "$ref": "#/definitions/DisplaynameImportPreference"
@@ -1903,11 +1836,6 @@
         },
         "email": {
           "description": "Import the email address of the user based on the `email` and `email_verified` claims",
-          "default": {
-            "action": "ignore",
-            "template": null,
-            "set_email_verification": "import"
-          },
           "allOf": [
             {
               "$ref": "#/definitions/EmailImportPreference"
@@ -1922,7 +1850,6 @@
       "properties": {
         "template": {
           "description": "The Jinja2 template to use for the subject attribute\n\nIf not provided, the default template is `{{ user.sub }}`",
-          "default": null,
           "type": "string"
         }
       }
@@ -1933,7 +1860,6 @@
       "properties": {
         "action": {
           "description": "How to handle the attribute",
-          "default": "ignore",
           "allOf": [
             {
               "$ref": "#/definitions/ImportAction"
@@ -1942,7 +1868,6 @@
         },
         "template": {
           "description": "The Jinja2 template to use for the localpart attribute\n\nIf not provided, the default template is `{{ user.preferred_username }}`",
-          "default": null,
           "type": "string"
         }
       }
@@ -1986,7 +1911,6 @@
       "properties": {
         "action": {
           "description": "How to handle the attribute",
-          "default": "ignore",
           "allOf": [
             {
               "$ref": "#/definitions/ImportAction"
@@ -1995,7 +1919,6 @@
         },
         "template": {
           "description": "The Jinja2 template to use for the displayname attribute\n\nIf not provided, the default template is `{{ user.name }}`",
-          "default": null,
           "type": "string"
         }
       }
@@ -2006,7 +1929,6 @@
       "properties": {
         "action": {
           "description": "How to handle the claim",
-          "default": "ignore",
           "allOf": [
             {
               "$ref": "#/definitions/ImportAction"
@@ -2015,12 +1937,10 @@
         },
         "template": {
           "description": "The Jinja2 template to use for the email address attribute\n\nIf not provided, the default template is `{{ user.email }}`",
-          "default": null,
           "type": "string"
         },
         "set_email_verification": {
           "description": "Should the email address be marked as verified",
-          "default": "import",
           "allOf": [
             {
               "$ref": "#/definitions/SetEmailVerification"

--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -1016,60 +1016,44 @@
     "DatabaseConfig": {
       "description": "Database connection configuration",
       "type": "object",
-      "anyOf": [
-        {
-          "description": "Connect via a full URI",
-          "type": "object",
-          "properties": {
-            "uri": {
-              "description": "Connection URI",
-              "default": "postgresql://",
-              "type": "string",
-              "format": "uri"
-            }
-          }
-        },
-        {
-          "description": "Connect via a map of options",
-          "type": "object",
-          "properties": {
-            "host": {
-              "description": "Name of host to connect to",
-              "default": null,
-              "type": "string",
-              "format": "hostname"
-            },
-            "port": {
-              "description": "Port number to connect at the server host",
-              "default": null,
-              "type": "integer",
-              "maximum": 65535.0,
-              "minimum": 1.0
-            },
-            "socket": {
-              "description": "Directory containing the UNIX socket to connect to",
-              "default": null,
-              "type": "string"
-            },
-            "username": {
-              "description": "PostgreSQL user name to connect as",
-              "default": null,
-              "type": "string"
-            },
-            "password": {
-              "description": "Password to be used if the server demands password authentication",
-              "default": null,
-              "type": "string"
-            },
-            "database": {
-              "description": "The database name",
-              "default": null,
-              "type": "string"
-            }
-          }
-        }
-      ],
       "properties": {
+        "uri": {
+          "description": "Connection URI\n\nThis must not be specified if `host`, `port`, `socket`, `username`, `password`, or `database` are specified.",
+          "default": "postgresql://",
+          "type": "string",
+          "format": "uri"
+        },
+        "host": {
+          "description": "Name of host to connect to\n\nThis must not be specified if `uri` is specified.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Hostname"
+            }
+          ]
+        },
+        "port": {
+          "description": "Port number to connect at the server host\n\nThis must not be specified if `uri` is specified.",
+          "type": "integer",
+          "format": "uint16",
+          "maximum": 65535.0,
+          "minimum": 1.0
+        },
+        "socket": {
+          "description": "Directory containing the UNIX socket to connect to\n\nThis must not be specified if `uri` is specified.",
+          "type": "string"
+        },
+        "username": {
+          "description": "PostgreSQL user name to connect as\n\nThis must not be specified if `uri` is specified.",
+          "type": "string"
+        },
+        "password": {
+          "description": "Password to be used if the server demands password authentication\n\nThis must not be specified if `uri` is specified.",
+          "type": "string"
+        },
+        "database": {
+          "description": "The database name\n\nThis must not be specified if `uri` is specified.",
+          "type": "string"
+        },
         "max_connections": {
           "description": "Set the maximum number of connections the pool should maintain",
           "default": 10,
@@ -1106,6 +1090,10 @@
           "minimum": 0.0
         }
       }
+    },
+    "Hostname": {
+      "type": "string",
+      "format": "hostname"
     },
     "TelemetryConfig": {
       "description": "Configuration related to sending monitoring data",
@@ -1401,8 +1389,11 @@
             },
             "hostname": {
               "description": "Hostname to connect to",
-              "type": "string",
-              "format": "hostname"
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Hostname"
+                }
+              ]
             },
             "port": {
               "description": "Port to connect to. Default is 25 for plain, 465 for TLS and 587 for StartTLS",

--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -1348,105 +1348,8 @@
     "EmailConfig": {
       "description": "Configuration related to sending emails",
       "type": "object",
-      "oneOf": [
-        {
-          "description": "Don't send emails anywhere",
-          "type": "object",
-          "required": [
-            "transport"
-          ],
-          "properties": {
-            "transport": {
-              "type": "string",
-              "enum": [
-                "blackhole"
-              ]
-            }
-          }
-        },
-        {
-          "description": "Send emails via an SMTP relay",
-          "type": "object",
-          "required": [
-            "hostname",
-            "mode",
-            "transport"
-          ],
-          "properties": {
-            "transport": {
-              "type": "string",
-              "enum": [
-                "smtp"
-              ]
-            },
-            "mode": {
-              "description": "Connection mode to the relay",
-              "allOf": [
-                {
-                  "$ref": "#/definitions/EmailSmtpMode"
-                }
-              ]
-            },
-            "hostname": {
-              "description": "Hostname to connect to",
-              "allOf": [
-                {
-                  "$ref": "#/definitions/Hostname"
-                }
-              ]
-            },
-            "port": {
-              "description": "Port to connect to. Default is 25 for plain, 465 for TLS and 587 for StartTLS",
-              "type": "integer",
-              "format": "uint16",
-              "minimum": 1.0
-            },
-            "username": {
-              "description": "Username for use to authenticate when connecting to the SMTP server",
-              "type": "string"
-            },
-            "password": {
-              "description": "Password for use to authenticate when connecting to the SMTP server",
-              "type": "string"
-            }
-          }
-        },
-        {
-          "description": "Send emails by calling sendmail",
-          "type": "object",
-          "required": [
-            "transport"
-          ],
-          "properties": {
-            "transport": {
-              "type": "string",
-              "enum": [
-                "sendmail"
-              ]
-            },
-            "command": {
-              "description": "Command to execute",
-              "default": "sendmail",
-              "type": "string"
-            }
-          }
-        },
-        {
-          "description": "Send emails via the AWS SESv2 API",
-          "deprecated": true,
-          "type": "object",
-          "required": [
-            "transport"
-          ],
-          "properties": {
-            "transport": {
-              "type": "string",
-              "enum": [
-                "aws_ses"
-              ]
-            }
-          }
-        }
+      "required": [
+        "transport"
       ],
       "properties": {
         "from": {
@@ -1460,8 +1363,78 @@
           "default": "\"Authentication Service\" <root@localhost>",
           "type": "string",
           "format": "email"
+        },
+        "transport": {
+          "description": "What backend should be used when sending emails",
+          "allOf": [
+            {
+              "$ref": "#/definitions/EmailTransportKind"
+            }
+          ]
+        },
+        "mode": {
+          "description": "SMTP transport: Connection mode to the relay",
+          "allOf": [
+            {
+              "$ref": "#/definitions/EmailSmtpMode"
+            }
+          ]
+        },
+        "hostname": {
+          "description": "SMTP transport: Hostname to connect to",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Hostname"
+            }
+          ]
+        },
+        "port": {
+          "description": "SMTP transport: Port to connect to. Default is 25 for plain, 465 for TLS and 587 for StartTLS",
+          "type": "integer",
+          "format": "uint16",
+          "maximum": 65535.0,
+          "minimum": 1.0
+        },
+        "username": {
+          "description": "SMTP transport: Username for use to authenticate when connecting to the SMTP server\n\nMust be set if the `password` field is set",
+          "type": "string"
+        },
+        "password": {
+          "description": "SMTP transport: Password for use to authenticate when connecting to the SMTP server\n\nMust be set if the `username` field is set",
+          "type": "string"
+        },
+        "command": {
+          "description": "Sendmail transport: Command to use to send emails",
+          "default": "sendmail",
+          "type": "string"
         }
       }
+    },
+    "EmailTransportKind": {
+      "description": "What backend should be used when sending emails",
+      "oneOf": [
+        {
+          "description": "Don't send emails anywhere",
+          "type": "string",
+          "enum": [
+            "blackhole"
+          ]
+        },
+        {
+          "description": "Send emails via an SMTP relay",
+          "type": "string",
+          "enum": [
+            "smtp"
+          ]
+        },
+        {
+          "description": "Send emails by calling sendmail",
+          "type": "string",
+          "enum": [
+            "sendmail"
+          ]
+        }
+      ]
     },
     "EmailSmtpMode": {
       "description": "Encryption mode to use",

--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -110,9 +110,7 @@
         "metrics": {
           "exporter": "none"
         },
-        "sentry": {
-          "dsn": null
-        }
+        "sentry": {}
       },
       "allOf": [
         {
@@ -1108,9 +1106,7 @@
         },
         "sentry": {
           "description": "Configuration related to the Sentry integration",
-          "default": {
-            "dsn": null
-          },
+          "default": {},
           "allOf": [
             {
               "$ref": "#/definitions/SentryConfig"
@@ -1122,68 +1118,25 @@
     "TracingConfig": {
       "description": "Configuration related to exporting traces",
       "type": "object",
-      "oneOf": [
-        {
-          "description": "Don't export traces",
-          "type": "object",
-          "required": [
-            "exporter"
-          ],
-          "properties": {
-            "exporter": {
-              "type": "string",
-              "enum": [
-                "none"
-              ]
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "description": "Export traces to the standard output. Only useful for debugging",
-          "type": "object",
-          "required": [
-            "exporter"
-          ],
-          "properties": {
-            "exporter": {
-              "type": "string",
-              "enum": [
-                "stdout"
-              ]
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "description": "Export traces to an OpenTelemetry protocol compatible endpoint",
-          "type": "object",
-          "required": [
-            "exporter"
-          ],
-          "properties": {
-            "exporter": {
-              "type": "string",
-              "enum": [
-                "otlp"
-              ]
-            },
-            "endpoint": {
-              "description": "OTLP compatible endpoint",
-              "examples": [
-                "https://localhost:4318"
-              ],
-              "type": "string",
-              "format": "uri"
-            }
-          },
-          "additionalProperties": false
-        }
-      ],
       "required": [
         "propagators"
       ],
       "properties": {
+        "exporter": {
+          "description": "Exporter to use when exporting traces",
+          "default": "none",
+          "allOf": [
+            {
+              "$ref": "#/definitions/TracingExporterKind"
+            }
+          ]
+        },
+        "endpoint": {
+          "description": "OTLP exporter: OTLP over HTTP compatible endpoint",
+          "default": "https://localhost:4318",
+          "type": "string",
+          "format": "uri"
+        },
         "propagators": {
           "description": "List of propagation formats to use for incoming and outgoing requests",
           "type": "array",
@@ -1192,6 +1145,32 @@
           }
         }
       }
+    },
+    "TracingExporterKind": {
+      "description": "Exporter to use when exporting traces",
+      "oneOf": [
+        {
+          "description": "Don't export traces",
+          "type": "string",
+          "enum": [
+            "none"
+          ]
+        },
+        {
+          "description": "Export traces to the standard output. Only useful for debugging",
+          "type": "string",
+          "enum": [
+            "stdout"
+          ]
+        },
+        {
+          "description": "Export traces to an OpenTelemetry protocol compatible endpoint",
+          "type": "string",
+          "enum": [
+            "otlp"
+          ]
+        }
+      ]
     },
     "Propagator": {
       "description": "Propagation format for incoming and outgoing requests",
@@ -1222,74 +1201,54 @@
     "MetricsConfig": {
       "description": "Configuration related to exporting metrics",
       "type": "object",
+      "properties": {
+        "exporter": {
+          "description": "Exporter to use when exporting metrics",
+          "default": "none",
+          "allOf": [
+            {
+              "$ref": "#/definitions/MetricsExporterKind"
+            }
+          ]
+        },
+        "endpoint": {
+          "description": "OTLP exporter: OTLP over HTTP compatible endpoint",
+          "default": "https://localhost:4318",
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "MetricsExporterKind": {
+      "description": "Exporter to use when exporting metrics",
       "oneOf": [
         {
           "description": "Don't export metrics",
-          "type": "object",
-          "required": [
-            "exporter"
-          ],
-          "properties": {
-            "exporter": {
-              "type": "string",
-              "enum": [
-                "none"
-              ]
-            }
-          }
+          "type": "string",
+          "enum": [
+            "none"
+          ]
         },
         {
           "description": "Export metrics to stdout. Only useful for debugging",
-          "type": "object",
-          "required": [
-            "exporter"
-          ],
-          "properties": {
-            "exporter": {
-              "type": "string",
-              "enum": [
-                "stdout"
-              ]
-            }
-          }
+          "type": "string",
+          "enum": [
+            "stdout"
+          ]
         },
         {
           "description": "Export metrics to an OpenTelemetry protocol compatible endpoint",
-          "type": "object",
-          "required": [
-            "exporter"
-          ],
-          "properties": {
-            "exporter": {
-              "type": "string",
-              "enum": [
-                "otlp"
-              ]
-            },
-            "endpoint": {
-              "description": "OTLP compatible endpoint",
-              "examples": [
-                "https://localhost:4318"
-              ],
-              "type": "string",
-              "format": "uri"
-            }
-          }
+          "type": "string",
+          "enum": [
+            "otlp"
+          ]
         },
         {
           "description": "Export metrics via Prometheus. An HTTP listener with the `prometheus` resource must be setup to expose the Promethes metrics.",
-          "type": "object",
-          "required": [
-            "exporter"
-          ],
-          "properties": {
-            "exporter": {
-              "type": "string",
-              "enum": [
-                "prometheus"
-              ]
-            }
-          }
+          "type": "string",
+          "enum": [
+            "prometheus"
+          ]
         }
       ]
     },
@@ -1299,7 +1258,6 @@
       "properties": {
         "dsn": {
           "description": "Sentry DSN",
-          "default": null,
           "examples": [
             "https://public@host:port/1"
           ],

--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -239,126 +239,8 @@
     "ClientConfig": {
       "description": "An OAuth 2.0 client configuration",
       "type": "object",
-      "oneOf": [
-        {
-          "description": "`none`: No authentication",
-          "type": "object",
-          "required": [
-            "client_auth_method"
-          ],
-          "properties": {
-            "client_auth_method": {
-              "type": "string",
-              "enum": [
-                "none"
-              ]
-            }
-          }
-        },
-        {
-          "description": "`client_secret_basic`: `client_id` and `client_secret` used as basic authorization credentials",
-          "type": "object",
-          "required": [
-            "client_auth_method",
-            "client_secret"
-          ],
-          "properties": {
-            "client_auth_method": {
-              "type": "string",
-              "enum": [
-                "client_secret_basic"
-              ]
-            },
-            "client_secret": {
-              "description": "The client secret",
-              "type": "string"
-            }
-          }
-        },
-        {
-          "description": "`client_secret_post`: `client_id` and `client_secret` sent in the request body",
-          "type": "object",
-          "required": [
-            "client_auth_method",
-            "client_secret"
-          ],
-          "properties": {
-            "client_auth_method": {
-              "type": "string",
-              "enum": [
-                "client_secret_post"
-              ]
-            },
-            "client_secret": {
-              "description": "The client secret",
-              "type": "string"
-            }
-          }
-        },
-        {
-          "description": "`client_secret_basic`: a `client_assertion` sent in the request body and signed using the `client_secret`",
-          "type": "object",
-          "required": [
-            "client_auth_method",
-            "client_secret"
-          ],
-          "properties": {
-            "client_auth_method": {
-              "type": "string",
-              "enum": [
-                "client_secret_jwt"
-              ]
-            },
-            "client_secret": {
-              "description": "The client secret",
-              "type": "string"
-            }
-          }
-        },
-        {
-          "description": "`client_secret_basic`: a `client_assertion` sent in the request body and signed by an asymmetric key",
-          "type": "object",
-          "oneOf": [
-            {
-              "type": "object",
-              "required": [
-                "jwks"
-              ],
-              "properties": {
-                "jwks": {
-                  "$ref": "#/definitions/JsonWebKeySet_for_JsonWebKeyPublicParameters"
-                }
-              },
-              "additionalProperties": false
-            },
-            {
-              "type": "object",
-              "required": [
-                "jwks_uri"
-              ],
-              "properties": {
-                "jwks_uri": {
-                  "type": "string",
-                  "format": "uri"
-                }
-              },
-              "additionalProperties": false
-            }
-          ],
-          "required": [
-            "client_auth_method"
-          ],
-          "properties": {
-            "client_auth_method": {
-              "type": "string",
-              "enum": [
-                "private_key_jwt"
-              ]
-            }
-          }
-        }
-      ],
       "required": [
+        "client_auth_method",
         "client_id"
       ],
       "properties": {
@@ -367,9 +249,33 @@
           "type": "string",
           "pattern": "^[0123456789ABCDEFGHJKMNPQRSTVWXYZ]{26}$"
         },
+        "client_auth_method": {
+          "description": "Authentication method used for this client",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ClientAuthMethodConfig"
+            }
+          ]
+        },
+        "client_secret": {
+          "description": "The client secret, used by the `client_secret_basic`, `client_secret_post` and `client_secret_jwt` authentication methods",
+          "type": "string"
+        },
+        "jwks": {
+          "description": "The JSON Web Key Set (JWKS) used by the `private_key_jwt` authentication method. Mutually exclusive with `jwks_uri`",
+          "allOf": [
+            {
+              "$ref": "#/definitions/JsonWebKeySet_for_JsonWebKeyPublicParameters"
+            }
+          ]
+        },
+        "jwks_uri": {
+          "description": "The URL of the JSON Web Key Set (JWKS) used by the `private_key_jwt` authentication method. Mutually exclusive with `jwks`",
+          "type": "string",
+          "format": "uri"
+        },
         "redirect_uris": {
           "description": "List of allowed redirect URIs",
-          "default": [],
           "type": "array",
           "items": {
             "type": "string",
@@ -377,6 +283,46 @@
           }
         }
       }
+    },
+    "ClientAuthMethodConfig": {
+      "description": "Authentication method used by clients",
+      "oneOf": [
+        {
+          "description": "`none`: No authentication",
+          "type": "string",
+          "enum": [
+            "none"
+          ]
+        },
+        {
+          "description": "`client_secret_basic`: `client_id` and `client_secret` used as basic authorization credentials",
+          "type": "string",
+          "enum": [
+            "client_secret_basic"
+          ]
+        },
+        {
+          "description": "`client_secret_post`: `client_id` and `client_secret` sent in the request body",
+          "type": "string",
+          "enum": [
+            "client_secret_post"
+          ]
+        },
+        {
+          "description": "`client_secret_basic`: a `client_assertion` sent in the request body and signed using the `client_secret`",
+          "type": "string",
+          "enum": [
+            "client_secret_jwt"
+          ]
+        },
+        {
+          "description": "`client_secret_basic`: a `client_assertion` sent in the request body and signed by an asymmetric key",
+          "type": "string",
+          "enum": [
+            "private_key_jwt"
+          ]
+        }
+      ]
     },
     "JsonWebKeySet_for_JsonWebKeyPublicParameters": {
       "type": "object",

--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -1532,63 +1532,9 @@
       }
     },
     "HashingScheme": {
-      "description": "A hashing algorithm",
       "type": "object",
-      "oneOf": [
-        {
-          "description": "bcrypt",
-          "type": "object",
-          "required": [
-            "algorithm"
-          ],
-          "properties": {
-            "algorithm": {
-              "type": "string",
-              "enum": [
-                "bcrypt"
-              ]
-            },
-            "cost": {
-              "description": "Hashing cost",
-              "default": 12,
-              "type": "integer",
-              "format": "uint32",
-              "minimum": 0.0
-            }
-          }
-        },
-        {
-          "description": "argon2id",
-          "type": "object",
-          "required": [
-            "algorithm"
-          ],
-          "properties": {
-            "algorithm": {
-              "type": "string",
-              "enum": [
-                "argon2id"
-              ]
-            }
-          }
-        },
-        {
-          "description": "PBKDF2",
-          "type": "object",
-          "required": [
-            "algorithm"
-          ],
-          "properties": {
-            "algorithm": {
-              "type": "string",
-              "enum": [
-                "pbkdf2"
-              ]
-            }
-          }
-        }
-      ],
       "required": [
+        "algorithm",
         "version"
       ],
       "properties": {
@@ -1596,8 +1542,50 @@
           "type": "integer",
           "format": "uint16",
           "minimum": 0.0
+        },
+        "algorithm": {
+          "$ref": "#/definitions/Algorithm"
+        },
+        "cost": {
+          "description": "Cost for the bcrypt algorithm",
+          "default": 12,
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        },
+        "secret": {
+          "type": "string"
+        },
+        "secret_file": {
+          "type": "string"
         }
       }
+    },
+    "Algorithm": {
+      "description": "A hashing algorithm",
+      "oneOf": [
+        {
+          "description": "bcrypt",
+          "type": "string",
+          "enum": [
+            "bcrypt"
+          ]
+        },
+        {
+          "description": "argon2id",
+          "type": "string",
+          "enum": [
+            "argon2id"
+          ]
+        },
+        {
+          "description": "PBKDF2",
+          "type": "string",
+          "enum": [
+            "pbkdf2"
+          ]
+        }
+      ]
     },
     "MatrixConfig": {
       "description": "Configuration related to the Matrix homeserver",

--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -836,22 +836,6 @@
               ]
             }
           }
-        },
-        {
-          "description": "Mount the single page app\n\nThis is deprecated and will be removed in a future release.",
-          "deprecated": true,
-          "type": "object",
-          "required": [
-            "name"
-          ],
-          "properties": {
-            "name": {
-              "type": "string",
-              "enum": [
-                "spa"
-              ]
-            }
-          }
         }
       ]
     },
@@ -955,32 +939,32 @@
     "TlsConfig": {
       "description": "Configuration related to TLS on a listener",
       "type": "object",
-      "oneOf": [
-        {
-          "type": "object",
-          "required": [
-            "certificate"
-          ],
-          "properties": {
-            "certificate": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false
+      "properties": {
+        "certificate": {
+          "description": "PEM-encoded X509 certificate chain\n\nExactly one of `certificate` or `certificate_file` must be set.",
+          "type": "string"
         },
-        {
-          "type": "object",
-          "required": [
-            "certificate_file"
-          ],
-          "properties": {
-            "certificate_file": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false
+        "certificate_file": {
+          "description": "File containing the PEM-encoded X509 certificate chain\n\nExactly one of `certificate` or `certificate_file` must be set.",
+          "type": "string"
+        },
+        "key": {
+          "description": "PEM-encoded private key\n\nExactly one of `key` or `key_file` must be set.",
+          "type": "string"
+        },
+        "key_file": {
+          "description": "File containing a PEM or DER-encoded private key\n\nExactly one of `key` or `key_file` must be set.",
+          "type": "string"
+        },
+        "password": {
+          "description": "Password used to decode the private key\n\nOne of `password` or `password_file` must be set if the key is encrypted.",
+          "type": "string"
+        },
+        "password_file": {
+          "description": "Password file used to decode the private key\n\nOne of `password` or `password_file` must be set if the key is encrypted.",
+          "type": "string"
         }
-      ]
+      }
     },
     "IpNetwork": {
       "oneOf": [

--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -1473,37 +1473,23 @@
     },
     "KeyConfig": {
       "type": "object",
-      "oneOf": [
-        {
-          "type": "object",
-          "required": [
-            "password"
-          ],
-          "properties": {
-            "password": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "type": "object",
-          "required": [
-            "password_file"
-          ],
-          "properties": {
-            "password_file": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false
-        }
-      ],
       "required": [
         "kid"
       ],
       "properties": {
         "kid": {
+          "type": "string"
+        },
+        "password": {
+          "type": "string"
+        },
+        "password_file": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "key_file": {
           "type": "string"
         }
       }

--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -188,7 +188,7 @@
         "authorization_grant_entrypoint": "authorization_grant/violation",
         "password_entrypoint": "password/violation",
         "email_entrypoint": "email/violation",
-        "data": null
+        "data": {}
       },
       "allOf": [
         {
@@ -1647,7 +1647,7 @@
         },
         "data": {
           "description": "Arbitrary data to pass to the policy",
-          "default": null
+          "default": {}
         }
       }
     },

--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -10,7 +10,6 @@
   "properties": {
     "clients": {
       "description": "List of OAuth 2.0/OIDC clients config",
-      "default": [],
       "type": "array",
       "items": {
         "$ref": "#/definitions/ClientConfig"
@@ -40,8 +39,7 @@
                 "playground": true
               },
               {
-                "name": "assets",
-                "path": "./frontend/dist/"
+                "name": "assets"
               }
             ],
             "binds": [
@@ -102,16 +100,6 @@
     },
     "telemetry": {
       "description": "Configuration related to sending monitoring data",
-      "default": {
-        "tracing": {
-          "exporter": "none",
-          "propagators": []
-        },
-        "metrics": {
-          "exporter": "none"
-        },
-        "sentry": {}
-      },
       "allOf": [
         {
           "$ref": "#/definitions/TelemetryConfig"
@@ -120,11 +108,6 @@
     },
     "templates": {
       "description": "Configuration related to templates",
-      "default": {
-        "path": "./templates/",
-        "assets_manifest": "./frontend/dist/manifest.json",
-        "translations_path": "./translations/"
-      },
       "allOf": [
         {
           "$ref": "#/definitions/TemplatesConfig"
@@ -179,15 +162,6 @@
     },
     "policy": {
       "description": "Configuration related to the OPA policies",
-      "default": {
-        "wasm_module": "./policies/policy.wasm",
-        "client_registration_entrypoint": "client_registration/violation",
-        "register_entrypoint": "register/violation",
-        "authorization_grant_entrypoint": "authorization_grant/violation",
-        "password_entrypoint": "password/violation",
-        "email_entrypoint": "email/violation",
-        "data": {}
-      },
       "allOf": [
         {
           "$ref": "#/definitions/PolicyConfig"
@@ -196,9 +170,6 @@
     },
     "upstream_oauth2": {
       "description": "Configuration related to upstream OAuth providers",
-      "default": {
-        "providers": []
-      },
       "allOf": [
         {
           "$ref": "#/definitions/UpstreamOAuth2Config"
@@ -207,13 +178,6 @@
     },
     "branding": {
       "description": "Configuration section for tweaking the branding of the service",
-      "default": {
-        "service_name": null,
-        "policy_uri": null,
-        "tos_uri": null,
-        "imprint": null,
-        "logo_uri": null
-      },
       "allOf": [
         {
           "$ref": "#/definitions/BrandingConfig"
@@ -222,10 +186,6 @@
     },
     "experimental": {
       "description": "Experimental configuration options",
-      "default": {
-        "access_token_ttl": 300,
-        "compat_token_ttl": 300
-      },
       "allOf": [
         {
           "$ref": "#/definitions/ExperimentalConfig"
@@ -815,7 +775,6 @@
             },
             "path": {
               "description": "Path to the directory to serve.",
-              "default": "./frontend/dist/",
               "type": "string"
             }
           }
@@ -1083,10 +1042,6 @@
       "properties": {
         "tracing": {
           "description": "Configuration related to exporting traces",
-          "default": {
-            "exporter": "none",
-            "propagators": []
-          },
           "allOf": [
             {
               "$ref": "#/definitions/TracingConfig"
@@ -1095,9 +1050,6 @@
         },
         "metrics": {
           "description": "Configuration related to exporting metrics",
-          "default": {
-            "exporter": "none"
-          },
           "allOf": [
             {
               "$ref": "#/definitions/MetricsConfig"
@@ -1106,7 +1058,6 @@
         },
         "sentry": {
           "description": "Configuration related to the Sentry integration",
-          "default": {},
           "allOf": [
             {
               "$ref": "#/definitions/SentryConfig"
@@ -1272,17 +1223,14 @@
       "properties": {
         "path": {
           "description": "Path to the folder which holds the templates",
-          "default": "./templates/",
           "type": "string"
         },
         "assets_manifest": {
           "description": "Path to the assets manifest",
-          "default": "./frontend/dist/manifest.json",
           "type": "string"
         },
         "translations_path": {
           "description": "Path to the translations",
-          "default": "./translations/",
           "type": "string"
         }
       }
@@ -1561,37 +1509,30 @@
       "properties": {
         "wasm_module": {
           "description": "Path to the WASM module",
-          "default": "./policies/policy.wasm",
           "type": "string"
         },
         "client_registration_entrypoint": {
           "description": "Entrypoint to use when evaluating client registrations",
-          "default": "client_registration/violation",
           "type": "string"
         },
         "register_entrypoint": {
           "description": "Entrypoint to use when evaluating user registrations",
-          "default": "register/violation",
           "type": "string"
         },
         "authorization_grant_entrypoint": {
           "description": "Entrypoint to use when evaluating authorization grants",
-          "default": "authorization_grant/violation",
           "type": "string"
         },
         "password_entrypoint": {
           "description": "Entrypoint to use when changing password",
-          "default": "password/violation",
           "type": "string"
         },
         "email_entrypoint": {
           "description": "Entrypoint to use when adding an email address",
-          "default": "email/violation",
           "type": "string"
         },
         "data": {
-          "description": "Arbitrary data to pass to the policy",
-          "default": {}
+          "description": "Arbitrary data to pass to the policy"
         }
       }
     },
@@ -2010,7 +1951,6 @@
       "properties": {
         "access_token_ttl": {
           "description": "Time-to-live of access tokens in seconds. Defaults to 5 minutes.",
-          "default": 300,
           "type": "integer",
           "format": "uint64",
           "maximum": 86400.0,
@@ -2018,7 +1958,6 @@
         },
         "compat_token_ttl": {
           "description": "Time-to-live of compatibility access tokens in seconds. Defaults to 5 minutes.",
-          "default": 300,
           "type": "integer",
           "format": "uint64",
           "maximum": 86400.0,


### PR DESCRIPTION
This removes any `#[serde(flatten)]` from the config, to both make the JSON schema simpler and make error reporting more accurate.

This introduces a few breaking changes to how MAS handles the configuration:

 - using the `spa` resource in `http.listeners.*.resources` would previously show a warning as it being deprecated. It now refuses to start
 - running `mas-cli config generate` would previously pick up a few environment variables, allowing to pre-set some fields. This feature was undocumented and environment variables are now ignored during configuration file generation
 - the JSON Schema of the config is now mostly flat, instead of using tagged union. This means that some required options (e.g. `hostname` field if the `email.transport` is set to `smtp`) are not considered as errors according to the schema. The upside of this, is that errors at the runtime now show the right path when reporting errors
 - the `mas-cli config dump` and `mas-cli config generate` commands only include essentials sections now