### PR TITLE
Allow parameters in UserInfo endpoint's response's content-type

### DIFF
--- a/crates/oidc-client/src/error.rs
+++ b/crates/oidc-client/src/error.rs
@@ -452,8 +452,8 @@ pub enum UserInfoError {
     DecodeResponseContentType(#[from] ToStrError),
 
     /// The content-type is not valid.
-    #[error("invalid response content-type: {0}")]
-    InvalidResponseContentTypeValue(#[from] mime::FromStrError),
+    #[error("invalid response content-type")]
+    InvalidResponseContentTypeValue,
 
     /// The content-type is not the one that was expected.
     #[error("unexpected response content-type {got:?}, expected {expected:?}")]

--- a/crates/oidc-client/src/error.rs
+++ b/crates/oidc-client/src/error.rs
@@ -451,9 +451,13 @@ pub enum UserInfoError {
     #[error("could not decoded response content-type: {0}")]
     DecodeResponseContentType(#[from] ToStrError),
 
+    /// The content-type is not valid.
+    #[error("invalid response content-type: {0}")]
+    InvalidResponseContentTypeValue(#[from] mime::FromStrError),
+
     /// The content-type is not the one that was expected.
-    #[error("invalid response content-type {got:?}, expected {expected:?}")]
-    InvalidResponseContentType {
+    #[error("unexpected response content-type {got:?}, expected {expected:?}")]
+    UnexpectedResponseContentType {
         /// The expected content-type.
         expected: String,
         /// The returned content-type.

--- a/crates/oidc-client/src/requests/userinfo.rs
+++ b/crates/oidc-client/src/requests/userinfo.rs
@@ -19,8 +19,8 @@
 use std::collections::HashMap;
 
 use bytes::Bytes;
-use headers::{Authorization, HeaderMapExt, HeaderValue};
-use http::header::{ACCEPT, CONTENT_TYPE};
+use headers::{Authorization, ContentType, HeaderMapExt, HeaderValue};
+use http::header::ACCEPT;
 use mas_http::CatchHttpCodesLayer;
 use mas_jose::claims;
 use mime::Mime;
@@ -101,10 +101,10 @@ pub async fn fetch_userinfo(
 
     let content_type: Mime = userinfo_response
         .headers()
-        .get(CONTENT_TYPE)
+        .typed_try_get::<ContentType>()
+        .map_err(|_| UserInfoError::InvalidResponseContentTypeValue)?
         .ok_or(UserInfoError::MissingResponseContentType)?
-        .to_str()?
-        .parse()?;
+        .into();
 
     if content_type.essence_str() != expected_content_type {
         return Err(UserInfoError::UnexpectedResponseContentType {


### PR DESCRIPTION
`application/json; charset=utf8` should be as valid as `application/json`, so we only check the "essence" of the content type.