### PR TITLE
Allow disabling registrations

### DIFF
--- a/crates/cli/src/commands/worker.rs
+++ b/crates/cli/src/commands/worker.rs
@@ -24,7 +24,9 @@ use rand::{
 };
 use tracing::{info, info_span};
 
-use crate::util::{database_pool_from_config, mailer_from_config, templates_from_config};
+use crate::util::{
+    database_pool_from_config, mailer_from_config, site_config_from_config, templates_from_config,
+};
 
 #[derive(Parser, Debug, Default)]
 pub(super) struct Options {}
@@ -44,14 +46,17 @@ impl Options {
             None,
         );
 
-        // Load and compile the templates
-        let templates = templates_from_config(
-            &config.templates,
+        // Load the site configuration
+        let site_config = site_config_from_config(
             &config.branding,
-            &url_builder,
-            &config.matrix.homeserver,
-        )
-        .await?;
+            &config.matrix,
+            &config.experimental,
+            &config.passwords,
+        );
+
+        // Load and compile the templates
+        let templates =
+            templates_from_config(&config.templates, &site_config, &url_builder).await?;
 
         let mailer = mailer_from_config(&config.email, &templates)?;
         mailer.test_connection().await?;

--- a/crates/config/src/sections/experimental.rs
+++ b/crates/config/src/sections/experimental.rs
@@ -27,6 +27,15 @@ fn is_default_token_ttl(value: &Duration) -> bool {
     *value == default_token_ttl()
 }
 
+const fn default_true() -> bool {
+    true
+}
+
+#[allow(clippy::trivially_copy_pass_by_ref)]
+const fn is_default_true(value: &bool) -> bool {
+    *value == default_true()
+}
+
 /// Configuration sections for experimental options
 ///
 /// Do not change these options unless you know what you are doing.
@@ -51,6 +60,11 @@ pub struct ExperimentalConfig {
     )]
     #[serde_as(as = "serde_with::DurationSeconds<i64>")]
     pub compat_token_ttl: Duration,
+
+    /// Whether to enable self-service password registration. Defaults to `true`
+    /// if password authentication is enabled.
+    #[serde(default = "default_true", skip_serializing_if = "is_default_true")]
+    pub password_registration_enabled: bool,
 }
 
 impl Default for ExperimentalConfig {
@@ -58,13 +72,16 @@ impl Default for ExperimentalConfig {
         Self {
             access_token_ttl: default_token_ttl(),
             compat_token_ttl: default_token_ttl(),
+            password_registration_enabled: default_true(),
         }
     }
 }
 
 impl ExperimentalConfig {
     pub(crate) fn is_default(&self) -> bool {
-        is_default_token_ttl(&self.access_token_ttl) && is_default_token_ttl(&self.compat_token_ttl)
+        is_default_token_ttl(&self.access_token_ttl)
+            && is_default_token_ttl(&self.compat_token_ttl)
+            && is_default_true(&self.password_registration_enabled)
     }
 }
 

--- a/crates/handlers/src/lib.rs
+++ b/crates/handlers/src/lib.rs
@@ -150,6 +150,7 @@ where
     B: HttpBody + Send + 'static,
     S: Clone + Send + Sync + 'static,
     Keystore: FromRef<S>,
+    SiteConfig: FromRef<S>,
     UrlBuilder: FromRef<S>,
     BoxClock: FromRequestParts<S>,
     BoxRng: FromRequestParts<S>,

--- a/crates/handlers/src/site_config.rs
+++ b/crates/handlers/src/site_config.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 The Matrix.org Foundation C.I.C.
+// Copyright 2023, 2024 The Matrix.org Foundation C.I.C.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use chrono::Duration;
+use mas_templates::{SiteBranding, SiteFeatures};
 use url::Url;
 
 /// Random site configuration we don't now where to put yet.
@@ -20,15 +21,39 @@ use url::Url;
 pub struct SiteConfig {
     pub access_token_ttl: Duration,
     pub compat_token_ttl: Duration,
+    pub server_name: String,
+    pub policy_uri: Option<Url>,
     pub tos_uri: Option<Url>,
+    pub imprint: Option<String>,
+    pub password_login_enabled: bool,
+    pub password_registration_enabled: bool,
 }
 
-impl Default for SiteConfig {
-    fn default() -> Self {
-        Self {
-            access_token_ttl: Duration::microseconds(5 * 60 * 1000 * 1000),
-            compat_token_ttl: Duration::microseconds(5 * 60 * 1000 * 1000),
-            tos_uri: None,
+impl SiteConfig {
+    #[must_use]
+    pub fn templates_branding(&self) -> SiteBranding {
+        let mut branding = SiteBranding::new(self.server_name.clone());
+
+        if let Some(policy_uri) = &self.policy_uri {
+            branding = branding.with_policy_uri(policy_uri.as_str());
+        }
+
+        if let Some(tos_uri) = &self.tos_uri {
+            branding = branding.with_tos_uri(tos_uri.as_str());
+        }
+
+        if let Some(imprint) = &self.imprint {
+            branding = branding.with_imprint(imprint.as_str());
+        }
+
+        branding
+    }
+
+    #[must_use]
+    pub fn templates_features(&self) -> SiteFeatures {
+        SiteFeatures {
+            password_registration: self.password_registration_enabled,
+            password_login: self.password_login_enabled,
         }
     }
 }

--- a/crates/router/src/url_builder.rs
+++ b/crates/router/src/url_builder.rs
@@ -112,6 +112,12 @@ impl UrlBuilder {
         }
     }
 
+    /// HTTP base
+    #[must_use]
+    pub fn http_base(&self) -> Url {
+        self.http_base.clone()
+    }
+
     /// OIDC issuer
     #[must_use]
     pub fn oidc_issuer(&self) -> Url {

--- a/crates/templates/src/context.rs
+++ b/crates/templates/src/context.rs
@@ -15,6 +15,7 @@
 //! Contexts used in templates
 
 mod branding;
+mod features;
 
 use std::{
     fmt::Formatter,
@@ -39,7 +40,7 @@ use serde::{ser::SerializeStruct, Deserialize, Serialize};
 use ulid::Ulid;
 use url::Url;
 
-pub use self::branding::SiteBranding;
+pub use self::{branding::SiteBranding, features::SiteFeatures};
 use crate::{FieldError, FormField, FormState};
 
 /// Helper trait to construct context wrappers
@@ -399,7 +400,6 @@ pub struct PostAuthContext {
 pub struct LoginContext {
     form: FormState<LoginFormField>,
     next: Option<PostAuthContext>,
-    password_disabled: bool,
     providers: Vec<UpstreamOAuthProvider>,
 }
 
@@ -413,13 +413,11 @@ impl TemplateContext for LoginContext {
             LoginContext {
                 form: FormState::default(),
                 next: None,
-                password_disabled: true,
                 providers: Vec::new(),
             },
             LoginContext {
                 form: FormState::default(),
                 next: None,
-                password_disabled: false,
                 providers: Vec::new(),
             },
             LoginContext {
@@ -432,14 +430,12 @@ impl TemplateContext for LoginContext {
                         },
                     ),
                 next: None,
-                password_disabled: false,
                 providers: Vec::new(),
             },
             LoginContext {
                 form: FormState::default()
                     .with_error_on_field(LoginFormField::Username, FieldError::Exists),
                 next: None,
-                password_disabled: false,
                 providers: Vec::new(),
             },
         ]
@@ -447,15 +443,6 @@ impl TemplateContext for LoginContext {
 }
 
 impl LoginContext {
-    /// Set whether password login is enabled or not
-    #[must_use]
-    pub fn with_password_login(self, enabled: bool) -> Self {
-        Self {
-            password_disabled: !enabled,
-            ..self
-        }
-    }
-
     /// Set the form state
     #[must_use]
     pub fn with_form_state(self, form: FormState<LoginFormField>) -> Self {

--- a/crates/templates/src/context/branding.rs
+++ b/crates/templates/src/context/branding.rs
@@ -1,3 +1,17 @@
+// Copyright 2024 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::sync::Arc;
 
 use minijinja::{value::StructObject, Value};
@@ -6,11 +20,9 @@ use minijinja::{value::StructObject, Value};
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SiteBranding {
     server_name: Arc<str>,
-    service_name: Option<Arc<str>>,
     policy_uri: Option<Arc<str>>,
     tos_uri: Option<Arc<str>>,
     imprint: Option<Arc<str>>,
-    logo_uri: Option<Arc<str>>,
 }
 
 impl SiteBranding {
@@ -19,19 +31,10 @@ impl SiteBranding {
     pub fn new(server_name: impl Into<Arc<str>>) -> Self {
         Self {
             server_name: server_name.into(),
-            service_name: None,
             policy_uri: None,
             tos_uri: None,
             imprint: None,
-            logo_uri: None,
         }
-    }
-
-    /// Set the service name.
-    #[must_use]
-    pub fn with_service_name(mut self, service_name: impl Into<Arc<str>>) -> Self {
-        self.service_name = Some(service_name.into());
-        self
     }
 
     /// Set the policy URI.
@@ -54,36 +57,20 @@ impl SiteBranding {
         self.imprint = Some(imprint.into());
         self
     }
-
-    /// Set the logo URI.
-    #[must_use]
-    pub fn with_logo_uri(mut self, logo_uri: impl Into<Arc<str>>) -> Self {
-        self.logo_uri = Some(logo_uri.into());
-        self
-    }
 }
 
 impl StructObject for SiteBranding {
     fn get_field(&self, name: &str) -> Option<Value> {
         match name {
             "server_name" => Some(self.server_name.clone().into()),
-            "service_name" => self.service_name.clone().map(Value::from),
             "policy_uri" => self.policy_uri.clone().map(Value::from),
             "tos_uri" => self.tos_uri.clone().map(Value::from),
             "imprint" => self.imprint.clone().map(Value::from),
-            "logo_uri" => self.logo_uri.clone().map(Value::from),
             _ => None,
         }
     }
 
     fn static_fields(&self) -> Option<&'static [&'static str]> {
-        Some(&[
-            "server_name",
-            "service_name",
-            "policy_uri",
-            "tos_uri",
-            "imprint",
-            "logo_uri",
-        ])
+        Some(&["server_name", "policy_uri", "tos_uri", "imprint"])
     }
 }

--- a/crates/templates/src/context/features.rs
+++ b/crates/templates/src/context/features.rs
@@ -1,0 +1,39 @@
+// Copyright 2024 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use minijinja::{value::StructObject, Value};
+
+/// Site features information.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SiteFeatures {
+    /// Whether local password-based registration is enabled.
+    pub password_registration: bool,
+
+    /// Whether local password-based login is enabled.
+    pub password_login: bool,
+}
+
+impl StructObject for SiteFeatures {
+    fn get_field(&self, field: &str) -> Option<Value> {
+        match field {
+            "password_registration" => Some(Value::from(self.password_registration)),
+            "password_login" => Some(Value::from(self.password_login)),
+            _ => None,
+        }
+    }
+
+    fn static_fields(&self) -> Option<&'static [&'static str]> {
+        Some(&["password_registration", "password_login"])
+    }
+}

--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -1962,6 +1962,10 @@
           "format": "uint64",
           "maximum": 86400.0,
           "minimum": 60.0
+        },
+        "password_registration_enabled": {
+          "description": "Whether to enable self-service password registration. Defaults to `true` if password authentication is enabled.",
+          "type": "boolean"
         }
       }
     }

--- a/templates/pages/index.html
+++ b/templates/pages/index.html
@@ -36,7 +36,10 @@ limitations under the License.
       {{ logout.button(text=_("action.sign_out"), csrf_token=csrf_token) }}
     {% else %}
       {{ button.link(text=_("action.sign_in"), href="/login") }}
-      {{ button.link_outline(text=_("mas.navbar.register"), href="/register") }}
+
+      {% if features.password_registration %}
+        {{ button.link_outline(text=_("mas.navbar.register"), href="/register") }}
+      {% endif %}
     {% endif %}
   </main>
 {% endblock content %}

--- a/templates/pages/login.html
+++ b/templates/pages/login.html
@@ -62,7 +62,7 @@ limitations under the License.
         {{ button.button(text=_("action.continue")) }}
       </form>
 
-      {% if not next or next.kind != "link_upstream" %}
+      {% if (not next or next.kind != "link_upstream") and features.password_registration %}
         <div class="flex gap-1 justify-center items-center cpd-text-body-md-regular">
           <p class="cpd-text-secondary">
             {{ _("mas.login.call_to_register") }}

--- a/templates/pages/login.html
+++ b/templates/pages/login.html
@@ -20,7 +20,7 @@ limitations under the License.
 
 {% block content %}
   <main class="flex flex-col gap-6">
-    {% if not password_disabled %}
+    {% if features.password_login %}
       <header class="page-heading">
         <div class="icon">
           {{ icon.user_profile_solid() }}
@@ -75,7 +75,7 @@ limitations under the License.
     {% endif %}
 
     {% if providers %}
-      {% if not password_disabled %}
+      {% if features.password_login %}
         {{ field.separator() }}
       {% endif %}
 
@@ -89,7 +89,7 @@ limitations under the License.
       {% endfor %}
     {% endif %}
 
-    {% if not providers and password_disabled %}
+    {% if not providers and not features.password_login %}
       <div class="text-center">
         {{ _("mas.login.no_login_methods") }}
       </div>

--- a/translations/en.json
+++ b/translations/en.json
@@ -226,7 +226,7 @@
       },
       "register": "Create an account",
       "@register": {
-        "context": "pages/index.html:39:34-58"
+        "context": "pages/index.html:41:36-60"
       },
       "signed_in_as": "Signed in as <span class=\"font-semibold\">%(username)s</span>.",
       "@signed_in_as": {


### PR DESCRIPTION
Fixes #2241 

This adds an experimental flag in the config, `experimental.password_registration_enabled`, which can be set to `false` to disable open registration. It defaults to the previous behaviour, `true`.

This is in the experimental section, as we don't exactly know yet how we want to shape the configuration around this.