### PR TITLE
Create the AccountManagementError enum

### DIFF
--- a/crates/oidc-client/src/error.rs
+++ b/crates/oidc-client/src/error.rs
@@ -64,6 +64,9 @@ pub enum Error {
 
     /// An error occurred introspecting a token.
     Introspection(#[from] IntrospectionError),
+
+    /// An error occurred building the account management URL.
+    AccountManagement(#[from] AccountManagementError),
 }
 
 /// All possible errors when fetching provider metadata.
@@ -702,4 +705,12 @@ pub enum CredentialsError {
     /// An error occurred with a custom signing method.
     #[error(transparent)]
     Custom(BoxError),
+}
+
+/// All errors that can occur when building the account management URL.
+#[derive(Debug, Error)]
+pub enum AccountManagementError {
+    /// An error occurred serializing the parameters.
+    #[error(transparent)]
+    UrlEncoded(#[from] serde_urlencoded::ser::Error),
 }

--- a/crates/oidc-client/src/requests/account_management.rs
+++ b/crates/oidc-client/src/requests/account_management.rs
@@ -20,6 +20,8 @@ use serde::Serialize;
 use serde_with::skip_serializing_none;
 use url::Url;
 
+use crate::error::AccountManagementError;
+
 /// An account management action that a user can take, including a device ID for
 /// the actions that support it.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -101,7 +103,7 @@ pub fn build_account_management_url(
     mut account_management_uri: Url,
     action: Option<AccountManagementActionFull>,
     id_token_hint: Option<String>,
-) -> Result<Url, serde_urlencoded::ser::Error> {
+) -> Result<Url, AccountManagementError> {
     let data = AccountManagementData {
         action,
         id_token_hint,


### PR DESCRIPTION
Otherwise it forces dependant crates to add serde_urlencoded as a dependency just to be able to forward the error type.

We don't use that crate directly in matrix-sdk, so it is a bit annoying to have to add that dependency just to forward the error.