### PR TITLE
Improve errors when MAS contacts the Synapse homeserver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3384,6 +3384,7 @@ dependencies = [
  "mas-http",
  "mas-matrix",
  "serde",
+ "serde_json",
  "tower",
  "tracing",
  "url",

--- a/crates/axum-utils/src/language_detection.rs
+++ b/crates/axum-utils/src/language_detection.rs
@@ -109,7 +109,7 @@ impl Header for AcceptLanguage {
                     let quality = std::str::from_utf8(quality).map_err(|_e| Error::invalid())?;
                     let quality = quality.parse::<f64>().map_err(|_e| Error::invalid())?;
                     // Bound the quality between 0 and 1
-                    let quality = quality.min(1_f64).max(0_f64);
+                    let quality = quality.clamp(0_f64, 1_f64);
 
                     // Make sure the iterator is empty
                     if it.next().is_some() {

--- a/crates/http/src/ext.rs
+++ b/crates/http/src/ext.rs
@@ -70,6 +70,9 @@ pub trait ServiceExt<Body>: Sized {
         BytesToBodyRequest::new(self)
     }
 
+    /// Adds a layer which collects all the response body into a contiguous
+    /// byte buffer.
+    /// This makes the response type `Response<Bytes>`.
     fn response_body_to_bytes(self) -> BodyToBytesResponse<Self> {
         BodyToBytesResponse::new(self)
     }

--- a/crates/http/src/ext.rs
+++ b/crates/http/src/ext.rs
@@ -111,6 +111,18 @@ pub trait ServiceExt<Body>: Sized {
     {
         CatchHttpCodes::new(self, bounds, mapper)
     }
+
+    /// Shorthand for [`Self::catch_http_codes`] which catches all client errors
+    /// (4xx) and server errors (5xx).
+    fn catch_http_errors<M, ResBody, E>(self, mapper: M) -> CatchHttpCodes<Self, M>
+    where
+        M: Fn(Response<ResBody>) -> E + Send + Clone + 'static,
+    {
+        self.catch_http_codes(
+            StatusCode::from_u16(400).unwrap()..StatusCode::from_u16(600).unwrap(),
+            mapper,
+        )
+    }
 }
 
 impl<S, B> ServiceExt<B> for S where S: Service<Request<B>> {}

--- a/crates/http/src/layers/catch_http_codes.rs
+++ b/crates/http/src/layers/catch_http_codes.rs
@@ -24,12 +24,8 @@ pub enum Error<S, E> {
     #[error(transparent)]
     Service { inner: S },
 
-    #[error("request failed with status {status_code}")]
-    HttpError {
-        status_code: StatusCode,
-        #[source]
-        inner: E,
-    },
+    #[error("request failed with status {status_code}: {inner}")]
+    HttpError { status_code: StatusCode, inner: E },
 }
 
 impl<S, E> Error<S, E> {

--- a/crates/http/src/layers/catch_http_codes.rs
+++ b/crates/http/src/layers/catch_http_codes.rs
@@ -45,10 +45,16 @@ impl<S, E> Error<S, E> {
     }
 }
 
+/// A layer that catches responses with the HTTP status codes lying within
+/// `bounds` and then maps the requests into a custom error type using `mapper`.
 #[derive(Clone)]
 pub struct CatchHttpCodes<S, M> {
+    /// The inner service
     inner: S,
+    /// Which HTTP status codes to catch
     bounds: (Bound<StatusCode>, Bound<StatusCode>),
+    /// The function used to convert errors, which must be
+    /// `Fn(Response<ResBody>) -> E + Send + Clone + 'static`.
     mapper: M,
 }
 

--- a/crates/http/src/layers/json_response.rs
+++ b/crates/http/src/layers/json_response.rs
@@ -23,6 +23,7 @@ use tower::{Layer, Service};
 
 #[derive(Debug, Error)]
 pub enum Error<Service> {
+    /// An error from the inner service.
     #[error(transparent)]
     Service { inner: Service },
 

--- a/crates/matrix-synapse/Cargo.toml
+++ b/crates/matrix-synapse/Cargo.toml
@@ -16,6 +16,7 @@ anyhow.workspace = true
 async-trait.workspace = true
 http.workspace = true
 serde.workspace = true
+serde_json.workspace = true
 tower.workspace = true
 tracing.workspace = true
 url.workspace = true

--- a/crates/matrix-synapse/src/error.rs
+++ b/crates/matrix-synapse/src/error.rs
@@ -1,0 +1,64 @@
+use std::{error::Error, fmt::Display};
+
+use http::Response;
+use mas_axum_utils::axum::body::Bytes;
+use serde::Deserialize;
+use tracing::debug;
+
+/// Represents a Matrix error
+/// Ref: <https://spec.matrix.org/v1.10/client-server-api/#standard-error-response>
+#[derive(Debug, Deserialize)]
+struct MatrixError {
+    errcode: String,
+    error: String,
+}
+
+/// Represents an error received from the homeserver.
+/// Where possible, we capture the Matrix error from the JSON response body.
+///
+/// Note that the `CatchHttpCodes` layer already captures the `StatusCode` for
+/// us; we don't need to do that twice.
+#[derive(Debug)]
+pub(crate) struct HomeserverError {
+    matrix_error: Option<MatrixError>,
+}
+
+impl Display for HomeserverError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some(matrix_error) = &self.matrix_error {
+            write!(f, "{matrix_error}")
+        } else {
+            write!(f, "(no specific error)")
+        }
+    }
+}
+
+impl Error for HomeserverError {}
+
+impl HomeserverError {
+    /// Return the error code (`errcode`)
+    pub fn errcode(&self) -> Option<&str> {
+        self.matrix_error.as_ref().map(|me| me.errcode.as_str())
+    }
+}
+
+/// Parses a JSON-encoded Matrix error from the response body
+/// Spec reference: <https://spec.matrix.org/v1.10/client-server-api/#standard-error-response>
+#[allow(clippy::needless_pass_by_value)]
+pub(crate) fn catch_homeserver_error(response: Response<Bytes>) -> HomeserverError {
+    let matrix_error: Option<MatrixError> = match serde_json::from_slice(response.body().as_ref()) {
+        Ok(body) => Some(body),
+        Err(err) => {
+            debug!("failed to deserialise expected homeserver error: {err:?}");
+            None
+        }
+    };
+    HomeserverError { matrix_error }
+}
+
+impl Display for MatrixError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let MatrixError { errcode, error } = &self;
+        write!(f, "{errcode}: {error}")
+    }
+}

--- a/crates/matrix-synapse/src/lib.rs
+++ b/crates/matrix-synapse/src/lib.rs
@@ -171,7 +171,7 @@ impl HomeserverConnection for SynapseConnection {
             matrix.homeserver = self.homeserver,
             matrix.mxid = mxid,
         ),
-        err(Display),
+        err(Debug),
     )]
     async fn query_user(&self, mxid: &str) -> Result<MatrixUser, Self::Error> {
         let mxid = urlencoding::encode(mxid);
@@ -212,7 +212,7 @@ impl HomeserverConnection for SynapseConnection {
             matrix.homeserver = self.homeserver,
             matrix.localpart = localpart,
         ),
-        err(Display),
+        err(Debug),
     )]
     async fn is_localpart_available(&self, localpart: &str) -> Result<bool, Self::Error> {
         let localpart = urlencoding::encode(localpart);
@@ -273,7 +273,7 @@ impl HomeserverConnection for SynapseConnection {
             matrix.mxid = request.mxid(),
             user.id = request.sub(),
         ),
-        err(Display),
+        err(Debug),
     )]
     async fn provision_user(&self, request: &ProvisionRequest) -> Result<bool, Self::Error> {
         let mut body = SynapseUser {
@@ -342,7 +342,7 @@ impl HomeserverConnection for SynapseConnection {
             matrix.mxid = mxid,
             matrix.device_id = device_id,
         ),
-        err(Display),
+        err(Debug),
     )]
     async fn create_device(&self, mxid: &str, device_id: &str) -> Result<(), Self::Error> {
         let mxid = urlencoding::encode(mxid);
@@ -380,7 +380,7 @@ impl HomeserverConnection for SynapseConnection {
             matrix.mxid = mxid,
             matrix.device_id = device_id,
         ),
-        err(Display),
+        err(Debug),
     )]
     async fn delete_device(&self, mxid: &str, device_id: &str) -> Result<(), Self::Error> {
         let mxid = urlencoding::encode(mxid);
@@ -419,7 +419,7 @@ impl HomeserverConnection for SynapseConnection {
             matrix.mxid = mxid,
             erase = erase,
         ),
-        err(Display),
+        err(Debug),
     )]
     async fn delete_user(&self, mxid: &str, erase: bool) -> Result<(), Self::Error> {
         let mxid = urlencoding::encode(mxid);
@@ -457,7 +457,7 @@ impl HomeserverConnection for SynapseConnection {
             matrix.mxid = mxid,
             matrix.displayname = displayname,
         ),
-        err(Display),
+        err(Debug),
     )]
     async fn set_displayname(&self, mxid: &str, displayname: &str) -> Result<(), Self::Error> {
         let mxid = urlencoding::encode(mxid);
@@ -507,7 +507,7 @@ impl HomeserverConnection for SynapseConnection {
             matrix.homeserver = self.homeserver,
             matrix.mxid = mxid,
         ),
-        err(Display),
+        err(Debug),
     )]
     async fn allow_cross_signing_reset(&self, mxid: &str) -> Result<(), Self::Error> {
         let mxid = urlencoding::encode(mxid);
@@ -534,7 +534,8 @@ impl HomeserverConnection for SynapseConnection {
 
         if response.status() != StatusCode::OK {
             return Err(anyhow::anyhow!(
-                "Failed to allow cross signing reset in Synapse"
+                "Failed to allow cross signing reset in Synapse: {}",
+                response.status()
             ));
         }
 

--- a/templates/pages/error.html
+++ b/templates/pages/error.html
@@ -43,9 +43,8 @@ limitations under the License.
 
     {% if details %}
       <hr />
-      <pre>
-        <code class="font-mono whitespace-pre-wrap break-all">{{ details }}</code>
-      </pre>
+      {# caution: do not introduce whitespace between <pre> and <code> #}
+      <pre><code class="font-mono whitespace-pre-wrap break-all">{{ details }}</code></pre>
     {% endif %}
   </main>
 {% endblock %}


### PR DESCRIPTION
An example of a failed registration now looks like:

![Screenshot_20240523_172645](https://github.com/matrix-org/matrix-authentication-service/assets/38398653/8638ffd6-85af-4df5-b44f-d572bb849310)

Before the only detail this gave you was the headline message repeated a few times.

The logs now say

```
2024-05-23T16:26:32.863728Z ERROR http.server.request{otel.kind="server" otel.name="POST /register" network.protocol.name="http" network.protocol.version="1.1" http.request.method="POST" url.path="/register" url.scheme="http" http.route="/register" user_agent.original="Mozilla/5.0 (X11; Linux x86_64; rv:125.0) Gecko/20100101 Firefox/125.0"}:handlers.views.register.post: mas_handlers::views::register: error=Internal error: Failed to query localpart availability from Synapse (Failed to query localpart availability from Synapse

Caused by:
    request failed with status 401 Unauthorized: M_UNKNOWN_TOKEN: Invalid access token passed.)
```

Should be commit-by-commit review friendly