### PR TITLE
CAPTCHA verification during registration

### DIFF
--- a/crates/cli/src/commands/server.rs
+++ b/crates/cli/src/commands/server.rs
@@ -145,7 +145,8 @@ impl Options {
             &config.matrix,
             &config.experimental,
             &config.passwords,
-        );
+            &config.captcha,
+        )?;
 
         // Load and compile the templates
         let templates =

--- a/crates/cli/src/commands/templates.rs
+++ b/crates/cli/src/commands/templates.rs
@@ -15,8 +15,8 @@
 use clap::Parser;
 use figment::Figment;
 use mas_config::{
-    BrandingConfig, ConfigurationSection, ExperimentalConfig, MatrixConfig, PasswordsConfig,
-    TemplatesConfig,
+    BrandingConfig, CaptchaConfig, ConfigurationSection, ExperimentalConfig, MatrixConfig,
+    PasswordsConfig, TemplatesConfig,
 };
 use mas_storage::{Clock, SystemClock};
 use rand::SeedableRng;
@@ -48,6 +48,7 @@ impl Options {
                 let matrix_config = MatrixConfig::extract(figment)?;
                 let experimental_config = ExperimentalConfig::extract(figment)?;
                 let password_config = PasswordsConfig::extract(figment)?;
+                let captcha_config = CaptchaConfig::extract(figment)?;
 
                 let clock = SystemClock::default();
                 // XXX: we should disallow SeedableRng::from_entropy
@@ -59,7 +60,8 @@ impl Options {
                     &matrix_config,
                     &experimental_config,
                     &password_config,
-                );
+                    &captcha_config,
+                )?;
                 let templates =
                     templates_from_config(&template_config, &site_config, &url_builder).await?;
                 templates.check_render(clock.now(), &mut rng)?;

--- a/crates/cli/src/commands/worker.rs
+++ b/crates/cli/src/commands/worker.rs
@@ -52,7 +52,8 @@ impl Options {
             &config.matrix,
             &config.experimental,
             &config.passwords,
-        );
+            &config.captcha,
+        )?;
 
         // Load and compile the templates
         let templates =

--- a/crates/cli/src/util.rs
+++ b/crates/cli/src/util.rs
@@ -132,6 +132,7 @@ pub fn captcha_config_from_config(
         mas_config::CaptchaServiceKind::CloudflareTurnstile => {
             mas_data_model::CaptchaService::CloudflareTurnstile
         }
+        mas_config::CaptchaServiceKind::HCaptcha => mas_data_model::CaptchaService::HCaptcha,
     };
 
     Ok(Some(mas_data_model::CaptchaConfig {

--- a/crates/cli/src/util.rs
+++ b/crates/cli/src/util.rs
@@ -129,6 +129,9 @@ pub fn captcha_config_from_config(
 
     let service = match service {
         mas_config::CaptchaServiceKind::RecaptchaV2 => mas_data_model::CaptchaService::RecaptchaV2,
+        mas_config::CaptchaServiceKind::CloudflareTurnstile => {
+            mas_data_model::CaptchaService::CloudflareTurnstile
+        }
     };
 
     Ok(Some(mas_data_model::CaptchaConfig {

--- a/crates/config/src/sections/captcha.rs
+++ b/crates/config/src/sections/captcha.rs
@@ -23,6 +23,10 @@ pub enum CaptchaServiceKind {
     /// Use Google's reCAPTCHA v2 API
     #[serde(rename = "recaptcha_v2")]
     RecaptchaV2,
+
+    /// Use Cloudflare Turnstile
+    #[serde(rename = "cloudflare_turnstile")]
+    CloudflareTurnstile,
 }
 
 /// Configuration section to setup CAPTCHA protection on a few operations

--- a/crates/config/src/sections/captcha.rs
+++ b/crates/config/src/sections/captcha.rs
@@ -27,6 +27,10 @@ pub enum CaptchaServiceKind {
     /// Use Cloudflare Turnstile
     #[serde(rename = "cloudflare_turnstile")]
     CloudflareTurnstile,
+
+    /// Use ``HCaptcha``
+    #[serde(rename = "hcaptcha")]
+    HCaptcha,
 }
 
 /// Configuration section to setup CAPTCHA protection on a few operations

--- a/crates/config/src/sections/captcha.rs
+++ b/crates/config/src/sections/captcha.rs
@@ -1,0 +1,80 @@
+// Copyright 2024 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use schemars::JsonSchema;
+use serde::{de::Error, Deserialize, Serialize};
+
+use crate::ConfigurationSection;
+
+/// Which service should be used for CAPTCHA protection
+#[derive(Clone, Copy, Debug, Deserialize, JsonSchema, Serialize)]
+pub enum CaptchaServiceKind {
+    /// Use Google's reCAPTCHA v2 API
+    #[serde(rename = "recaptcha_v2")]
+    RecaptchaV2,
+}
+
+/// Configuration section to setup CAPTCHA protection on a few operations
+#[derive(Clone, Debug, Deserialize, JsonSchema, Serialize, Default)]
+pub struct CaptchaConfig {
+    /// Which service should be used for CAPTCHA protection
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub service: Option<CaptchaServiceKind>,
+
+    /// The site key to use
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub site_key: Option<String>,
+
+    /// The secret key to use
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub secret_key: Option<String>,
+}
+
+impl CaptchaConfig {
+    /// Returns true if the configuration is the default one
+    pub(crate) fn is_default(&self) -> bool {
+        self.service.is_none() && self.site_key.is_none() && self.secret_key.is_none()
+    }
+}
+
+impl ConfigurationSection for CaptchaConfig {
+    const PATH: Option<&'static str> = Some("captcha");
+
+    fn validate(&self, figment: &figment::Figment) -> Result<(), figment::Error> {
+        let metadata = figment.find_metadata(Self::PATH.unwrap());
+
+        let error_on_field = |mut error: figment::error::Error, field: &'static str| {
+            error.metadata = metadata.cloned();
+            error.profile = Some(figment::Profile::Default);
+            error.path = vec![Self::PATH.unwrap().to_owned(), field.to_owned()];
+            error
+        };
+
+        let missing_field = |field: &'static str| {
+            error_on_field(figment::error::Error::missing_field(field), field)
+        };
+
+        if let Some(CaptchaServiceKind::RecaptchaV2) = self.service {
+            if self.site_key.is_none() {
+                return Err(missing_field("site_key"));
+            }
+
+            if self.secret_key.is_none() {
+                return Err(missing_field("secret_key"));
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/crates/config/src/sections/mod.rs
+++ b/crates/config/src/sections/mod.rs
@@ -17,6 +17,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 mod branding;
+mod captcha;
 mod clients;
 mod database;
 mod email;
@@ -32,6 +33,7 @@ mod upstream_oauth2;
 
 pub use self::{
     branding::BrandingConfig,
+    captcha::{CaptchaConfig, CaptchaServiceKind},
     clients::{ClientAuthMethodConfig, ClientConfig, ClientsConfig},
     database::DatabaseConfig,
     email::{EmailConfig, EmailSmtpMode, EmailTransportKind},
@@ -107,6 +109,10 @@ pub struct RootConfig {
     #[serde(default, skip_serializing_if = "BrandingConfig::is_default")]
     pub branding: BrandingConfig,
 
+    /// Configuration section to setup CAPTCHA protection on a few operations
+    #[serde(default, skip_serializing_if = "CaptchaConfig::is_default")]
+    pub captcha: CaptchaConfig,
+
     /// Experimental configuration options
     #[serde(default, skip_serializing_if = "ExperimentalConfig::is_default")]
     pub experimental: ExperimentalConfig,
@@ -126,6 +132,7 @@ impl ConfigurationSection for RootConfig {
         self.policy.validate(figment)?;
         self.upstream_oauth2.validate(figment)?;
         self.branding.validate(figment)?;
+        self.captcha.validate(figment)?;
         self.experimental.validate(figment)?;
 
         Ok(())
@@ -155,6 +162,7 @@ impl RootConfig {
             policy: PolicyConfig::default(),
             upstream_oauth2: UpstreamOAuth2Config::default(),
             branding: BrandingConfig::default(),
+            captcha: CaptchaConfig::default(),
             experimental: ExperimentalConfig::default(),
         })
     }
@@ -175,6 +183,7 @@ impl RootConfig {
             policy: PolicyConfig::default(),
             upstream_oauth2: UpstreamOAuth2Config::default(),
             branding: BrandingConfig::default(),
+            captcha: CaptchaConfig::default(),
             experimental: ExperimentalConfig::default(),
         }
     }
@@ -210,6 +219,9 @@ pub struct AppConfig {
     pub branding: BrandingConfig,
 
     #[serde(default)]
+    pub captcha: CaptchaConfig,
+
+    #[serde(default)]
     pub experimental: ExperimentalConfig,
 }
 
@@ -224,6 +236,7 @@ impl ConfigurationSection for AppConfig {
         self.matrix.validate(figment)?;
         self.policy.validate(figment)?;
         self.branding.validate(figment)?;
+        self.captcha.validate(figment)?;
         self.experimental.validate(figment)?;
 
         Ok(())

--- a/crates/data-model/src/lib.rs
+++ b/crates/data-model/src/lib.rs
@@ -40,7 +40,7 @@ pub use self::{
         AuthorizationCode, AuthorizationGrant, AuthorizationGrantStage, Client, DeviceCodeGrant,
         DeviceCodeGrantState, InvalidRedirectUriError, JwksOrJwksUri, Pkce, Session, SessionState,
     },
-    site_config::SiteConfig,
+    site_config::{CaptchaConfig, CaptchaService, SiteConfig},
     tokens::{
         AccessToken, AccessTokenState, RefreshToken, RefreshTokenState, TokenFormatError, TokenType,
     },

--- a/crates/data-model/src/site_config.rs
+++ b/crates/data-model/src/site_config.rs
@@ -15,6 +15,25 @@
 use chrono::Duration;
 use url::Url;
 
+/// Which Captcha service is being used
+#[derive(Debug, Clone)]
+pub enum CaptchaService {
+    RecaptchaV2,
+}
+
+/// Captcha configuration
+#[derive(Debug, Clone)]
+pub struct CaptchaConfig {
+    /// Which Captcha service is being used
+    pub service: CaptchaService,
+
+    /// The site key used by the instance
+    pub site_key: String,
+
+    /// The secret key used by the instance
+    pub secret_key: String,
+}
+
 /// Random site configuration we want accessible in various places.
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Debug, Clone)]
@@ -51,4 +70,7 @@ pub struct SiteConfig {
 
     /// Whether users can change their password.
     pub password_change_allowed: bool,
+
+    /// Captcha configuration
+    pub captcha: Option<CaptchaConfig>,
 }

--- a/crates/data-model/src/site_config.rs
+++ b/crates/data-model/src/site_config.rs
@@ -16,7 +16,7 @@ use chrono::Duration;
 use url::Url;
 
 /// Which Captcha service is being used
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub enum CaptchaService {
     RecaptchaV2,
     CloudflareTurnstile,

--- a/crates/data-model/src/site_config.rs
+++ b/crates/data-model/src/site_config.rs
@@ -19,6 +19,7 @@ use url::Url;
 #[derive(Debug, Clone)]
 pub enum CaptchaService {
     RecaptchaV2,
+    CloudflareTurnstile,
 }
 
 /// Captcha configuration

--- a/crates/data-model/src/site_config.rs
+++ b/crates/data-model/src/site_config.rs
@@ -20,6 +20,7 @@ use url::Url;
 pub enum CaptchaService {
     RecaptchaV2,
     CloudflareTurnstile,
+    HCaptcha,
 }
 
 /// Captcha configuration

--- a/crates/handlers/src/captcha.rs
+++ b/crates/handlers/src/captcha.rs
@@ -212,9 +212,7 @@ impl Form {
             }
 
             // hCaptcha
-            // XXX: this is also allowing g-recaptcha-response, because apparently hCaptcha thought
-            // it was a good idea to send both
-            (CaptchaService::HCaptcha, _, Some(response), None) => {
+            (CaptchaService::HCaptcha, None, Some(response), None) => {
                 Request::post(HCAPTCHA_VERIFY_URL)
                     .body(VerificationRequest {
                         secret,

--- a/crates/handlers/src/captcha.rs
+++ b/crates/handlers/src/captcha.rs
@@ -1,0 +1,280 @@
+// Copyright 2024 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::net::IpAddr;
+
+use axum::BoxError;
+use hyper::Request;
+use mas_axum_utils::http_client_factory::HttpClientFactory;
+use mas_data_model::{CaptchaConfig, CaptchaService};
+use mas_http::HttpServiceExt;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use tower::{Service, ServiceExt};
+
+use crate::BoundActivityTracker;
+
+// https://developers.google.com/recaptcha/docs/verify#api_request
+const RECAPTCHA_VERIFY_URL: &str = "https://www.google.com/recaptcha/api/siteverify";
+
+// https://docs.hcaptcha.com/#verify-the-user-response-server-side
+const HCAPTCHA_VERIFY_URL: &str = "https://api.hcaptcha.com/siteverify";
+
+// https://developers.cloudflare.com/turnstile/get-started/server-side-validation/
+const CF_TURNSTILE_VERIFY_URL: &str = "https://challenges.cloudflare.com/turnstile/v0/siteverify";
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("A CAPTCHA response was expected, but none was provided")]
+    MissingCaptchaResponse,
+
+    #[error("A CAPTCHA response was provided, but no CAPTCHA provider is configured")]
+    NoCaptchaConfigured,
+
+    #[error("The CAPTCHA response provided is not valid for the configured service")]
+    CaptchaResponseMismatch,
+
+    #[error("The CAPTCHA response provided is invalid: {0:?}")]
+    InvalidCaptcha(Vec<ErrorCode>),
+
+    #[error("The CAPTCHA provider returned an invalid response")]
+    InvalidResponse,
+
+    #[error("The hostname in the CAPTCHA response ({got:?}) does not match the site hostname ({expected:?})")]
+    HostnameMismatch { expected: String, got: String },
+
+    #[error("The CAPTCHA provider returned an error")]
+    RequestFailed(#[source] BoxError),
+}
+
+#[allow(clippy::struct_field_names)]
+#[derive(Debug, Deserialize, Default)]
+#[serde(rename_all = "kebab-case")]
+pub struct Form {
+    g_recaptcha_response: Option<String>,
+    h_captcha_response: Option<String>,
+    cf_turnstile_response: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct VerificationRequest<'a> {
+    secret: &'a str,
+    response: &'a str,
+    remoteip: Option<IpAddr>,
+}
+
+#[derive(Debug, Deserialize)]
+struct VerificationResponse {
+    success: bool,
+    #[serde(rename = "error-codes")]
+    error_codes: Option<Vec<ErrorCode>>,
+
+    challenge_ts: Option<String>,
+    hostname: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Clone, Copy)]
+#[serde(rename_all = "kebab-case")]
+pub enum ErrorCode {
+    /// The secret parameter is missing.
+    ///
+    /// Used by Cloudflare Turnstile, hCaptcha, reCAPTCHA
+    MissingInputSecret,
+
+    /// The secret parameter is invalid or malformed.
+    ///
+    /// Used by Cloudflare Turnstile, hCaptcha, reCAPTCHA
+    InvalidInputSecret,
+
+    /// The response parameter is missing.
+    ///
+    /// Used by Cloudflare Turnstile, hCaptcha, reCAPTCHA
+    MissingInputResponse,
+
+    /// The response parameter is invalid or malformed.
+    ///
+    /// Used by Cloudflare Turnstile, hCaptcha, reCAPTCHA
+    InvalidInputResponse,
+
+    /// The widget ID extracted from the parsed site secret key was invalid or
+    /// did not exist.
+    ///
+    /// Used by Cloudflare Turnstile
+    InvalidWidgetId,
+
+    /// The secret extracted from the parsed site secret key was invalid.
+    ///
+    /// Used by Cloudflare Turnstile
+    InvalidParsedSecret,
+
+    /// The request is invalid or malformed.
+    ///
+    /// Used by Cloudflare Turnstile, hCaptcha, reCAPTCHA
+    BadRequest,
+
+    /// The remoteip parameter is missing.
+    ///
+    /// Used by hCaptcha
+    MissingRemoteip,
+
+    /// The remoteip parameter is not a valid IP address or blinded value.
+    ///
+    /// Used by hCaptcha
+    InvalidRemoteip,
+
+    /// The response parameter has already been checked, or has another issue.
+    ///
+    /// Used by hCaptcha
+    InvalidOrAlreadySeenResponse,
+
+    /// You have used a testing sitekey but have not used its matching secret.
+    ///
+    /// Used by hCaptcha
+    NotUsingDummyPasscode,
+
+    /// The sitekey is not registered with the provided secret.
+    ///
+    /// Used by hCaptcha
+    SitekeySecretMismatch,
+
+    /// The response is no longer valid: either is too old or has been used
+    /// previously.
+    ///
+    /// Used by Cloudflare Turnstile, reCAPTCHA
+    TimeoutOrDisplicate,
+
+    /// An internal error happened while validating the response. The request
+    /// can be retried.
+    ///
+    /// Used by Cloudflare Turnstile
+    InternalError,
+}
+
+impl Form {
+    #[tracing::instrument(
+        skip_all,
+        name = "captcha.verify",
+        fields(captcha.hostname, captcha.challenge_ts, captcha.service),
+        err
+    )]
+    pub async fn verify(
+        &self,
+        activity_tracker: &BoundActivityTracker,
+        http_client_factory: &HttpClientFactory,
+        site_hostname: &str,
+        config: Option<&CaptchaConfig>,
+    ) -> Result<(), Error> {
+        let Some(config) = config else {
+            if self.g_recaptcha_response.is_some()
+                || self.h_captcha_response.is_some()
+                || self.cf_turnstile_response.is_some()
+            {
+                return Err(Error::NoCaptchaConfigured);
+            }
+
+            return Ok(());
+        };
+
+        let remoteip = activity_tracker.ip();
+        let secret = &config.secret_key;
+
+        let span = tracing::Span::current();
+        span.record("captcha.service", tracing::field::debug(config.service));
+
+        let request = match (
+            config.service,
+            &self.g_recaptcha_response,
+            &self.h_captcha_response,
+            &self.cf_turnstile_response,
+        ) {
+            (_, None, None, None) => return Err(Error::MissingCaptchaResponse),
+
+            // reCAPTCHA v2
+            (CaptchaService::RecaptchaV2, Some(response), None, None) => {
+                Request::post(RECAPTCHA_VERIFY_URL)
+                    .body(VerificationRequest {
+                        secret,
+                        response,
+                        remoteip,
+                    })
+                    .unwrap()
+            }
+
+            // hCaptcha
+            // XXX: this is also allowing g-recaptcha-response, because apparently hCaptcha thought
+            // it was a good idea to send both
+            (CaptchaService::HCaptcha, _, Some(response), None) => {
+                Request::post(HCAPTCHA_VERIFY_URL)
+                    .body(VerificationRequest {
+                        secret,
+                        response,
+                        remoteip,
+                    })
+                    .unwrap()
+            }
+
+            // Cloudflare Turnstile
+            (CaptchaService::CloudflareTurnstile, None, None, Some(response)) => {
+                Request::post(CF_TURNSTILE_VERIFY_URL)
+                    .body(VerificationRequest {
+                        secret,
+                        response,
+                        remoteip,
+                    })
+                    .unwrap()
+            }
+
+            _ => return Err(Error::CaptchaResponseMismatch),
+        };
+
+        let client = http_client_factory
+            .client("captcha")
+            .request_bytes_to_body()
+            .form_urlencoded_request()
+            .response_body_to_bytes()
+            .json_response::<VerificationResponse>()
+            .map_err(|e| Error::RequestFailed(e.into()));
+
+        let response = client.ready_oneshot().await?.call(request).await?;
+        let response = response.into_body();
+
+        if !response.success {
+            return Err(Error::InvalidCaptcha(
+                response.error_codes.unwrap_or_default(),
+            ));
+        }
+
+        // If the response is successful, we should have both the hostname and the
+        // challenge_ts
+        let Some(hostname) = response.hostname else {
+            return Err(Error::InvalidResponse);
+        };
+
+        let Some(challenge_ts) = response.challenge_ts else {
+            return Err(Error::InvalidResponse);
+        };
+
+        span.record("captcha.hostname", &hostname);
+        span.record("captcha.challenge_ts", &challenge_ts);
+
+        if hostname != site_hostname {
+            return Err(Error::HostnameMismatch {
+                expected: site_hostname.to_owned(),
+                got: hostname,
+            });
+        }
+
+        Ok(())
+    }
+}

--- a/crates/handlers/src/lib.rs
+++ b/crates/handlers/src/lib.rs
@@ -63,6 +63,7 @@ pub mod upstream_oauth2;
 mod views;
 
 mod activity_tracker;
+mod captcha;
 mod preferred_language;
 #[cfg(test)]
 mod test_utils;

--- a/crates/handlers/src/test_utils.rs
+++ b/crates/handlers/src/test_utils.rs
@@ -132,6 +132,7 @@ pub fn test_site_config() -> SiteConfig {
         email_change_allowed: true,
         displayname_change_allowed: true,
         password_change_allowed: true,
+        captcha: None,
     }
 }
 

--- a/crates/handlers/src/views/register.rs
+++ b/crates/handlers/src/views/register.rs
@@ -141,18 +141,24 @@ pub(crate) async fn post(
 
     // Validate the captcha
     // TODO: display a nice error message to the user
-    form.captcha
+    let passed_captcha = form
+        .captcha
         .verify(
             &activity_tracker,
             &http_client_factory,
             url_builder.public_hostname(),
             site_config.captcha.as_ref(),
         )
-        .await?;
+        .await
+        .is_ok();
 
     // Validate the form
     let state = {
         let mut state = form.to_form_state();
+
+        if !passed_captcha {
+            state.add_error_on_form(FormError::Captcha);
+        }
 
         if form.username.is_empty() {
             state.add_error_on_field(RegisterFormField::Username, FieldError::Required);

--- a/crates/router/src/url_builder.rs
+++ b/crates/router/src/url_builder.rs
@@ -112,6 +112,18 @@ impl UrlBuilder {
         }
     }
 
+    /// Site public hostname
+    ///
+    /// # Panics
+    ///
+    /// Panics if the base URL does not have a host
+    #[must_use]
+    pub fn public_hostname(&self) -> &str {
+        self.http_base
+            .host_str()
+            .expect("base URL must have a host")
+    }
+
     /// HTTP base
     #[must_use]
     pub fn http_base(&self) -> Url {

--- a/crates/templates/src/context.rs
+++ b/crates/templates/src/context.rs
@@ -15,6 +15,7 @@
 //! Contexts used in templates
 
 mod branding;
+mod captcha;
 mod ext;
 mod features;
 
@@ -41,7 +42,9 @@ use serde::{ser::SerializeStruct, Deserialize, Serialize};
 use ulid::Ulid;
 use url::Url;
 
-pub use self::{branding::SiteBranding, ext::SiteConfigExt, features::SiteFeatures};
+pub use self::{
+    branding::SiteBranding, captcha::WithCaptcha, ext::SiteConfigExt, features::SiteFeatures,
+};
 use crate::{FieldError, FormField, FormState};
 
 /// Helper trait to construct context wrappers
@@ -93,6 +96,14 @@ pub trait TemplateContext: Serialize {
             lang: lang.to_string(),
             inner: self,
         }
+    }
+
+    /// Attach a CAPTCHA configuration to the template context
+    fn with_captcha(self, captcha: Option<mas_data_model::CaptchaConfig>) -> WithCaptcha<Self>
+    where
+        Self: Sized,
+    {
+        WithCaptcha::new(captcha, self)
     }
 
     /// Generate sample values for this context type

--- a/crates/templates/src/context/captcha.rs
+++ b/crates/templates/src/context/captcha.rs
@@ -30,6 +30,9 @@ impl Object for CaptchaConfig {
         match key.as_str() {
             Some("service") => Some(match &self.0.service {
                 mas_data_model::CaptchaService::RecaptchaV2 => "recaptcha_v2".into(),
+                mas_data_model::CaptchaService::CloudflareTurnstile => {
+                    "cloudflare_turnstile".into()
+                }
             }),
             Some("site_key") => Some(self.0.site_key.clone().into()),
             _ => None,

--- a/crates/templates/src/context/captcha.rs
+++ b/crates/templates/src/context/captcha.rs
@@ -1,0 +1,77 @@
+// Copyright 2024 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use minijinja::{
+    value::{Enumerator, Object},
+    Value,
+};
+use serde::Serialize;
+
+use crate::TemplateContext;
+
+#[derive(Debug)]
+struct CaptchaConfig(mas_data_model::CaptchaConfig);
+
+impl Object for CaptchaConfig {
+    fn get_value(self: &Arc<Self>, key: &Value) -> Option<Value> {
+        match key.as_str() {
+            Some("service") => Some(match &self.0.service {
+                mas_data_model::CaptchaService::RecaptchaV2 => "recaptcha_v2".into(),
+            }),
+            Some("site_key") => Some(self.0.site_key.clone().into()),
+            _ => None,
+        }
+    }
+
+    fn enumerate(self: &Arc<Self>) -> Enumerator {
+        Enumerator::Str(&["service", "site_key"])
+    }
+}
+
+/// Context with an optional CAPTCHA configuration in it
+#[derive(Serialize)]
+pub struct WithCaptcha<T> {
+    captcha: Option<Value>,
+
+    #[serde(flatten)]
+    inner: T,
+}
+
+impl<T> WithCaptcha<T> {
+    #[must_use]
+    pub fn new(captcha: Option<mas_data_model::CaptchaConfig>, inner: T) -> Self {
+        Self {
+            captcha: captcha.map(|captcha| Value::from_object(CaptchaConfig(captcha))),
+            inner,
+        }
+    }
+}
+
+impl<T: TemplateContext> TemplateContext for WithCaptcha<T> {
+    fn sample(
+        now: chrono::DateTime<chrono::prelude::Utc>,
+        rng: &mut impl rand::prelude::Rng,
+    ) -> Vec<Self>
+    where
+        Self: Sized,
+    {
+        let inner = T::sample(now, rng);
+        inner
+            .into_iter()
+            .map(|inner| Self::new(None, inner))
+            .collect()
+    }
+}

--- a/crates/templates/src/context/captcha.rs
+++ b/crates/templates/src/context/captcha.rs
@@ -33,6 +33,7 @@ impl Object for CaptchaConfig {
                 mas_data_model::CaptchaService::CloudflareTurnstile => {
                     "cloudflare_turnstile".into()
                 }
+                mas_data_model::CaptchaService::HCaptcha => "hcaptcha".into(),
             }),
             Some("site_key") => Some(self.0.site_key.clone().into()),
             _ => None,

--- a/crates/templates/src/forms.rs
+++ b/crates/templates/src/forms.rs
@@ -64,6 +64,9 @@ pub enum FormError {
         /// Message for this policy violation
         message: String,
     },
+
+    /// Failed to validate CAPTCHA
+    Captcha,
 }
 
 #[derive(Debug, Default, Serialize)]

--- a/crates/templates/src/lib.rs
+++ b/crates/templates/src/lib.rs
@@ -22,6 +22,7 @@ use std::{collections::HashSet, sync::Arc};
 use anyhow::Context as _;
 use arc_swap::ArcSwap;
 use camino::{Utf8Path, Utf8PathBuf};
+use context::WithCaptcha;
 use mas_i18n::Translator;
 use mas_router::UrlBuilder;
 use mas_spa::ViteManifest;
@@ -326,7 +327,7 @@ register_templates! {
     pub fn render_login(WithLanguage<WithCsrf<LoginContext>>) { "pages/login.html" }
 
     /// Render the registration page
-    pub fn render_register(WithLanguage<WithCsrf<RegisterContext>>) { "pages/register.html" }
+    pub fn render_register(WithLanguage<WithCsrf<WithCaptcha<RegisterContext>>>) { "pages/register.html" }
 
     /// Render the client consent page
     pub fn render_consent(WithLanguage<WithCsrf<WithSession<ConsentContext>>>) { "pages/consent.html" }

--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -1995,6 +1995,13 @@
           "enum": [
             "cloudflare_turnstile"
           ]
+        },
+        {
+          "description": "Use ``HCaptcha``",
+          "type": "string",
+          "enum": [
+            "hcaptcha"
+          ]
         }
       ]
     },

--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -1988,6 +1988,13 @@
           "enum": [
             "recaptcha_v2"
           ]
+        },
+        {
+          "description": "Use Cloudflare Turnstile",
+          "type": "string",
+          "enum": [
+            "cloudflare_turnstile"
+          ]
         }
       ]
     },

--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -184,6 +184,14 @@
         }
       ]
     },
+    "captcha": {
+      "description": "Configuration section to setup CAPTCHA protection on a few operations",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CaptchaConfig"
+        }
+      ]
+    },
     "experimental": {
       "description": "Experimental configuration options",
       "allOf": [
@@ -1948,6 +1956,40 @@
           "format": "uri"
         }
       }
+    },
+    "CaptchaConfig": {
+      "description": "Configuration section to setup CAPTCHA protection on a few operations",
+      "type": "object",
+      "properties": {
+        "service": {
+          "description": "Which service should be used for CAPTCHA protection",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CaptchaServiceKind"
+            }
+          ]
+        },
+        "site_key": {
+          "description": "The site key to use",
+          "type": "string"
+        },
+        "secret_key": {
+          "description": "The secret key to use",
+          "type": "string"
+        }
+      }
+    },
+    "CaptchaServiceKind": {
+      "description": "Which service should be used for CAPTCHA protection",
+      "oneOf": [
+        {
+          "description": "Use Google's reCAPTCHA v2 API",
+          "type": "string",
+          "enum": [
+            "recaptcha_v2"
+          ]
+        }
+      ]
     },
     "ExperimentalConfig": {
       "description": "Configuration sections for experimental options\n\nDo not change these options unless you know what you are doing.",

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -248,6 +248,32 @@ passwords:
       algorithm: argon2id
 ```
 
+## `captcha`
+
+Settings related to CAPTCHA protection
+
+```yaml
+captcha:
+    # Which service to use for CAPTCHA protection. Set to `null` (or `~`) to disable CAPTCHA protection
+    service: ~
+
+    # Use Google reCAPTCHA v2
+    #service: recaptcha_v2
+    #site_key: "6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI"
+    #secret_key: "6LeIxAcTAAAAAGG"-vFI1TnRWxMZNFuojJ4WifJWe
+
+    # Use Cloudflare Turnstile
+    #service: cloudflare_turnstile
+    #site_key: "1x00000000000000000000AA"
+    #secret_key: "1x0000000000000000000000000000000AA"
+
+    # Use hCaptcha
+    #service: hcaptcha
+    #site_key: "10000000-ffff-ffff-ffff-000000000001"
+    #secret_key: "0x0000000000000000000000000000000000000000"
+```
+
+
 ## `policy`
 
 Policy settings

--- a/frontend/src/templates.css
+++ b/frontend/src/templates.css
@@ -64,6 +64,17 @@
   color: var(--cpd-color-text-secondary);
 }
 
+.captcha-noscript {
+  color: var(--cpd-color-text-critical-primary);
+  font: var(--cpd-font-body-md-semibold);
+  letter-spacing: var(--cpd-font-letter-spacing-body-md);
+  background-color: var(--cpd-color-bg-critical-subtle);
+  border: 1px solid var(--cpd-color-border-critical-subtle);
+  border-radius: var(--cpd-space-2x);
+  text-align: justify;
+  padding: var(--cpd-space-4x);
+}
+
 .consent-client-icon {
   display: block;
   height: var(--cpd-space-16x);

--- a/templates/base.html
+++ b/templates/base.html
@@ -23,6 +23,7 @@ limitations under the License.
 {% import "components/errors.html" as errors %}
 {% import "components/icon.html" as icon %}
 {% import "components/scope.html" as scope %}
+{% import "components/captcha.html" as captcha %}
 
 <!DOCTYPE html>
 <html lang="{{ lang }}">
@@ -31,6 +32,7 @@ limitations under the License.
     <title>{% block title %}{{ _("app.name") }}{% endblock title %}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     {{ include_asset('src/templates.css', preload=true) | indent(4) | safe }}
+    {{ captcha.head() }}
   </head>
   <body>
     <div class="layout-container">

--- a/templates/components/captcha.html
+++ b/templates/components/captcha.html
@@ -14,10 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 #}
 
-{% macro form() -%}
+{% macro form(class="") -%}
   {%- if captcha|default(False) -%}
     {%- if captcha.service == "recaptcha_v2" -%}
-      <div class="g-recaptcha" data-sitekey="{{ captcha.site_key }}"></div>
+      <div class="g-recaptcha {{ class }}" data-sitekey="{{ captcha.site_key }}"></div>
+    {%- elif captcha.service == "cloudflare_turnstile" -%}
+      <div class="cf-turnstile {{ class }}" data-sitekey="{{ captcha.site_key }}"></div>
     {%- else -%}
       {{ throw(message="Invalid captcha service setup") }}
     {%- endif %}
@@ -28,6 +30,8 @@ limitations under the License.
   {%- if captcha|default(False) -%}
     {%- if captcha.service == "recaptcha_v2" -%}
       <script src="https://www.google.com/recaptcha/api.js" async defer></script>
+    {%- elif captcha.service == "cloudflare_turnstile" -%}
+      <script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
     {%- else -%}
       {{ throw(message="Invalid captcha service setup") }}
     {%- endif %}

--- a/templates/components/captcha.html
+++ b/templates/components/captcha.html
@@ -41,7 +41,7 @@ limitations under the License.
     {%- elif captcha.service == "cloudflare_turnstile" -%}
       <script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
     {%- elif captcha.service == "hcaptcha" -%}
-      <script src="https://js.hcaptcha.com/1/api.js" async defer></script>
+      <script src="https://js.hcaptcha.com/1/api.js?recaptchacompat=off" async defer></script>
     {%- else -%}
       {{ throw(message="Invalid captcha service setup") }}
     {%- endif %}

--- a/templates/components/captcha.html
+++ b/templates/components/captcha.html
@@ -20,6 +20,8 @@ limitations under the License.
       <div class="g-recaptcha {{ class }}" data-sitekey="{{ captcha.site_key }}"></div>
     {%- elif captcha.service == "cloudflare_turnstile" -%}
       <div class="cf-turnstile {{ class }}" data-sitekey="{{ captcha.site_key }}"></div>
+    {%- elif captcha.service == "hcaptcha" -%}
+      <div class="h-captcha {{ class }}" data-sitekey="{{ captcha.site_key }}"></div>
     {%- else -%}
       {{ throw(message="Invalid captcha service setup") }}
     {%- endif %}
@@ -32,6 +34,8 @@ limitations under the License.
       <script src="https://www.google.com/recaptcha/api.js" async defer></script>
     {%- elif captcha.service == "cloudflare_turnstile" -%}
       <script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
+    {%- elif captcha.service == "hcaptcha" -%}
+      <script src="https://js.hcaptcha.com/1/api.js" async defer></script>
     {%- else -%}
       {{ throw(message="Invalid captcha service setup") }}
     {%- endif %}

--- a/templates/components/captcha.html
+++ b/templates/components/captcha.html
@@ -1,0 +1,35 @@
+{#
+Copyright 2024 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+#}
+
+{% macro form() -%}
+  {%- if captcha|default(False) -%}
+    {%- if captcha.service == "recaptcha_v2" -%}
+      <div class="g-recaptcha" data-sitekey="{{ captcha.site_key }}"></div>
+    {%- else -%}
+      {{ throw(message="Invalid captcha service setup") }}
+    {%- endif %}
+  {%- endif -%}
+{% endmacro %}
+
+{% macro head() -%}
+  {%- if captcha|default(False) -%}
+    {%- if captcha.service == "recaptcha_v2" -%}
+      <script src="https://www.google.com/recaptcha/api.js" async defer></script>
+    {%- else -%}
+      {{ throw(message="Invalid captcha service setup") }}
+    {%- endif %}
+  {%- endif -%}
+{%- endmacro %}

--- a/templates/components/captcha.html
+++ b/templates/components/captcha.html
@@ -16,6 +16,12 @@ limitations under the License.
 
 {% macro form(class="") -%}
   {%- if captcha|default(False) -%}
+    <noscript>
+      <div class="captcha-noscript">
+        {{ _("mas.captcha.noscript") }}
+      </div>
+    </noscript>
+
     {%- if captcha.service == "recaptcha_v2" -%}
       <div class="g-recaptcha {{ class }}" data-sitekey="{{ captcha.site_key }}"></div>
     {%- elif captcha.service == "cloudflare_turnstile" -%}

--- a/templates/components/errors.html
+++ b/templates/components/errors.html
@@ -1,5 +1,5 @@
 {#
-Copyright 2022 The Matrix.org Foundation C.I.C.
+Copyright 2022-2024 The Matrix.org Foundation C.I.C.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -21,6 +21,8 @@ limitations under the License.
     {{ _("mas.errors.password_mismatch") }}
   {% elif error.kind == "policy" %}
     {{ _("mas.errors.denied_policy", policy=error.message) }}
+  {% elif error.kind == "captcha" %}
+    {{ _("mas.errors.captcha") }}
   {% else %}
     {{ error.kind }}
   {% endif %}

--- a/templates/pages/register.html
+++ b/templates/pages/register.html
@@ -69,7 +69,7 @@ limitations under the License.
         {% endcall %}
       {% endif %}
 
-      {{ captcha.form() }}
+      {{ captcha.form(class="mb-4 self-center") }}
 
       {{ button.button(text=_("action.continue")) }}
     </form>

--- a/templates/pages/register.html
+++ b/templates/pages/register.html
@@ -30,13 +30,14 @@ limitations under the License.
 
   <section class="flex flex-col gap-6">
     <form method="POST" class="cpd-form-root">
-      {% if form.errors is not empty %}
-        {% for error in form.errors %}
+      {% for error in form.errors %}
+        {# Special case for the captcha error, as we want to put it at the bottom #}
+        {% if error.kind != "captcha" %}
           <div class="text-critical font-medium">
             {{ errors.form_error_message(error=error) }}
           </div>
-        {% endfor %}
-      {% endif %}
+        {% endif %}
+      {% endfor %}
 
       <input type="hidden" name="csrf" value="{{ csrf_token }}" />
 
@@ -70,6 +71,15 @@ limitations under the License.
       {% endif %}
 
       {{ captcha.form(class="mb-4 self-center") }}
+
+      {% for error in form.errors %}
+        {# Special case for the captcha error #}
+        {% if error.kind == "captcha" %}
+          <div class="text-critical font-medium text-center -mt-4 mb-4">
+            {{ errors.form_error_message(error=error) }}
+          </div>
+        {% endif %}
+      {% endfor %}
 
       {{ button.button(text=_("action.continue")) }}
     </form>

--- a/templates/pages/register.html
+++ b/templates/pages/register.html
@@ -69,6 +69,8 @@ limitations under the License.
         {% endcall %}
       {% endif %}
 
+      {{ captcha.form() }}
+
       {{ button.button(text=_("action.continue")) }}
     </form>
 

--- a/translations/en.json
+++ b/translations/en.json
@@ -2,11 +2,11 @@
   "action": {
     "cancel": "Cancel",
     "@cancel": {
-      "context": "pages/consent.html:75:11-29, pages/device_consent.html:132:13-31, pages/login.html:100:13-31, pages/policy_violation.html:52:13-31, pages/register.html:77:13-31"
+      "context": "pages/consent.html:75:11-29, pages/device_consent.html:132:13-31, pages/login.html:100:13-31, pages/policy_violation.html:52:13-31, pages/register.html:79:13-31"
     },
     "continue": "Continue",
     "@continue": {
-      "context": "pages/account/emails/add.html:45:26-46, pages/account/emails/verify.html:60:26-46, pages/consent.html:63:28-48, pages/device_consent.html:129:13-33, pages/device_link.html:48:26-46, pages/login.html:62:30-50, pages/reauth.html:40:28-48, pages/register.html:72:28-48, pages/sso.html:45:28-48"
+      "context": "pages/account/emails/add.html:45:26-46, pages/account/emails/verify.html:60:26-46, pages/consent.html:63:28-48, pages/device_consent.html:129:13-33, pages/device_link.html:48:26-46, pages/login.html:62:30-50, pages/reauth.html:40:28-48, pages/register.html:74:28-48, pages/sso.html:45:28-48"
     },
     "create_account": "Create Account",
     "@create_account": {
@@ -29,7 +29,7 @@
     },
     "name": "matrix-authentication-service",
     "@name": {
-      "context": "app.html:25:14-27, base.html:31:31-44",
+      "context": "app.html:25:14-27, base.html:32:31-44",
       "description": "Name of the application"
     },
     "technical_description": "OpenID Connect discovery document: <a class=\"cpd-link\" data-kind=\"primary\" href=\"%(discovery_url)s\">%(discovery_url)s</a>",
@@ -349,7 +349,7 @@
     "register": {
       "call_to_login": "Already have an account?",
       "@call_to_login": {
-        "context": "pages/register.html:87:11-42",
+        "context": "pages/register.html:89:11-42",
         "description": "Displayed on the registration page to suggest to log in instead"
       },
       "create_account": {
@@ -364,7 +364,7 @@
       },
       "sign_in_instead": "Sign in instead",
       "@sign_in_instead": {
-        "context": "pages/register.html:91:31-64"
+        "context": "pages/register.html:93:31-64"
       },
       "terms_of_service": "I agree to the <a href=\"%s\" data-kind=\"primary\" class=\"cpd-link\">Terms and Conditions</a>",
       "@terms_of_service": {

--- a/translations/en.json
+++ b/translations/en.json
@@ -109,6 +109,12 @@
     "@back_to_homepage": {
       "context": "pages/404.html:24:29-54"
     },
+    "captcha": {
+      "noscript": "This form is protected by a CAPTCHA and requires JavaScript to be enabled to submit it. Please enable JavaScript in your browser and reload this page.",
+      "@noscript": {
+        "context": "components/captcha.html:21:11-36"
+      }
+    },
     "change_password": {
       "change": "Change password",
       "@change": {

--- a/translations/en.json
+++ b/translations/en.json
@@ -247,6 +247,10 @@
       }
     },
     "errors": {
+      "captcha": "CAPTCHA verification failed, please try again",
+      "@captcha": {
+        "context": "components/errors.html:25:7-30"
+      },
       "denied_policy": "Denied by policy: %(policy)s",
       "@denied_policy": {
         "context": "components/errors.html:23:7-58, components/field.html:72:17-68"

--- a/translations/en.json
+++ b/translations/en.json
@@ -2,11 +2,11 @@
   "action": {
     "cancel": "Cancel",
     "@cancel": {
-      "context": "pages/consent.html:75:11-29, pages/device_consent.html:132:13-31, pages/login.html:100:13-31, pages/policy_violation.html:52:13-31, pages/register.html:79:13-31"
+      "context": "pages/consent.html:75:11-29, pages/device_consent.html:132:13-31, pages/login.html:100:13-31, pages/policy_violation.html:52:13-31, pages/register.html:89:13-31"
     },
     "continue": "Continue",
     "@continue": {
-      "context": "pages/account/emails/add.html:45:26-46, pages/account/emails/verify.html:60:26-46, pages/consent.html:63:28-48, pages/device_consent.html:129:13-33, pages/device_link.html:48:26-46, pages/login.html:62:30-50, pages/reauth.html:40:28-48, pages/register.html:74:28-48, pages/sso.html:45:28-48"
+      "context": "pages/account/emails/add.html:45:26-46, pages/account/emails/verify.html:60:26-46, pages/consent.html:63:28-48, pages/device_consent.html:129:13-33, pages/device_link.html:48:26-46, pages/login.html:62:30-50, pages/reauth.html:40:28-48, pages/register.html:84:28-48, pages/sso.html:45:28-48"
     },
     "create_account": "Create Account",
     "@create_account": {
@@ -67,7 +67,7 @@
     },
     "email_address": "Email address",
     "@email_address": {
-      "context": "pages/account/emails/add.html:41:33-58, pages/register.html:47:35-60, pages/upstream_oauth2/do_register.html:87:37-62"
+      "context": "pages/account/emails/add.html:41:33-58, pages/register.html:48:35-60, pages/upstream_oauth2/do_register.html:87:37-62"
     },
     "mxid": "Matrix ID",
     "@mxid": {
@@ -75,15 +75,15 @@
     },
     "password": "Password",
     "@password": {
-      "context": "pages/login.html:58:37-57, pages/reauth.html:36:35-55, pages/register.html:51:35-55"
+      "context": "pages/login.html:58:37-57, pages/reauth.html:36:35-55, pages/register.html:52:35-55"
     },
     "password_confirm": "Confirm password",
     "@password_confirm": {
-      "context": "pages/register.html:55:35-63"
+      "context": "pages/register.html:56:35-63"
     },
     "username": "Username",
     "@username": {
-      "context": "pages/login.html:54:37-57, pages/register.html:43:35-55, pages/upstream_oauth2/do_register.html:74:35-55, pages/upstream_oauth2/do_register.html:79:39-59"
+      "context": "pages/login.html:54:37-57, pages/register.html:44:35-55, pages/upstream_oauth2/do_register.html:74:35-55, pages/upstream_oauth2/do_register.html:79:39-59"
     }
   },
   "error": {
@@ -359,7 +359,7 @@
     "register": {
       "call_to_login": "Already have an account?",
       "@call_to_login": {
-        "context": "pages/register.html:89:11-42",
+        "context": "pages/register.html:99:11-42",
         "description": "Displayed on the registration page to suggest to log in instead"
       },
       "create_account": {
@@ -374,11 +374,11 @@
       },
       "sign_in_instead": "Sign in instead",
       "@sign_in_instead": {
-        "context": "pages/register.html:93:31-64"
+        "context": "pages/register.html:103:31-64"
       },
       "terms_of_service": "I agree to the <a href=\"%s\" data-kind=\"primary\" class=\"cpd-link\">Terms and Conditions</a>",
       "@terms_of_service": {
-        "context": "pages/register.html:60:37-97, pages/upstream_oauth2/do_register.html:144:35-95"
+        "context": "pages/register.html:61:37-97, pages/upstream_oauth2/do_register.html:144:35-95"
       }
     },
     "scope": {


### PR DESCRIPTION
This adds support for Cloudflare Turnstile, reCAPTCHA and hCAPTCHA validation during self-service user registration.
They all have very similar APIs, so supporting all three isn't very costly.

Fixes #138 

Follow up to do:

 - [x] Make sure the placement/style is right
 - [x] Display user-friendly errors on CAPTCHA failures (needs design)
 - [x] Have a `<noscript>` message to tell users to enable JS
 - [ ] Protect other actions?
 - [x] Document the feature



| reCAPTCHA | Cloudflare Turnstile | hCAPTCHA |
| --- | --- | --- |
| ![image](https://github.com/matrix-org/matrix-authentication-service/assets/1549952/4d7195c4-e863-438d-99a4-802330bc6ca9) | ![image](https://github.com/matrix-org/matrix-authentication-service/assets/1549952/09feaa70-5198-44da-a249-4f37bbd959b1) | ![image](https://github.com/matrix-org/matrix-authentication-service/assets/1549952/40ce26f7-b8fa-4cde-a1ed-e3797f4a64dd) |


| `<noscript>` fallback | Failure error message | 
| --- | --- |
| ![image](https://github.com/matrix-org/matrix-authentication-service/assets/1549952/bf91649b-fa56-475a-bf8d-26c6f6e21558) | ![image](https://github.com/matrix-org/matrix-authentication-service/assets/1549952/bcd0e0aa-9479-44c4-a58f-8601183b3030) |

