### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -321,7 +321,7 @@ jobs:
       - name: Create the archives
         run: |
           for arch in x86_64 aarch64; do
-            mv artifacts/target/${arch}-unknown-linux-musl/release/mas-cli dist/mas-cli
+            mv artifacts/target/${arch}-unknown-linux-gnu/release/mas-cli dist/mas-cli
             chmod u=rwx,go=rx dist/mas-cli
             tar -czvf mas-cli-${arch}-linux.tar.gz --owner=0 --group=0 -C dist/ .
           

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -132,7 +132,7 @@ jobs:
     runs-on: ubuntu-latest
 
     outputs:
-      metadata: ${{ steps.bake.outputs.metadata }}
+      metadata: ${{ steps.output.outputs.metadata }}
 
     permissions:
       contents: read
@@ -240,6 +240,16 @@ jobs:
             base.cache-from=type=registry,ref=${{ env.BUILDCACHE }}:buildcache
             base.cache-to=type=registry,ref=${{ env.BUILDCACHE }}:buildcache,mode=max
 
+      - name: Transform bake output
+        # This transforms the ouput to an object which lookes like this:
+        # { reguar: { digest: "…", tags: ["…", "…"] }, debug: { digest: "…", tags: ["…"] }, … }
+        id: output
+        if: github.event_name != 'pull_request'
+        run: |
+          echo 'metadata<<EOF' >> $GITHUB_OUTPUT
+          echo '${{ steps.bake.outputs.metadata }}' | jq -c 'map_values({ digest: .["containerimage.digest"], tags: (.["image.name"] | split(",")) })' >> $GITHUB_OUTPUT
+          echo 'EOF' >> $GITHUB_OUTPUT
+
       - name: Sign the images with GitHub Actions provided token
         # Only sign on tags and on commits on main branch
         if: |
@@ -248,9 +258,9 @@ jobs:
 
         run: |-
           cosign sign --yes \
-            "${{ env.IMAGE }}@${{ fromJSON(steps.bake.outputs.metadata).regular['containerimage.digest'] }}" \
-            "${{ env.IMAGE }}@${{ fromJSON(steps.bake.outputs.metadata).debug['containerimage.digest'] }}" \
-            "${{ env.IMAGE_SYN2MAS }}@${{ fromJSON(steps.bake.outputs.metadata).syn2mas['containerimage.digest'] }}"
+            "${{ env.IMAGE }}@${{ fromJSON(steps.output.outputs.metadata).regular.digest }}" \
+            "${{ env.IMAGE }}@${{ fromJSON(steps.output.outputs.metadata).debug.digest }}" \
+            "${{ env.IMAGE_SYN2MAS }}@${{ fromJSON(steps.output.outputs.metadata).syn2mas.digest }}"
           
 
   syn2mas:
@@ -330,33 +340,36 @@ jobs:
             
               - Digest: 
                 ```
-                ${{ env.IMAGE }}@${{ fromJSON(needs.build-image.outputs.metadata).regular['containerimage.digest'] }}
+                ${{ env.IMAGE }}@${{ fromJSON(needs.build-image.outputs.metadata).regular.digest }}
                 ```
               - Tags:
                 ```
-                ${{ fromJSON(needs.build-image.outputs.metadata).regular['image.name'] }}
+                ${{ join(fromJSON(needs.build-image.outputs.metadata).regular.tags, '
+                ') }}
                 ```
             
             Debug variant: 
             
               - Digest: 
                 ```
-                ${{ env.IMAGE }}@${{ fromJSON(needs.build-image.outputs.metadata).debug['containerimage.digest'] }}
+                ${{ env.IMAGE }}@${{ fromJSON(needs.build-image.outputs.metadata).debug.digest }}
                 ```
               - Tags:
                 ```
-                ${{ fromJSON(needs.build-image.outputs.metadata).debug['image.name'] }}
+                ${{ join(fromJSON(needs.build-image.outputs.metadata).debug.tags, '
+                ') }}
                 ```
             
             `syn2mas` migration tool: 
             
               - Digest: 
                 ```
-                ${{ env.IMAGE_SYN2MAS }}@${{ fromJSON(needs.build-image.outputs.metadata).syn2mas['containerimage.digest'] }}
+                ${{ env.IMAGE_SYN2MAS }}@${{ fromJSON(needs.build-image.outputs.metadata).syn2mas.digest }}
                 ```
               - Tags:
                 ```
-                ${{ fromJSON(needs.build-image.outputs.metadata).syn2mas['image.name'] }}
+                ${{ join(fromJSON(needs.build-image.outputs.metadata).syn2mas.tags, '
+                ') }}
                 ```
 
           files: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -195,7 +195,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.2.0
         with:
-          config-inline: |
+          buildkitd-config-inline: |
             [registry."docker.io"]
               mirrors = ["mirror.gcr.io"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -93,8 +93,8 @@ RUN --network=default \
 RUN --network=default \
   rustup target add  \
   --toolchain "${RUSTC_VERSION}" \
-  x86_64-unknown-linux-musl \
-  aarch64-unknown-linux-musl
+  x86_64-unknown-linux-gnu \
+  aarch64-unknown-linux-gnu
 
 # Set the working directory
 WORKDIR /app
@@ -124,8 +124,8 @@ RUN --network=default \
   --recipe-path recipe.json \
   --no-default-features \
   --features docker \
-  --target x86_64-unknown-linux-musl \
-  --target aarch64-unknown-linux-musl \
+  --target x86_64-unknown-linux-gnu \
+  --target aarch64-unknown-linux-gnu \
   --package mas-cli
 
 # Build the rest
@@ -140,14 +140,14 @@ RUN --network=default \
   --bin mas-cli \
   --no-default-features \
   --features docker \
-  --target x86_64-unknown-linux-musl \
-  --target aarch64-unknown-linux-musl
+  --target x86_64-unknown-linux-gnu \
+  --target aarch64-unknown-linux-gnu
 
 # Move the binary to avoid having to guess its name in the next stage
 RUN --network=none \
-  mv "target/x86_64-unknown-linux-musl/release/mas-cli" /usr/local/bin/mas-cli-amd64
+  mv "target/x86_64-unknown-linux-gnu/release/mas-cli" /usr/local/bin/mas-cli-amd64
 RUN --network=none \
-  mv "target/aarch64-unknown-linux-musl/release/mas-cli" /usr/local/bin/mas-cli-arm64
+  mv "target/aarch64-unknown-linux-gnu/release/mas-cli" /usr/local/bin/mas-cli-arm64
 
 #######################################
 ## Prepare /usr/local/share/mas-cli/ ##
@@ -162,7 +162,7 @@ COPY ./translations/ /share/translations
 ##################################
 ## Runtime stage, debug variant ##
 ##################################
-FROM --platform=${TARGETPLATFORM} gcr.io/distroless/static-debian${DEBIAN_VERSION}:debug-nonroot AS debug
+FROM --platform=${TARGETPLATFORM} gcr.io/distroless/base-nossl-debian${DEBIAN_VERSION}:debug-nonroot AS debug
 
 ARG TARGETARCH
 COPY --from=builder /usr/local/bin/mas-cli-${TARGETARCH} /usr/local/bin/mas-cli
@@ -174,7 +174,7 @@ ENTRYPOINT ["/usr/local/bin/mas-cli"]
 ###################
 ## Runtime stage ##
 ###################
-FROM --platform=${TARGETPLATFORM} gcr.io/distroless/static-debian${DEBIAN_VERSION}:nonroot
+FROM --platform=${TARGETPLATFORM} gcr.io/distroless/base-nossl-debian${DEBIAN_VERSION}:nonroot
 
 ARG TARGETARCH
 COPY --from=builder /usr/local/bin/mas-cli-${TARGETARCH} /usr/local/bin/mas-cli


### PR DESCRIPTION
- Transform the bake output for a better release message
- Set buildkitd-config-inline instead of config-inline
- Fix the release artifacts
- Switch a glibc-based build in the docker image
