### PR TITLE
Forgot password flow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3534,6 +3534,7 @@ dependencies = [
  "mas-email",
  "mas-i18n",
  "mas-matrix",
+ "mas-router",
  "mas-storage",
  "mas-storage-pg",
  "mas-templates",

--- a/crates/cli/src/commands/server.rs
+++ b/crates/cli/src/commands/server.rs
@@ -170,9 +170,14 @@ impl Options {
             let worker_name = Alphanumeric.sample_string(&mut rng, 10);
 
             info!(worker_name, "Starting task worker");
-            let monitor =
-                mas_tasks::init(&worker_name, &pool, &mailer, homeserver_connection.clone())
-                    .await?;
+            let monitor = mas_tasks::init(
+                &worker_name,
+                &pool,
+                &mailer,
+                homeserver_connection.clone(),
+                url_builder.clone(),
+            )
+            .await?;
             // TODO: grab the handle
             tokio::spawn(monitor.run());
         }

--- a/crates/cli/src/commands/worker.rs
+++ b/crates/cli/src/commands/worker.rs
@@ -77,7 +77,7 @@ impl Options {
         let worker_name = Alphanumeric.sample_string(&mut rng, 10);
 
         info!(worker_name, "Starting task scheduler");
-        let monitor = mas_tasks::init(&worker_name, &pool, &mailer, conn).await?;
+        let monitor = mas_tasks::init(&worker_name, &pool, &mailer, conn, url_builder).await?;
 
         span.exit();
 

--- a/crates/cli/src/util.rs
+++ b/crates/cli/src/util.rs
@@ -170,6 +170,8 @@ pub fn site_config_from_config(
         displayname_change_allowed: experimental_config.displayname_change_allowed,
         password_change_allowed: password_config.enabled()
             && experimental_config.password_change_allowed,
+        account_recovery_allowed: password_config.enabled()
+            && experimental_config.account_recovery_enabled,
         captcha,
     })
 }

--- a/crates/config/src/sections/experimental.rs
+++ b/crates/config/src/sections/experimental.rs
@@ -36,6 +36,15 @@ const fn is_default_true(value: &bool) -> bool {
     *value == default_true()
 }
 
+const fn default_false() -> bool {
+    false
+}
+
+#[allow(clippy::trivially_copy_pass_by_ref)]
+const fn is_default_false(value: &bool) -> bool {
+    *value == default_false()
+}
+
 /// Configuration sections for experimental options
 ///
 /// Do not change these options unless you know what you are doing.
@@ -80,6 +89,10 @@ pub struct ExperimentalConfig {
     /// Whether users are allowed to change their passwords. Defaults to `true`.
     #[serde(default = "default_true", skip_serializing_if = "is_default_true")]
     pub password_change_allowed: bool,
+
+    /// Whether email-based account recovery is enabled. Defaults to `false`.
+    #[serde(default = "default_false", skip_serializing_if = "is_default_false")]
+    pub account_recovery_enabled: bool,
 }
 
 impl Default for ExperimentalConfig {
@@ -91,6 +104,7 @@ impl Default for ExperimentalConfig {
             email_change_allowed: default_true(),
             displayname_change_allowed: default_true(),
             password_change_allowed: default_true(),
+            account_recovery_enabled: default_false(),
         }
     }
 }
@@ -103,6 +117,7 @@ impl ExperimentalConfig {
             && is_default_true(&self.email_change_allowed)
             && is_default_true(&self.displayname_change_allowed)
             && is_default_true(&self.password_change_allowed)
+            && is_default_false(&self.account_recovery_enabled)
     }
 }
 

--- a/crates/data-model/src/lib.rs
+++ b/crates/data-model/src/lib.rs
@@ -54,6 +54,6 @@ pub use self::{
     user_agent::{DeviceType, UserAgent},
     users::{
         Authentication, AuthenticationMethod, BrowserSession, Password, User, UserEmail,
-        UserEmailVerification, UserEmailVerificationState,
+        UserEmailVerification, UserEmailVerificationState, UserRecoverySession, UserRecoveryTicket,
     },
 };

--- a/crates/data-model/src/site_config.rs
+++ b/crates/data-model/src/site_config.rs
@@ -73,6 +73,9 @@ pub struct SiteConfig {
     /// Whether users can change their password.
     pub password_change_allowed: bool,
 
+    /// Whether users can recover their account via email.
+    pub account_recovery_allowed: bool,
+
     /// Captcha configuration
     pub captcha: Option<CaptchaConfig>,
 }

--- a/crates/handlers/src/lib.rs
+++ b/crates/handlers/src/lib.rs
@@ -382,6 +382,10 @@ where
                 .post(self::views::account::emails::add::post),
         )
         .route(
+            mas_router::AccountRecoveryStart::route(),
+            get(self::views::recovery::start::get).post(self::views::recovery::start::post),
+        )
+        .route(
             mas_router::OAuth2AuthorizationEndpoint::route(),
             get(self::oauth2::authorization::get),
         )

--- a/crates/handlers/src/lib.rs
+++ b/crates/handlers/src/lib.rs
@@ -386,6 +386,10 @@ where
             get(self::views::recovery::start::get).post(self::views::recovery::start::post),
         )
         .route(
+            mas_router::AccountRecoveryProgress::route(),
+            get(self::views::recovery::progress::get),
+        )
+        .route(
             mas_router::OAuth2AuthorizationEndpoint::route(),
             get(self::oauth2::authorization::get),
         )

--- a/crates/handlers/src/lib.rs
+++ b/crates/handlers/src/lib.rs
@@ -387,7 +387,7 @@ where
         )
         .route(
             mas_router::AccountRecoveryProgress::route(),
-            get(self::views::recovery::progress::get),
+            get(self::views::recovery::progress::get).post(self::views::recovery::progress::post),
         )
         .route(
             mas_router::OAuth2AuthorizationEndpoint::route(),

--- a/crates/handlers/src/lib.rs
+++ b/crates/handlers/src/lib.rs
@@ -390,6 +390,10 @@ where
             get(self::views::recovery::progress::get).post(self::views::recovery::progress::post),
         )
         .route(
+            mas_router::AccountRecoveryFinish::route(),
+            get(self::views::recovery::finish::get).post(self::views::recovery::finish::post),
+        )
+        .route(
             mas_router::OAuth2AuthorizationEndpoint::route(),
             get(self::oauth2::authorization::get),
         )

--- a/crates/handlers/src/test_utils.rs
+++ b/crates/handlers/src/test_utils.rs
@@ -133,6 +133,7 @@ pub fn test_site_config() -> SiteConfig {
         email_change_allowed: true,
         displayname_change_allowed: true,
         password_change_allowed: true,
+        account_recovery_allowed: true,
         captcha: None,
     }
 }

--- a/crates/handlers/src/views/account/mod.rs
+++ b/crates/handlers/src/views/account/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2021, 2022 The Matrix.org Foundation C.I.C.
+// Copyright 2021-2024 The Matrix.org Foundation C.I.C.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/crates/handlers/src/views/recovery/finish.rs
+++ b/crates/handlers/src/views/recovery/finish.rs
@@ -1,0 +1,246 @@
+// Copyright 2024 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use anyhow::Context;
+use axum::{
+    extract::{Query, State},
+    response::{Html, IntoResponse, Response},
+    Form,
+};
+use mas_axum_utils::{
+    cookies::CookieJar,
+    csrf::{CsrfExt, ProtectedForm},
+    FancyError,
+};
+use mas_policy::Policy;
+use mas_router::UrlBuilder;
+use mas_storage::{BoxClock, BoxRepository, BoxRng};
+use mas_templates::{
+    ErrorContext, FieldError, FormState, RecoveryFinishContext, RecoveryFinishFormField,
+    TemplateContext, Templates,
+};
+use serde::{Deserialize, Serialize};
+use zeroize::Zeroizing;
+
+use crate::{passwords::PasswordManager, PreferredLanguage};
+
+#[derive(Deserialize)]
+pub(crate) struct RouteQuery {
+    ticket: String,
+}
+
+#[derive(Deserialize, Serialize)]
+pub(crate) struct RouteForm {
+    new_password: String,
+    new_password_confirm: String,
+}
+
+pub(crate) async fn get(
+    mut rng: BoxRng,
+    clock: BoxClock,
+    mut repo: BoxRepository,
+    State(templates): State<Templates>,
+    PreferredLanguage(locale): PreferredLanguage,
+    cookie_jar: CookieJar,
+    Query(query): Query<RouteQuery>,
+) -> Result<Response, FancyError> {
+    let (csrf_token, cookie_jar) = cookie_jar.csrf_token(&clock, &mut rng);
+
+    let ticket = repo
+        .user_recovery()
+        .find_ticket(&query.ticket)
+        .await?
+        .context("Unknown ticket")?;
+
+    let session = repo
+        .user_recovery()
+        .lookup_session(ticket.user_recovery_session_id)
+        .await?
+        .context("Unknown session")?;
+
+    if !ticket.active(clock.now()) || session.consumed_at.is_some() {
+        // TODO: render a 'link expired' page
+        let rendered = templates.render_error(
+            &ErrorContext::new()
+                .with_code("Link expired")
+                .with_language(&locale),
+        )?;
+        return Ok((cookie_jar, Html(rendered)).into_response());
+    }
+
+    let user_email = repo
+        .user_email()
+        .lookup(ticket.user_email_id)
+        .await?
+        // Only allow confirmed email addresses
+        .filter(|email| email.confirmed_at.is_some())
+        .context("Unknown email address")?;
+
+    let user = repo
+        .user()
+        .lookup(user_email.user_id)
+        .await?
+        .context("Invalid user")?;
+
+    if !user.is_valid() {
+        // TODO: render a 'account locked' page
+        let rendered = templates.render_error(
+            &ErrorContext::new()
+                .with_code("Account locked")
+                .with_language(&locale),
+        )?;
+        return Ok((cookie_jar, Html(rendered)).into_response());
+    }
+
+    let context = RecoveryFinishContext::new(user)
+        .with_csrf(csrf_token.form_value())
+        .with_language(locale);
+
+    let rendered = templates.render_recovery_finish(&context)?;
+
+    Ok((cookie_jar, Html(rendered)).into_response())
+}
+
+pub(crate) async fn post(
+    mut rng: BoxRng,
+    clock: BoxClock,
+    mut repo: BoxRepository,
+    mut policy: Policy,
+    State(password_manager): State<PasswordManager>,
+    State(templates): State<Templates>,
+    State(url_builder): State<UrlBuilder>,
+    PreferredLanguage(locale): PreferredLanguage,
+    cookie_jar: CookieJar,
+    Query(query): Query<RouteQuery>,
+    Form(form): Form<ProtectedForm<RouteForm>>,
+) -> Result<Response, FancyError> {
+    let (csrf_token, cookie_jar) = cookie_jar.csrf_token(&clock, &mut rng);
+
+    let ticket = repo
+        .user_recovery()
+        .find_ticket(&query.ticket)
+        .await?
+        .context("Unknown ticket")?;
+
+    let session = repo
+        .user_recovery()
+        .lookup_session(ticket.user_recovery_session_id)
+        .await?
+        .context("Unknown session")?;
+
+    if !ticket.active(clock.now()) || session.consumed_at.is_some() {
+        // TODO: render a 'link expired' page
+        let rendered = templates.render_error(
+            &ErrorContext::new()
+                .with_code("Link expired")
+                .with_language(&locale),
+        )?;
+        return Ok((cookie_jar, Html(rendered)).into_response());
+    }
+
+    let user_email = repo
+        .user_email()
+        .lookup(ticket.user_email_id)
+        .await?
+        // Only allow confirmed email addresses
+        .filter(|email| email.confirmed_at.is_some())
+        .context("Unknown email address")?;
+
+    let user = repo
+        .user()
+        .lookup(user_email.user_id)
+        .await?
+        .context("Invalid user")?;
+
+    if !user.is_valid() {
+        // TODO: render a 'account locked' page
+        let rendered = templates.render_error(
+            &ErrorContext::new()
+                .with_code("Account locked")
+                .with_language(&locale),
+        )?;
+        return Ok((cookie_jar, Html(rendered)).into_response());
+    }
+
+    let form = cookie_jar.verify_form(&clock, form)?;
+
+    // Check the form
+    let mut form_state = FormState::from_form(&form);
+
+    if form.new_password.is_empty() {
+        form_state = form_state
+            .with_error_on_field(RecoveryFinishFormField::NewPassword, FieldError::Required);
+    }
+
+    if form.new_password_confirm.is_empty() {
+        form_state = form_state.with_error_on_field(
+            RecoveryFinishFormField::NewPasswordConfirm,
+            FieldError::Required,
+        );
+    }
+
+    if form.new_password != form.new_password_confirm {
+        form_state = form_state
+            .with_error_on_field(
+                RecoveryFinishFormField::NewPassword,
+                FieldError::Unspecified,
+            )
+            .with_error_on_field(
+                RecoveryFinishFormField::NewPasswordConfirm,
+                FieldError::PasswordMismatch,
+            );
+    }
+
+    let res = policy.evaluate_password(&form.new_password).await?;
+
+    if !res.valid() {
+        form_state = form_state.with_error_on_field(
+            RecoveryFinishFormField::NewPassword,
+            FieldError::Policy {
+                message: res.to_string(),
+            },
+        );
+    }
+
+    if !form_state.is_valid() {
+        let context = RecoveryFinishContext::new(user)
+            .with_form_state(form_state)
+            .with_csrf(csrf_token.form_value())
+            .with_language(locale);
+
+        let rendered = templates.render_recovery_finish(&context)?;
+
+        return Ok((cookie_jar, Html(rendered)).into_response());
+    }
+
+    // Form is valid, change the password
+    let password = Zeroizing::new(form.new_password.into_bytes());
+    let (version, hashed_password) = password_manager.hash(&mut rng, password).await?;
+    repo.user_password()
+        .add(&mut rng, &clock, &user, version, hashed_password, None)
+        .await?;
+
+    // Mark the session as consumed
+    repo.user_recovery()
+        .consume_ticket(&clock, ticket, session)
+        .await?;
+
+    repo.save().await?;
+
+    Ok((
+        cookie_jar,
+        url_builder.redirect(&mas_router::Login::default()),
+    )
+        .into_response())
+}

--- a/crates/handlers/src/views/recovery/finish.rs
+++ b/crates/handlers/src/views/recovery/finish.rs
@@ -77,7 +77,13 @@ pub(crate) async fn get(
         .await?
         .context("Unknown session")?;
 
-    if !ticket.active(clock.now()) || session.consumed_at.is_some() {
+    if session.consumed_at.is_some() {
+        let context = EmptyContext.with_language(locale);
+        let rendered = templates.render_recovery_consumed(&context)?;
+        return Ok((cookie_jar, Html(rendered)).into_response());
+    }
+
+    if !ticket.active(clock.now()) {
         let context = RecoveryExpiredContext::new(session)
             .with_csrf(csrf_token.form_value())
             .with_language(locale);
@@ -118,6 +124,7 @@ pub(crate) async fn get(
     Ok((cookie_jar, Html(rendered)).into_response())
 }
 
+#[allow(clippy::too_many_lines)]
 pub(crate) async fn post(
     mut rng: BoxRng,
     clock: BoxClock,
@@ -152,7 +159,13 @@ pub(crate) async fn post(
         .await?
         .context("Unknown session")?;
 
-    if !ticket.active(clock.now()) || session.consumed_at.is_some() {
+    if session.consumed_at.is_some() {
+        let context = EmptyContext.with_language(locale);
+        let rendered = templates.render_recovery_consumed(&context)?;
+        return Ok((cookie_jar, Html(rendered)).into_response());
+    }
+
+    if !ticket.active(clock.now()) {
         let context = RecoveryExpiredContext::new(session)
             .with_csrf(csrf_token.form_value())
             .with_language(locale);

--- a/crates/handlers/src/views/recovery/mod.rs
+++ b/crates/handlers/src/views/recovery/mod.rs
@@ -12,5 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub mod finish;
 pub mod progress;
 pub mod start;

--- a/crates/handlers/src/views/recovery/mod.rs
+++ b/crates/handlers/src/views/recovery/mod.rs
@@ -12,4 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub mod progress;
 pub mod start;

--- a/crates/handlers/src/views/recovery/mod.rs
+++ b/crates/handlers/src/views/recovery/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2021, 2022 The Matrix.org Foundation C.I.C.
+// Copyright 2024 The Matrix.org Foundation C.I.C.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,12 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod account;
-pub mod app;
-pub mod index;
-pub mod login;
-pub mod logout;
-pub mod reauth;
-pub mod recovery;
-pub mod register;
-pub mod shared;
+pub mod start;

--- a/crates/handlers/src/views/recovery/progress.rs
+++ b/crates/handlers/src/views/recovery/progress.rs
@@ -22,12 +22,13 @@ use mas_axum_utils::{
     csrf::{CsrfExt, ProtectedForm},
     FancyError, SessionInfoExt,
 };
+use mas_data_model::SiteConfig;
 use mas_router::UrlBuilder;
 use mas_storage::{
     job::{JobRepositoryExt, SendAccountRecoveryEmailsJob},
     BoxClock, BoxRepository, BoxRng,
 };
-use mas_templates::{RecoveryProgressContext, TemplateContext, Templates};
+use mas_templates::{EmptyContext, RecoveryProgressContext, TemplateContext, Templates};
 use ulid::Ulid;
 
 use crate::PreferredLanguage;
@@ -36,12 +37,19 @@ pub(crate) async fn get(
     mut rng: BoxRng,
     clock: BoxClock,
     mut repo: BoxRepository,
+    State(site_config): State<SiteConfig>,
     State(templates): State<Templates>,
     State(url_builder): State<UrlBuilder>,
     PreferredLanguage(locale): PreferredLanguage,
     cookie_jar: CookieJar,
     Path(id): Path<Ulid>,
 ) -> Result<Response, FancyError> {
+    if !site_config.account_recovery_allowed {
+        let context = EmptyContext.with_language(locale);
+        let rendered = templates.render_recovery_disabled(&context)?;
+        return Ok((cookie_jar, Html(rendered)).into_response());
+    }
+
     let (session_info, cookie_jar) = cookie_jar.session_info();
     let (csrf_token, cookie_jar) = cookie_jar.csrf_token(&clock, &mut rng);
 
@@ -75,6 +83,7 @@ pub(crate) async fn post(
     mut rng: BoxRng,
     clock: BoxClock,
     mut repo: BoxRepository,
+    State(site_config): State<SiteConfig>,
     State(templates): State<Templates>,
     State(url_builder): State<UrlBuilder>,
     PreferredLanguage(locale): PreferredLanguage,
@@ -82,6 +91,12 @@ pub(crate) async fn post(
     Path(id): Path<Ulid>,
     Form(form): Form<ProtectedForm<()>>,
 ) -> Result<Response, FancyError> {
+    if !site_config.account_recovery_allowed {
+        let context = EmptyContext.with_language(locale);
+        let rendered = templates.render_recovery_disabled(&context)?;
+        return Ok((cookie_jar, Html(rendered)).into_response());
+    }
+
     let (session_info, cookie_jar) = cookie_jar.session_info();
     let (csrf_token, cookie_jar) = cookie_jar.csrf_token(&clock, &mut rng);
 

--- a/crates/handlers/src/views/recovery/progress.rs
+++ b/crates/handlers/src/views/recovery/progress.rs
@@ -68,6 +68,12 @@ pub(crate) async fn get(
             .into_response());
     };
 
+    if recovery_session.consumed_at.is_some() {
+        let context = EmptyContext.with_language(locale);
+        let rendered = templates.render_recovery_consumed(&context)?;
+        return Ok((cookie_jar, Html(rendered)).into_response());
+    }
+
     let context = RecoveryProgressContext::new(recovery_session)
         .with_csrf(csrf_token.form_value())
         .with_language(locale);
@@ -114,6 +120,12 @@ pub(crate) async fn post(
         )
             .into_response());
     };
+
+    if recovery_session.consumed_at.is_some() {
+        let context = EmptyContext.with_language(locale);
+        let rendered = templates.render_recovery_consumed(&context)?;
+        return Ok((cookie_jar, Html(rendered)).into_response());
+    }
 
     // Verify the CSRF token
     let () = cookie_jar.verify_form(&clock, form)?;

--- a/crates/handlers/src/views/recovery/progress.rs
+++ b/crates/handlers/src/views/recovery/progress.rs
@@ -1,0 +1,64 @@
+// Copyright 2024 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use axum::{
+    extract::{Path, State},
+    response::{Html, IntoResponse, Response},
+};
+use mas_axum_utils::{cookies::CookieJar, csrf::CsrfExt, FancyError, SessionInfoExt};
+use mas_router::UrlBuilder;
+use mas_storage::{BoxClock, BoxRepository, BoxRng};
+use mas_templates::{RecoveryProgressContext, TemplateContext, Templates};
+use ulid::Ulid;
+
+use crate::PreferredLanguage;
+
+pub(crate) async fn get(
+    mut rng: BoxRng,
+    clock: BoxClock,
+    mut repo: BoxRepository,
+    State(templates): State<Templates>,
+    State(url_builder): State<UrlBuilder>,
+    PreferredLanguage(locale): PreferredLanguage,
+    cookie_jar: CookieJar,
+    Path(id): Path<Ulid>,
+) -> Result<Response, FancyError> {
+    let (session_info, cookie_jar) = cookie_jar.session_info();
+    let (csrf_token, cookie_jar) = cookie_jar.csrf_token(&clock, &mut rng);
+
+    let maybe_session = session_info.load_session(&mut repo).await?;
+    if maybe_session.is_some() {
+        // TODO: redirect to continue whatever action was going on
+        return Ok((cookie_jar, url_builder.redirect(&mas_router::Index)).into_response());
+    }
+
+    let Some(recovery_session) = repo.user_recovery().lookup_session(id).await? else {
+        // XXX: is that the right thing to do?
+        return Ok((
+            cookie_jar,
+            url_builder.redirect(&mas_router::AccountRecoveryStart),
+        )
+            .into_response());
+    };
+
+    let context = RecoveryProgressContext::new(recovery_session)
+        .with_csrf(csrf_token.form_value())
+        .with_language(locale);
+
+    repo.save().await?;
+
+    let rendered = templates.render_recovery_progress(&context)?;
+
+    Ok((cookie_jar, Html(rendered)).into_response())
+}

--- a/crates/handlers/src/views/recovery/progress.rs
+++ b/crates/handlers/src/views/recovery/progress.rs
@@ -15,10 +15,18 @@
 use axum::{
     extract::{Path, State},
     response::{Html, IntoResponse, Response},
+    Form,
 };
-use mas_axum_utils::{cookies::CookieJar, csrf::CsrfExt, FancyError, SessionInfoExt};
+use mas_axum_utils::{
+    cookies::CookieJar,
+    csrf::{CsrfExt, ProtectedForm},
+    FancyError, SessionInfoExt,
+};
 use mas_router::UrlBuilder;
-use mas_storage::{BoxClock, BoxRepository, BoxRng};
+use mas_storage::{
+    job::{JobRepositoryExt, SendAccountRecoveryEmailsJob},
+    BoxClock, BoxRepository, BoxRng,
+};
 use mas_templates::{RecoveryProgressContext, TemplateContext, Templates};
 use ulid::Ulid;
 
@@ -57,6 +65,54 @@ pub(crate) async fn get(
         .with_language(locale);
 
     repo.save().await?;
+
+    let rendered = templates.render_recovery_progress(&context)?;
+
+    Ok((cookie_jar, Html(rendered)).into_response())
+}
+
+pub(crate) async fn post(
+    mut rng: BoxRng,
+    clock: BoxClock,
+    mut repo: BoxRepository,
+    State(templates): State<Templates>,
+    State(url_builder): State<UrlBuilder>,
+    PreferredLanguage(locale): PreferredLanguage,
+    cookie_jar: CookieJar,
+    Path(id): Path<Ulid>,
+    Form(form): Form<ProtectedForm<()>>,
+) -> Result<Response, FancyError> {
+    let (session_info, cookie_jar) = cookie_jar.session_info();
+    let (csrf_token, cookie_jar) = cookie_jar.csrf_token(&clock, &mut rng);
+
+    let maybe_session = session_info.load_session(&mut repo).await?;
+    if maybe_session.is_some() {
+        // TODO: redirect to continue whatever action was going on
+        return Ok((cookie_jar, url_builder.redirect(&mas_router::Index)).into_response());
+    }
+
+    let Some(recovery_session) = repo.user_recovery().lookup_session(id).await? else {
+        // XXX: is that the right thing to do?
+        return Ok((
+            cookie_jar,
+            url_builder.redirect(&mas_router::AccountRecoveryStart),
+        )
+            .into_response());
+    };
+
+    // Verify the CSRF token
+    let () = cookie_jar.verify_form(&clock, form)?;
+
+    // Schedule a new batch of emails
+    repo.job()
+        .schedule_job(SendAccountRecoveryEmailsJob::new(&recovery_session))
+        .await?;
+
+    repo.save().await?;
+
+    let context = RecoveryProgressContext::new(recovery_session)
+        .with_csrf(csrf_token.form_value())
+        .with_language(locale);
 
     let rendered = templates.render_recovery_progress(&context)?;
 

--- a/crates/handlers/src/views/recovery/start.rs
+++ b/crates/handlers/src/views/recovery/start.rs
@@ -27,7 +27,10 @@ use mas_axum_utils::{
 };
 use mas_data_model::UserAgent;
 use mas_router::UrlBuilder;
-use mas_storage::{BoxClock, BoxRepository, BoxRng};
+use mas_storage::{
+    job::{JobRepositoryExt, SendAccountRecoveryEmailsJob},
+    BoxClock, BoxRepository, BoxRng,
+};
 use mas_templates::{
     FieldError, FormState, RecoveryStartContext, RecoveryStartFormField, TemplateContext, Templates,
 };
@@ -125,7 +128,9 @@ pub(crate) async fn post(
         )
         .await?;
 
-    // TODO: spawn a job which will send all the emails
+    repo.job()
+        .schedule_job(SendAccountRecoveryEmailsJob::new(&session))
+        .await?;
 
     repo.save().await?;
 

--- a/crates/handlers/src/views/recovery/start.rs
+++ b/crates/handlers/src/views/recovery/start.rs
@@ -1,0 +1,137 @@
+// Copyright 2024 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::str::FromStr;
+
+use axum::{
+    extract::State,
+    response::{Html, IntoResponse, Response},
+    Form, TypedHeader,
+};
+use lettre::Address;
+use mas_axum_utils::{
+    cookies::CookieJar,
+    csrf::{CsrfExt, ProtectedForm},
+    FancyError, SessionInfoExt,
+};
+use mas_data_model::UserAgent;
+use mas_router::UrlBuilder;
+use mas_storage::{BoxClock, BoxRepository, BoxRng};
+use mas_templates::{
+    FieldError, FormState, RecoveryStartContext, RecoveryStartFormField, TemplateContext, Templates,
+};
+use serde::{Deserialize, Serialize};
+
+use crate::{BoundActivityTracker, PreferredLanguage};
+
+#[derive(Deserialize, Serialize)]
+pub(crate) struct StartRecoveryForm {
+    email: String,
+}
+
+pub(crate) async fn get(
+    mut rng: BoxRng,
+    clock: BoxClock,
+    mut repo: BoxRepository,
+    State(templates): State<Templates>,
+    State(url_builder): State<UrlBuilder>,
+    PreferredLanguage(locale): PreferredLanguage,
+    cookie_jar: CookieJar,
+) -> Result<Response, FancyError> {
+    let (session_info, cookie_jar) = cookie_jar.session_info();
+    let (csrf_token, cookie_jar) = cookie_jar.csrf_token(&clock, &mut rng);
+
+    let maybe_session = session_info.load_session(&mut repo).await?;
+    if maybe_session.is_some() {
+        // TODO: redirect to continue whatever action was going on
+        return Ok((cookie_jar, url_builder.redirect(&mas_router::Index)).into_response());
+    }
+
+    let context = RecoveryStartContext::new()
+        .with_csrf(csrf_token.form_value())
+        .with_language(locale);
+
+    repo.save().await?;
+
+    let rendered = templates.render_recovery_start(&context)?;
+
+    Ok((cookie_jar, Html(rendered)).into_response())
+}
+
+pub(crate) async fn post(
+    mut rng: BoxRng,
+    clock: BoxClock,
+    mut repo: BoxRepository,
+    user_agent: TypedHeader<headers::UserAgent>,
+    activity_tracker: BoundActivityTracker,
+    State(templates): State<Templates>,
+    State(url_builder): State<UrlBuilder>,
+    PreferredLanguage(locale): PreferredLanguage,
+    cookie_jar: CookieJar,
+    Form(form): Form<ProtectedForm<StartRecoveryForm>>,
+) -> Result<impl IntoResponse, FancyError> {
+    let (session_info, cookie_jar) = cookie_jar.session_info();
+    let (csrf_token, cookie_jar) = cookie_jar.csrf_token(&clock, &mut rng);
+
+    let maybe_session = session_info.load_session(&mut repo).await?;
+    if maybe_session.is_some() {
+        // TODO: redirect to continue whatever action was going on
+        return Ok((cookie_jar, url_builder.redirect(&mas_router::Index)).into_response());
+    }
+
+    let user_agent = UserAgent::parse(user_agent.as_str().to_owned());
+    let ip_address = activity_tracker.ip();
+
+    let form = cookie_jar.verify_form(&clock, form)?;
+    let mut form_state = FormState::from_form(&form);
+
+    if Address::from_str(&form.email).is_err() {
+        form_state =
+            form_state.with_error_on_field(RecoveryStartFormField::Email, FieldError::Invalid);
+    }
+
+    if !form_state.is_valid() {
+        repo.save().await?;
+        let context = RecoveryStartContext::new()
+            .with_form_state(form_state)
+            .with_csrf(csrf_token.form_value())
+            .with_language(locale);
+
+        let rendered = templates.render_recovery_start(&context)?;
+
+        return Ok((cookie_jar, Html(rendered)).into_response());
+    }
+
+    let session = repo
+        .user_recovery()
+        .add_session(
+            &mut rng,
+            &clock,
+            form.email,
+            user_agent,
+            ip_address,
+            locale.to_string(),
+        )
+        .await?;
+
+    // TODO: spawn a job which will send all the emails
+
+    repo.save().await?;
+
+    Ok((
+        cookie_jar,
+        url_builder.redirect(&mas_router::AccountRecoveryProgress::new(session.id)),
+    )
+        .into_response())
+}

--- a/crates/handlers/src/views/register.rs
+++ b/crates/handlers/src/views/register.rs
@@ -191,9 +191,11 @@ pub(crate) async fn post(
         }
 
         if form.password != form.password_confirm {
-            state.add_error_on_form(FormError::PasswordMismatch);
             state.add_error_on_field(RegisterFormField::Password, FieldError::Unspecified);
-            state.add_error_on_field(RegisterFormField::PasswordConfirm, FieldError::Unspecified);
+            state.add_error_on_field(
+                RegisterFormField::PasswordConfirm,
+                FieldError::PasswordMismatch,
+            );
         }
 
         // If the site has terms of service, the user must accept them

--- a/crates/router/src/endpoints.rs
+++ b/crates/router/src/endpoints.rs
@@ -776,6 +776,38 @@ impl SimpleRoute for OAuth2DeviceAuthorizationEndpoint {
     const PATH: &'static str = "/oauth2/device";
 }
 
+/// `GET|POST /recover`
+#[derive(Default, Serialize, Deserialize, Debug, Clone)]
+pub struct AccountRecoveryStart;
+
+impl SimpleRoute for AccountRecoveryStart {
+    const PATH: &'static str = "/recover";
+}
+
+/// `GET|POST /recover/progress/:session_id`
+#[derive(Default, Serialize, Deserialize, Debug, Clone)]
+pub struct AccountRecoveryProgress {
+    session_id: Ulid,
+}
+
+impl AccountRecoveryProgress {
+    #[must_use]
+    pub fn new(session_id: Ulid) -> Self {
+        Self { session_id }
+    }
+}
+
+impl Route for AccountRecoveryProgress {
+    type Query = ();
+    fn route() -> &'static str {
+        "/recover/progress/:session_id"
+    }
+
+    fn path(&self) -> std::borrow::Cow<'static, str> {
+        format!("/recover/progress/{}", self.session_id).into()
+    }
+}
+
 /// `GET /assets`
 pub struct StaticAsset {
     path: String,

--- a/crates/router/src/endpoints.rs
+++ b/crates/router/src/endpoints.rs
@@ -808,6 +808,31 @@ impl Route for AccountRecoveryProgress {
     }
 }
 
+/// `GET|POST /recover/complete?ticket=:ticket`
+#[derive(Default, Serialize, Deserialize, Debug, Clone)]
+pub struct AccountRecoveryFinish {
+    ticket: String,
+}
+
+impl AccountRecoveryFinish {
+    #[must_use]
+    pub fn new(ticket: String) -> Self {
+        Self { ticket }
+    }
+}
+
+impl Route for AccountRecoveryFinish {
+    type Query = AccountRecoveryFinish;
+
+    fn route() -> &'static str {
+        "/recover/complete"
+    }
+
+    fn query(&self) -> Option<&Self::Query> {
+        Some(self)
+    }
+}
+
 /// `GET /assets`
 pub struct StaticAsset {
     path: String,

--- a/crates/router/src/url_builder.rs
+++ b/crates/router/src/url_builder.rs
@@ -237,6 +237,12 @@ impl UrlBuilder {
     pub fn account_management_uri(&self) -> Url {
         self.absolute_url_for(&crate::endpoints::Account::default())
     }
+
+    /// Account recovery link
+    #[must_use]
+    pub fn account_recovery_link(&self, ticket: String) -> Url {
+        self.absolute_url_for(&crate::endpoints::AccountRecoveryFinish::new(ticket))
+    }
 }
 
 #[cfg(test)]

--- a/crates/storage-pg/.sqlx/query-1764715e59f879f6b917ca30f8e3c1de5910c7a46e7fe52d1fb3bfd5561ac320.json
+++ b/crates/storage-pg/.sqlx/query-1764715e59f879f6b917ca30f8e3c1de5910c7a46e7fe52d1fb3bfd5561ac320.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                UPDATE user_recovery_sessions\n                SET consumed_at = $1\n                WHERE user_recovery_session_id = $2\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Timestamptz",
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "1764715e59f879f6b917ca30f8e3c1de5910c7a46e7fe52d1fb3bfd5561ac320"
+}

--- a/crates/storage-pg/.sqlx/query-607262ccf28b672df51e4e5d371e5cc5119a7d6e7fe784112703c0406f28300f.json
+++ b/crates/storage-pg/.sqlx/query-607262ccf28b672df51e4e5d371e5cc5119a7d6e7fe784112703c0406f28300f.json
@@ -1,0 +1,52 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                SELECT\n                      user_recovery_ticket_id\n                    , user_recovery_session_id\n                    , user_email_id\n                    , ticket\n                    , created_at\n                    , expires_at\n                FROM user_recovery_tickets\n                WHERE ticket = $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "user_recovery_ticket_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "user_recovery_session_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "user_email_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 3,
+        "name": "ticket",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 5,
+        "name": "expires_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "607262ccf28b672df51e4e5d371e5cc5119a7d6e7fe784112703c0406f28300f"
+}

--- a/crates/storage-pg/.sqlx/query-8275a440640ea28fd8f82e7df672e45a6eba981a0d621665ed8f8b60354b3389.json
+++ b/crates/storage-pg/.sqlx/query-8275a440640ea28fd8f82e7df672e45a6eba981a0d621665ed8f8b60354b3389.json
@@ -1,0 +1,19 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                INSERT INTO user_recovery_sessions (\n                      user_recovery_session_id\n                    , email\n                    , user_agent\n                    , ip_address\n                    , locale\n                    , created_at\n                )\n                VALUES ($1, $2, $3, $4, $5, $6)\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Text",
+        "Inet",
+        "Text",
+        "Timestamptz"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "8275a440640ea28fd8f82e7df672e45a6eba981a0d621665ed8f8b60354b3389"
+}

--- a/crates/storage-pg/.sqlx/query-d7a0e4fa2f168976505405c7e7800847f3379f7b57c0972659a35bfb68b0f6cd.json
+++ b/crates/storage-pg/.sqlx/query-d7a0e4fa2f168976505405c7e7800847f3379f7b57c0972659a35bfb68b0f6cd.json
@@ -1,0 +1,19 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                INSERT INTO user_recovery_tickets (\n                      user_recovery_ticket_id\n                    , user_recovery_session_id\n                    , user_email_id\n                    , ticket\n                    , created_at\n                    , expires_at\n                )\n                VALUES ($1, $2, $3, $4, $5, $6)\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid",
+        "Uuid",
+        "Text",
+        "Timestamptz",
+        "Timestamptz"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "d7a0e4fa2f168976505405c7e7800847f3379f7b57c0972659a35bfb68b0f6cd"
+}

--- a/crates/storage-pg/.sqlx/query-f46e87bbb149b35e1d13b2b3cd2bdeab3c28a56a395f52f001a7bb013a5dfece.json
+++ b/crates/storage-pg/.sqlx/query-f46e87bbb149b35e1d13b2b3cd2bdeab3c28a56a395f52f001a7bb013a5dfece.json
@@ -1,0 +1,58 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                SELECT\n                      user_recovery_session_id\n                    , email\n                    , user_agent\n                    , ip_address as \"ip_address: IpAddr\"\n                    , locale\n                    , created_at\n                    , consumed_at\n                FROM user_recovery_sessions\n                WHERE user_recovery_session_id = $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "user_recovery_session_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "email",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "user_agent",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "ip_address: IpAddr",
+        "type_info": "Inet"
+      },
+      {
+        "ordinal": 4,
+        "name": "locale",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 6,
+        "name": "consumed_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      false,
+      false,
+      true
+    ]
+  },
+  "hash": "f46e87bbb149b35e1d13b2b3cd2bdeab3c28a56a395f52f001a7bb013a5dfece"
+}

--- a/crates/storage-pg/migrations/20240621080509_user_recovery.sql
+++ b/crates/storage-pg/migrations/20240621080509_user_recovery.sql
@@ -1,0 +1,64 @@
+-- Copyright 2024 The Matrix.org Foundation C.I.C.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- Stores user recovery sessions for when the user lost their credentials.
+CREATE TABLE "user_recovery_sessions" (
+  "user_recovery_session_id" UUID NOT NULL
+    CONSTRAINT "user_recovery_sessions_pkey"
+    PRIMARY KEY,
+
+  -- The email address for which the recovery session was requested
+  "email" TEXT NOT NULL,
+
+  -- The user agent of the client that requested the recovery session
+  "user_agent" TEXT NOT NULL,
+
+  -- The IP address of the client that requested the recovery session
+  "ip_address" INET,
+
+  -- The language of the client that requested the recovery session
+  "locale" TEXT NOT NULL,
+
+  -- When the recovery session was created
+  "created_at" TIMESTAMP WITH TIME ZONE NOT NULL,
+
+  -- When the recovery session was consumed
+  "consumed_at" TIMESTAMP WITH TIME ZONE
+);
+
+-- Stores the recovery tickets for a user recovery session.
+CREATE TABLE "user_recovery_tickets" (
+  "user_recovery_ticket_id" UUID NOT NULL
+    CONSTRAINT "user_recovery_tickets_pkey"
+    PRIMARY KEY,
+
+  -- The recovery session this ticket belongs to
+  "user_recovery_session_id" UUID NOT NULL
+    REFERENCES "user_recovery_sessions" ("user_recovery_session_id")
+    ON DELETE CASCADE,
+
+  -- The user_email for which the recovery ticket was generated
+  "user_email_id" UUID NOT NULL
+    REFERENCES "user_emails" ("user_email_id")
+    ON DELETE CASCADE,
+
+  -- The recovery ticket
+  "ticket" TEXT NOT NULL,
+
+  -- When the recovery ticket was created
+  "created_at" TIMESTAMP WITH TIME ZONE NOT NULL,
+
+  -- When the recovery ticket expires
+  "expires_at" TIMESTAMP WITH TIME ZONE NOT NULL
+);

--- a/crates/storage-pg/src/repository.rs
+++ b/crates/storage-pg/src/repository.rs
@@ -1,4 +1,4 @@
-// Copyright 2022, 2023 The Matrix.org Foundation C.I.C.
+// Copyright 2022-2024 The Matrix.org Foundation C.I.C.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -54,7 +54,7 @@ use crate::{
     },
     user::{
         PgBrowserSessionRepository, PgUserEmailRepository, PgUserPasswordRepository,
-        PgUserRepository, PgUserTermsRepository,
+        PgUserRecoveryRepository, PgUserRepository, PgUserTermsRepository,
     },
     DatabaseError,
 };
@@ -177,6 +177,12 @@ where
         &'c mut self,
     ) -> Box<dyn UserPasswordRepository<Error = Self::Error> + 'c> {
         Box::new(PgUserPasswordRepository::new(self.conn.as_mut()))
+    }
+
+    fn user_recovery<'c>(
+        &'c mut self,
+    ) -> Box<dyn mas_storage::user::UserRecoveryRepository<Error = Self::Error> + 'c> {
+        Box::new(PgUserRecoveryRepository::new(self.conn.as_mut()))
     }
 
     fn user_terms<'c>(

--- a/crates/storage-pg/src/user/email.rs
+++ b/crates/storage-pg/src/user/email.rs
@@ -1,4 +1,4 @@
-// Copyright 2022, 2023 The Matrix.org Foundation C.I.C.
+// Copyright 2022-2024 The Matrix.org Foundation C.I.C.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -270,6 +270,11 @@ impl<'c> UserEmailRepository for PgUserEmailRepository<'c> {
             .and_where_option(filter.user().map(|user| {
                 Expr::col((UserEmails::Table, UserEmails::UserId)).eq(Uuid::from(user.id))
             }))
+            .and_where_option(
+                filter
+                    .email()
+                    .map(|email| Expr::col((UserEmails::Table, UserEmails::Email)).eq(email)),
+            )
             .and_where_option(filter.state().map(|state| {
                 if state.is_verified() {
                     Expr::col((UserEmails::Table, UserEmails::ConfirmedAt)).is_not_null()
@@ -305,6 +310,11 @@ impl<'c> UserEmailRepository for PgUserEmailRepository<'c> {
             .and_where_option(filter.user().map(|user| {
                 Expr::col((UserEmails::Table, UserEmails::UserId)).eq(Uuid::from(user.id))
             }))
+            .and_where_option(
+                filter
+                    .email()
+                    .map(|email| Expr::col((UserEmails::Table, UserEmails::Email)).eq(email)),
+            )
             .and_where_option(filter.state().map(|state| {
                 if state.is_verified() {
                     Expr::col((UserEmails::Table, UserEmails::ConfirmedAt)).is_not_null()

--- a/crates/storage-pg/src/user/mod.rs
+++ b/crates/storage-pg/src/user/mod.rs
@@ -28,6 +28,7 @@ use crate::{tracing::ExecuteExt, DatabaseError};
 
 mod email;
 mod password;
+mod recovery;
 mod session;
 mod terms;
 
@@ -36,7 +37,8 @@ mod tests;
 
 pub use self::{
     email::PgUserEmailRepository, password::PgUserPasswordRepository,
-    session::PgBrowserSessionRepository, terms::PgUserTermsRepository,
+    recovery::PgUserRecoveryRepository, session::PgBrowserSessionRepository,
+    terms::PgUserTermsRepository,
 };
 
 /// An implementation of [`UserRepository`] for a PostgreSQL connection

--- a/crates/storage-pg/src/user/recovery.rs
+++ b/crates/storage-pg/src/user/recovery.rs
@@ -1,0 +1,337 @@
+// Copyright 2024 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::net::IpAddr;
+
+use async_trait::async_trait;
+use chrono::{DateTime, Duration, Utc};
+use mas_data_model::{UserAgent, UserEmail, UserRecoverySession, UserRecoveryTicket};
+use mas_storage::{user::UserRecoveryRepository, Clock};
+use rand::RngCore;
+use sqlx::PgConnection;
+use ulid::Ulid;
+use uuid::Uuid;
+
+use crate::{DatabaseError, ExecuteExt};
+
+/// An implementation of [`UserRecoveryRepository`] for a PostgreSQL connection
+pub struct PgUserRecoveryRepository<'c> {
+    conn: &'c mut PgConnection,
+}
+
+impl<'c> PgUserRecoveryRepository<'c> {
+    /// Create a new [`PgUserRecoveryRepository`] from an active PostgreSQL
+    /// connection
+    pub fn new(conn: &'c mut PgConnection) -> Self {
+        Self { conn }
+    }
+}
+
+struct UserRecoverySessionRow {
+    user_recovery_session_id: Uuid,
+    email: String,
+    user_agent: String,
+    ip_address: Option<IpAddr>,
+    locale: String,
+    created_at: DateTime<Utc>,
+    consumed_at: Option<DateTime<Utc>>,
+}
+
+impl From<UserRecoverySessionRow> for UserRecoverySession {
+    fn from(row: UserRecoverySessionRow) -> Self {
+        UserRecoverySession {
+            id: row.user_recovery_session_id.into(),
+            email: row.email,
+            user_agent: UserAgent::parse(row.user_agent),
+            ip_address: row.ip_address,
+            locale: row.locale,
+            created_at: row.created_at,
+            consumed_at: row.consumed_at,
+        }
+    }
+}
+
+struct UserRecoveryTicketRow {
+    user_recovery_ticket_id: Uuid,
+    user_recovery_session_id: Uuid,
+    user_email_id: Uuid,
+    ticket: String,
+    created_at: DateTime<Utc>,
+    expires_at: DateTime<Utc>,
+}
+
+impl From<UserRecoveryTicketRow> for UserRecoveryTicket {
+    fn from(row: UserRecoveryTicketRow) -> Self {
+        Self {
+            id: row.user_recovery_ticket_id.into(),
+            user_recovery_session_id: row.user_recovery_session_id.into(),
+            user_email_id: row.user_email_id.into(),
+            ticket: row.ticket,
+            created_at: row.created_at,
+            expires_at: row.expires_at,
+        }
+    }
+}
+
+#[async_trait]
+impl<'c> UserRecoveryRepository for PgUserRecoveryRepository<'c> {
+    type Error = DatabaseError;
+
+    #[tracing::instrument(
+        name = "db.user_recovery.lookup_session",
+        skip_all,
+        fields(
+            db.statement,
+            user_recovery_session.id = %id,
+        ),
+        err,
+    )]
+    async fn lookup_session(
+        &mut self,
+        id: Ulid,
+    ) -> Result<Option<UserRecoverySession>, Self::Error> {
+        let row = sqlx::query_as!(
+            UserRecoverySessionRow,
+            r#"
+                SELECT
+                      user_recovery_session_id
+                    , email
+                    , user_agent
+                    , ip_address as "ip_address: IpAddr"
+                    , locale
+                    , created_at
+                    , consumed_at
+                FROM user_recovery_sessions
+                WHERE user_recovery_session_id = $1
+            "#,
+            Uuid::from(id),
+        )
+        .traced()
+        .fetch_optional(&mut *self.conn)
+        .await?;
+
+        let Some(row) = row else {
+            return Ok(None);
+        };
+
+        Ok(Some(row.into()))
+    }
+
+    #[tracing::instrument(
+        name = "db.user_recovery.add_session",
+        skip_all,
+        fields(
+            db.statement,
+            user_recovery_session.id,
+            user_recovery_session.email = email,
+            user_recovery_session.user_agent = &*user_agent,
+            user_recovery_session.ip_address = ip_address.map(|ip| ip.to_string()),
+        )
+    )]
+    async fn add_session(
+        &mut self,
+        rng: &mut (dyn RngCore + Send),
+        clock: &dyn Clock,
+        email: String,
+        user_agent: UserAgent,
+        ip_address: Option<IpAddr>,
+        locale: String,
+    ) -> Result<UserRecoverySession, Self::Error> {
+        let created_at = clock.now();
+        let id = Ulid::from_datetime_with_source(created_at.into(), rng);
+        tracing::Span::current().record("user_recovery_session.id", tracing::field::display(id));
+        sqlx::query!(
+            r#"
+                INSERT INTO user_recovery_sessions (
+                      user_recovery_session_id
+                    , email
+                    , user_agent
+                    , ip_address
+                    , locale
+                    , created_at
+                )
+                VALUES ($1, $2, $3, $4, $5, $6)
+            "#,
+            Uuid::from(id),
+            &email,
+            &*user_agent,
+            ip_address as Option<IpAddr>,
+            &locale,
+            created_at,
+        )
+        .traced()
+        .execute(&mut *self.conn)
+        .await?;
+
+        let user_recovery_session = UserRecoverySession {
+            id,
+            email,
+            user_agent,
+            ip_address,
+            locale,
+            created_at,
+            consumed_at: None,
+        };
+
+        Ok(user_recovery_session)
+    }
+
+    #[tracing::instrument(
+        name = "db.user_recovery.find_ticket",
+        skip_all,
+        fields(
+            db.statement,
+            user_recovery_ticket.id = ticket,
+        ),
+        err,
+    )]
+    async fn find_ticket(
+        &mut self,
+        ticket: &str,
+    ) -> Result<Option<UserRecoveryTicket>, Self::Error> {
+        let row = sqlx::query_as!(
+            UserRecoveryTicketRow,
+            r#"
+                SELECT
+                      user_recovery_ticket_id
+                    , user_recovery_session_id
+                    , user_email_id
+                    , ticket
+                    , created_at
+                    , expires_at
+                FROM user_recovery_tickets
+                WHERE ticket = $1
+            "#,
+            ticket,
+        )
+        .traced()
+        .fetch_optional(&mut *self.conn)
+        .await?;
+
+        let Some(row) = row else {
+            return Ok(None);
+        };
+
+        Ok(Some(row.into()))
+    }
+
+    #[tracing::instrument(
+        name = "db.user_recovery.add_ticket",
+        skip_all,
+        fields(
+            db.statement,
+            user_recovery_ticket.id,
+            user_recovery_ticket.id = ticket,
+            %user_recovery_session.id,
+            %user_email.id,
+        )
+    )]
+    async fn add_ticket(
+        &mut self,
+        rng: &mut (dyn RngCore + Send),
+        clock: &dyn Clock,
+        user_recovery_session: &UserRecoverySession,
+        user_email: &UserEmail,
+        ticket: String,
+    ) -> Result<UserRecoveryTicket, Self::Error> {
+        let created_at = clock.now();
+        let id = Ulid::from_datetime_with_source(created_at.into(), rng);
+        tracing::Span::current().record("user_recovery_ticket.id", tracing::field::display(id));
+
+        // TODO: move that to a parameter
+        let expires_at = created_at + Duration::minutes(10);
+
+        sqlx::query!(
+            r#"
+                INSERT INTO user_recovery_tickets (
+                      user_recovery_ticket_id
+                    , user_recovery_session_id
+                    , user_email_id
+                    , ticket
+                    , created_at
+                    , expires_at
+                )
+                VALUES ($1, $2, $3, $4, $5, $6)
+            "#,
+            Uuid::from(id),
+            Uuid::from(user_recovery_session.id),
+            Uuid::from(user_email.id),
+            &ticket,
+            created_at,
+            expires_at,
+        )
+        .traced()
+        .execute(&mut *self.conn)
+        .await?;
+
+        let ticket = UserRecoveryTicket {
+            id,
+            user_recovery_session_id: user_recovery_session.id,
+            user_email_id: user_email.id,
+            ticket,
+            created_at,
+            expires_at,
+        };
+
+        Ok(ticket)
+    }
+
+    #[tracing::instrument(
+        name = "db.user_recovery.consume_ticket",
+        skip_all,
+        fields(
+            db.statement,
+            %user_recovery_ticket.id,
+            user_email.id = %user_recovery_ticket.user_email_id,
+            %user_recovery_session.id,
+            %user_recovery_session.email,
+        ),
+        err,
+    )]
+    async fn consume_ticket(
+        &mut self,
+        clock: &dyn Clock,
+        user_recovery_ticket: UserRecoveryTicket,
+        mut user_recovery_session: UserRecoverySession,
+    ) -> Result<UserRecoverySession, Self::Error> {
+        // We don't really use the ticket, we just want to make sure we drop it
+        let _ = user_recovery_ticket;
+
+        // This should have been checked by the caller
+        if user_recovery_session.consumed_at.is_some() {
+            return Err(DatabaseError::invalid_operation());
+        }
+
+        let consumed_at = clock.now();
+
+        let res = sqlx::query!(
+            r#"
+                UPDATE user_recovery_sessions
+                SET consumed_at = $1
+                WHERE user_recovery_session_id = $2
+            "#,
+            consumed_at,
+            Uuid::from(user_recovery_session.id),
+        )
+        .traced()
+        .execute(&mut *self.conn)
+        .await?;
+
+        user_recovery_session.consumed_at = Some(consumed_at);
+
+        DatabaseError::ensure_affected_rows(&res, 1)?;
+
+        Ok(user_recovery_session)
+    }
+}

--- a/crates/storage/src/job.rs
+++ b/crates/storage/src/job.rs
@@ -446,6 +446,7 @@ mod jobs {
         ///
         /// * `user_recovery_session` - The user recovery session to send the
         ///   email for
+        /// * `language` - The locale to send the email in
         #[must_use]
         pub fn new(user_recovery_session: &UserRecoverySession) -> Self {
             Self {

--- a/crates/storage/src/job.rs
+++ b/crates/storage/src/job.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 The Matrix.org Foundation C.I.C.
+// Copyright 2023, 2024 The Matrix.org Foundation C.I.C.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -231,7 +231,7 @@ where
 mod jobs {
     // XXX: Move this somewhere else?
     use apalis_core::job::Job;
-    use mas_data_model::{Device, User, UserEmail};
+    use mas_data_model::{Device, User, UserEmail, UserRecoverySession};
     use serde::{Deserialize, Serialize};
     use ulid::Ulid;
 
@@ -432,8 +432,40 @@ mod jobs {
     impl Job for DeactivateUserJob {
         const NAME: &'static str = "deactivate-user";
     }
+
+    /// Send account recovery emails
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct SendAccountRecoveryEmailsJob {
+        user_recovery_session_id: Ulid,
+    }
+
+    impl SendAccountRecoveryEmailsJob {
+        /// Create a new job to send account recovery emails
+        ///
+        /// # Parameters
+        ///
+        /// * `user_recovery_session` - The user recovery session to send the
+        ///   email for
+        #[must_use]
+        pub fn new(user_recovery_session: &UserRecoverySession) -> Self {
+            Self {
+                user_recovery_session_id: user_recovery_session.id,
+            }
+        }
+
+        /// The ID of the user recovery session to send the email for
+        #[must_use]
+        pub fn user_recovery_session_id(&self) -> Ulid {
+            self.user_recovery_session_id
+        }
+    }
+
+    impl Job for SendAccountRecoveryEmailsJob {
+        const NAME: &'static str = "send-account-recovery-email";
+    }
 }
 
 pub use self::jobs::{
-    DeactivateUserJob, DeleteDeviceJob, ProvisionDeviceJob, ProvisionUserJob, VerifyEmailJob,
+    DeactivateUserJob, DeleteDeviceJob, ProvisionDeviceJob, ProvisionUserJob,
+    SendAccountRecoveryEmailsJob, VerifyEmailJob,
 };

--- a/crates/storage/src/repository.rs
+++ b/crates/storage/src/repository.rs
@@ -31,8 +31,8 @@ use crate::{
         UpstreamOAuthSessionRepository,
     },
     user::{
-        BrowserSessionRepository, UserEmailRepository, UserPasswordRepository, UserRepository,
-        UserTermsRepository,
+        BrowserSessionRepository, UserEmailRepository, UserPasswordRepository,
+        UserRecoveryRepository, UserRepository, UserTermsRepository,
     },
     MapErr,
 };
@@ -148,6 +148,10 @@ pub trait RepositoryAccess: Send {
     /// Get an [`UserPasswordRepository`]
     fn user_password<'c>(&'c mut self)
         -> Box<dyn UserPasswordRepository<Error = Self::Error> + 'c>;
+
+    /// Get an [`UserRecoveryRepository`]
+    fn user_recovery<'c>(&'c mut self)
+        -> Box<dyn UserRecoveryRepository<Error = Self::Error> + 'c>;
 
     /// Get an [`UserTermsRepository`]
     fn user_terms<'c>(&'c mut self) -> Box<dyn UserTermsRepository<Error = Self::Error> + 'c>;
@@ -322,6 +326,12 @@ mod impls {
             Box::new(MapErr::new(self.inner.user_password(), &mut self.mapper))
         }
 
+        fn user_recovery<'c>(
+            &'c mut self,
+        ) -> Box<dyn crate::user::UserRecoveryRepository<Error = Self::Error> + 'c> {
+            Box::new(MapErr::new(self.inner.user_recovery(), &mut self.mapper))
+        }
+
         fn user_terms<'c>(&'c mut self) -> Box<dyn UserTermsRepository<Error = Self::Error> + 'c> {
             Box::new(MapErr::new(self.inner.user_terms(), &mut self.mapper))
         }
@@ -454,6 +464,12 @@ mod impls {
             &'c mut self,
         ) -> Box<dyn UserPasswordRepository<Error = Self::Error> + 'c> {
             (**self).user_password()
+        }
+
+        fn user_recovery<'c>(
+            &'c mut self,
+        ) -> Box<dyn crate::user::UserRecoveryRepository<Error = Self::Error> + 'c> {
+            (**self).user_recovery()
         }
 
         fn user_terms<'c>(&'c mut self) -> Box<dyn UserTermsRepository<Error = Self::Error> + 'c> {

--- a/crates/storage/src/user/email.rs
+++ b/crates/storage/src/user/email.rs
@@ -41,6 +41,7 @@ impl UserEmailState {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
 pub struct UserEmailFilter<'a> {
     user: Option<&'a User>,
+    email: Option<&'a str>,
     state: Option<UserEmailState>,
 }
 
@@ -58,12 +59,27 @@ impl<'a> UserEmailFilter<'a> {
         self
     }
 
+    /// Filter for emails matching a specific email address
+    #[must_use]
+    pub fn for_email(mut self, email: &'a str) -> Self {
+        self.email = Some(email);
+        self
+    }
+
     /// Get the user filter
     ///
     /// Returns [`None`] if no user filter is set
     #[must_use]
     pub fn user(&self) -> Option<&User> {
         self.user
+    }
+
+    /// Get the email filter
+    ///
+    /// Returns [`None`] if no email filter is set
+    #[must_use]
+    pub fn email(&self) -> Option<&str> {
+        self.email
     }
 
     /// Filter for emails that are verified

--- a/crates/storage/src/user/mod.rs
+++ b/crates/storage/src/user/mod.rs
@@ -23,12 +23,14 @@ use crate::{repository_impl, Clock};
 
 mod email;
 mod password;
+mod recovery;
 mod session;
 mod terms;
 
 pub use self::{
     email::{UserEmailFilter, UserEmailRepository},
     password::UserPasswordRepository,
+    recovery::UserRecoveryRepository,
     session::{BrowserSessionFilter, BrowserSessionRepository},
     terms::UserTermsRepository,
 };

--- a/crates/storage/src/user/recovery.rs
+++ b/crates/storage/src/user/recovery.rs
@@ -1,0 +1,167 @@
+// Copyright 2024 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::net::IpAddr;
+
+use async_trait::async_trait;
+use mas_data_model::{UserAgent, UserEmail, UserRecoverySession, UserRecoveryTicket};
+use rand_core::RngCore;
+use ulid::Ulid;
+
+use crate::{repository_impl, Clock};
+
+/// A [`UserRecoveryRepository`] helps interacting with [`UserRecoverySession`]
+/// and [`UserRecoveryTicket`] saved in the storage backend
+#[async_trait]
+pub trait UserRecoveryRepository: Send + Sync {
+    /// The error type returned by the repository
+    type Error;
+
+    /// Lookup an [`UserRecoverySession`] by its ID
+    ///
+    /// Returns `None` if no [`UserRecoverySession`] was found
+    ///
+    /// # Parameters
+    ///
+    /// * `id`: The ID of the [`UserRecoverySession`] to lookup
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Self::Error`] if the underlying repository fails
+    async fn lookup_session(
+        &mut self,
+        id: Ulid,
+    ) -> Result<Option<UserRecoverySession>, Self::Error>;
+
+    /// Create a new [`UserRecoverySession`] for the given email
+    ///
+    /// Returns the newly created [`UserRecoverySession`]
+    ///
+    /// # Parameters
+    ///
+    /// * `rng`: The random number generator to use
+    /// * `clock`: The clock to use
+    /// * `email`: The email to create the session for
+    /// * `user_agent`: The user agent of the browser which initiated the
+    ///   session
+    /// * `ip_address`: The IP address of the browser which initiated the
+    ///   session, if known
+    /// * `locale`: The locale of the browser which initiated the session
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Self::Error`] if the underlying repository fails
+    async fn add_session(
+        &mut self,
+        rng: &mut (dyn RngCore + Send),
+        clock: &dyn Clock,
+        email: String,
+        user_agent: UserAgent,
+        ip_address: Option<IpAddr>,
+        locale: String,
+    ) -> Result<UserRecoverySession, Self::Error>;
+
+    /// Find a [`UserRecoveryTicket`] by its ticket
+    ///
+    /// Returns `None` if no [`UserRecoveryTicket`] was found
+    ///
+    /// # Parameters
+    ///
+    /// * `ticket`: The ticket of the [`UserRecoveryTicket`] to lookup
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Self::Error`] if the underlying repository fails
+    async fn find_ticket(
+        &mut self,
+        ticket: &str,
+    ) -> Result<Option<UserRecoveryTicket>, Self::Error>;
+
+    /// Add a [`UserRecoveryTicket`] to the given [`UserRecoverySession`] for
+    /// the given [`UserEmail`]
+    ///
+    /// # Parameters
+    ///
+    /// * `rng`: The random number generator to use
+    /// * `clock`: The clock to use
+    /// * `session`: The [`UserRecoverySession`] to add the ticket to
+    /// * `user_email`: The [`UserEmail`] to add the ticket for
+    /// * `ticket`: The ticket to add
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Self::Error`] if the underlying repository fails
+    async fn add_ticket(
+        &mut self,
+        rng: &mut (dyn RngCore + Send),
+        clock: &dyn Clock,
+        user_recovery_session: &UserRecoverySession,
+        user_email: &UserEmail,
+        ticket: String,
+    ) -> Result<UserRecoveryTicket, Self::Error>;
+
+    /// Consume a [`UserRecoveryTicket`] and mark the session as used
+    ///
+    /// # Parameters
+    ///
+    /// * `clock`: The clock to use to record the time of consumption
+    /// * `ticket`: The [`UserRecoveryTicket`] to consume
+    /// * `session`: The [`UserRecoverySession`] to mark as used
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Self::Error`] if the underlying repository fails or if the
+    /// recovery session was already used
+    async fn consume_ticket(
+        &mut self,
+        clock: &dyn Clock,
+        user_recovery_ticket: UserRecoveryTicket,
+        user_recovery_session: UserRecoverySession,
+    ) -> Result<UserRecoverySession, Self::Error>;
+}
+
+repository_impl!(UserRecoveryRepository:
+    async fn lookup_session(&mut self, id: Ulid) -> Result<Option<UserRecoverySession>, Self::Error>;
+
+    async fn add_session(
+        &mut self,
+        rng: &mut (dyn RngCore + Send),
+        clock: &dyn Clock,
+        email: String,
+        user_agent: UserAgent,
+        ip_address: Option<IpAddr>,
+        locale: String,
+    ) -> Result<UserRecoverySession, Self::Error>;
+
+    async fn find_ticket(
+        &mut self,
+        ticket: &str,
+    ) -> Result<Option<UserRecoveryTicket>, Self::Error>;
+
+    async fn add_ticket(
+        &mut self,
+        rng: &mut (dyn RngCore + Send),
+        clock: &dyn Clock,
+        user_recovery_session: &UserRecoverySession,
+        user_email: &UserEmail,
+        ticket: String,
+    ) -> Result<UserRecoveryTicket, Self::Error>;
+
+    async fn consume_ticket(
+        &mut self,
+        clock: &dyn Clock,
+        user_recovery_ticket: UserRecoveryTicket,
+        user_recovery_session: UserRecoverySession,
+    ) -> Result<UserRecoverySession, Self::Error>;
+);

--- a/crates/tasks/Cargo.toml
+++ b/crates/tasks/Cargo.toml
@@ -38,6 +38,7 @@ mas-data-model.workspace = true
 mas-email.workspace = true
 mas-i18n.workspace = true
 mas-matrix.workspace = true
+mas-router.workspace = true
 mas-storage.workspace = true
 mas-storage-pg.workspace = true
 mas-templates.workspace = true

--- a/crates/tasks/src/lib.rs
+++ b/crates/tasks/src/lib.rs
@@ -28,6 +28,7 @@ use crate::storage::PostgresStorageFactory;
 mod database;
 mod email;
 mod matrix;
+mod recovery;
 mod storage;
 mod user;
 mod utils;
@@ -152,6 +153,7 @@ pub async fn init(
     let monitor = self::email::register(name, monitor, &state, &factory);
     let monitor = self::matrix::register(name, monitor, &state, &factory);
     let monitor = self::user::register(name, monitor, &state, &factory);
+    let monitor = self::recovery::register(name, monitor, &state, &factory);
     // TODO: we might want to grab the join handle here
     factory.listen().await?;
     debug!(?monitor, "workers registered");

--- a/crates/tasks/src/recovery.rs
+++ b/crates/tasks/src/recovery.rs
@@ -1,0 +1,105 @@
+// Copyright 2024 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use anyhow::Context;
+use apalis_core::{context::JobContext, executor::TokioExecutor, monitor::Monitor};
+use mas_storage::{
+    job::{JobWithSpanContext, SendAccountRecoveryEmailsJob},
+    user::{UserEmailFilter, UserRecoveryRepository},
+    Pagination, RepositoryAccess,
+};
+use rand::distributions::{Alphanumeric, DistString};
+use tracing::info;
+
+use crate::{storage::PostgresStorageFactory, JobContextExt, State};
+
+/// Job to send account recovery emails for a given recovery session.
+#[tracing::instrument(
+    name = "job.send_account_recovery_email",
+    fields(
+        user_recovery_session.id = %job.user_recovery_session_id(),
+        user_recovery_session.email,
+    ),
+    skip_all,
+    err(Debug),
+)]
+async fn send_account_recovery_email_job(
+    job: JobWithSpanContext<SendAccountRecoveryEmailsJob>,
+    ctx: JobContext,
+) -> Result<(), anyhow::Error> {
+    let state = ctx.state();
+    let clock = state.clock();
+    let mut rng = state.rng();
+    let mut repo = state.repository().await?;
+
+    let session = repo
+        .user_recovery()
+        .lookup_session(job.user_recovery_session_id())
+        .await?
+        .context("User recovery session not found")?;
+
+    tracing::Span::current().record("user_recovery_session.email", &session.email);
+
+    if session.consumed_at.is_some() {
+        info!("Recovery session already consumed, not sending email");
+        return Ok(());
+    }
+
+    let mut cursor = Pagination::first(50);
+
+    loop {
+        let page = repo
+            .user_email()
+            .list(
+                UserEmailFilter::new()
+                    .for_email(&session.email)
+                    .verified_only(),
+                cursor,
+            )
+            .await?;
+
+        for email in page.edges {
+            let ticket = Alphanumeric.sample_string(&mut rng, 32);
+
+            let _ticket = repo
+                .user_recovery()
+                .add_ticket(&mut rng, &clock, &session, &email, ticket)
+                .await?;
+
+            info!("Sending recovery email to {}", email.email);
+            // TODO
+
+            cursor = cursor.after(email.id);
+        }
+
+        if !page.has_next_page {
+            break;
+        }
+    }
+
+    repo.save().await?;
+
+    Ok(())
+}
+
+pub(crate) fn register(
+    suffix: &str,
+    monitor: Monitor<TokioExecutor>,
+    state: &State,
+    storage_factory: &PostgresStorageFactory,
+) -> Monitor<TokioExecutor> {
+    let send_user_recovery_email_worker = crate::build!(SendAccountRecoveryEmailsJob => send_account_recovery_email_job, suffix, state, storage_factory);
+
+    monitor.register(send_user_recovery_email_worker)
+}

--- a/crates/templates/src/context.rs
+++ b/crates/templates/src/context.rs
@@ -913,6 +913,61 @@ impl TemplateContext for EmailAddContext {
     }
 }
 
+/// Fields of the account recovery start form
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, Hash, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum RecoveryStartFormField {
+    /// The email
+    Email,
+}
+
+impl FormField for RecoveryStartFormField {
+    fn keep(&self) -> bool {
+        match self {
+            Self::Email => true,
+        }
+    }
+}
+
+/// Context used by the `pages/recovery/start.html` template
+#[derive(Serialize, Default)]
+pub struct RecoveryStartContext {
+    form: FormState<RecoveryStartFormField>,
+}
+
+impl RecoveryStartContext {
+    /// Constructs a context for the recovery start page
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set the form state
+    #[must_use]
+    pub fn with_form_state(self, form: FormState<RecoveryStartFormField>) -> Self {
+        Self { form }
+    }
+}
+
+impl TemplateContext for RecoveryStartContext {
+    fn sample(_now: chrono::DateTime<Utc>, _rng: &mut impl Rng) -> Vec<Self>
+    where
+        Self: Sized,
+    {
+        vec![
+            Self::new(),
+            Self::new().with_form_state(
+                FormState::default()
+                    .with_error_on_field(RecoveryStartFormField::Email, FieldError::Required),
+            ),
+            Self::new().with_form_state(
+                FormState::default()
+                    .with_error_on_field(RecoveryStartFormField::Email, FieldError::Invalid),
+            ),
+        ]
+    }
+}
+
 /// Context used by the `pages/upstream_oauth2/{link_mismatch,do_login}.html`
 /// templates
 #[derive(Serialize)]

--- a/crates/templates/src/context.rs
+++ b/crates/templates/src/context.rs
@@ -1056,6 +1056,39 @@ impl TemplateContext for RecoveryProgressContext {
     }
 }
 
+/// Context used by the `pages/recovery/expired.html` template
+#[derive(Serialize)]
+pub struct RecoveryExpiredContext {
+    session: UserRecoverySession,
+}
+
+impl RecoveryExpiredContext {
+    /// Constructs a context for the recovery expired page
+    #[must_use]
+    pub fn new(session: UserRecoverySession) -> Self {
+        Self { session }
+    }
+}
+
+impl TemplateContext for RecoveryExpiredContext {
+    fn sample(now: chrono::DateTime<Utc>, rng: &mut impl Rng) -> Vec<Self>
+    where
+        Self: Sized,
+    {
+        let session = UserRecoverySession {
+            id: Ulid::from_datetime_with_source(now.into(), rng),
+            email: "name@mail.com".to_owned(),
+            user_agent: UserAgent::parse("Mozilla/5.0".to_owned()),
+            ip_address: None,
+            locale: "en".to_owned(),
+            created_at: now,
+            consumed_at: None,
+        };
+
+        vec![Self { session }]
+    }
+}
+
 /// Fields of the account recovery finish form
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, Hash, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]

--- a/crates/templates/src/context.rs
+++ b/crates/templates/src/context.rs
@@ -1023,6 +1023,39 @@ impl TemplateContext for RecoveryStartContext {
     }
 }
 
+/// Context used by the `pages/recovery/progress.html` template
+#[derive(Serialize)]
+pub struct RecoveryProgressContext {
+    session: UserRecoverySession,
+}
+
+impl RecoveryProgressContext {
+    /// Constructs a context for the recovery progress page
+    #[must_use]
+    pub fn new(session: UserRecoverySession) -> Self {
+        Self { session }
+    }
+}
+
+impl TemplateContext for RecoveryProgressContext {
+    fn sample(now: chrono::DateTime<Utc>, rng: &mut impl Rng) -> Vec<Self>
+    where
+        Self: Sized,
+    {
+        let session = UserRecoverySession {
+            id: Ulid::from_datetime_with_source(now.into(), rng),
+            email: "name@mail.com".to_owned(),
+            user_agent: UserAgent::parse("Mozilla/5.0".to_owned()),
+            ip_address: None,
+            locale: "en".to_owned(),
+            created_at: now,
+            consumed_at: None,
+        };
+
+        vec![Self { session }]
+    }
+}
+
 /// Context used by the `pages/upstream_oauth2/{link_mismatch,do_login}.html`
 /// templates
 #[derive(Serialize)]

--- a/crates/templates/src/context.rs
+++ b/crates/templates/src/context.rs
@@ -1056,6 +1056,76 @@ impl TemplateContext for RecoveryProgressContext {
     }
 }
 
+/// Fields of the account recovery finish form
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, Hash, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum RecoveryFinishFormField {
+    /// The new password
+    NewPassword,
+
+    /// The new password confirmation
+    NewPasswordConfirm,
+}
+
+impl FormField for RecoveryFinishFormField {
+    fn keep(&self) -> bool {
+        false
+    }
+}
+
+/// Context used by the `pages/recovery/finish.html` template
+#[derive(Serialize)]
+pub struct RecoveryFinishContext {
+    user: User,
+    form: FormState<RecoveryFinishFormField>,
+}
+
+impl RecoveryFinishContext {
+    /// Constructs a context for the recovery finish page
+    #[must_use]
+    pub fn new(user: User) -> Self {
+        Self {
+            user,
+            form: FormState::default(),
+        }
+    }
+
+    /// Set the form state
+    #[must_use]
+    pub fn with_form_state(mut self, form: FormState<RecoveryFinishFormField>) -> Self {
+        self.form = form;
+        self
+    }
+}
+
+impl TemplateContext for RecoveryFinishContext {
+    fn sample(now: chrono::DateTime<Utc>, rng: &mut impl Rng) -> Vec<Self>
+    where
+        Self: Sized,
+    {
+        User::samples(now, rng)
+            .into_iter()
+            .flat_map(|user| {
+                vec![
+                    Self::new(user.clone()),
+                    Self::new(user.clone()).with_form_state(
+                        FormState::default().with_error_on_field(
+                            RecoveryFinishFormField::NewPassword,
+                            FieldError::Invalid,
+                        ),
+                    ),
+                    Self::new(user.clone()).with_form_state(
+                        FormState::default().with_error_on_field(
+                            RecoveryFinishFormField::NewPasswordConfirm,
+                            FieldError::Invalid,
+                        ),
+                    ),
+                ]
+            })
+            .collect()
+    }
+}
+
 /// Context used by the `pages/upstream_oauth2/{link_mismatch,do_login}.html`
 /// templates
 #[derive(Serialize)]

--- a/crates/templates/src/context/captcha.rs
+++ b/crates/templates/src/context/captcha.rs
@@ -56,7 +56,7 @@ pub struct WithCaptcha<T> {
 
 impl<T> WithCaptcha<T> {
     #[must_use]
-    pub fn new(captcha: Option<mas_data_model::CaptchaConfig>, inner: T) -> Self {
+    pub(crate) fn new(captcha: Option<mas_data_model::CaptchaConfig>, inner: T) -> Self {
         Self {
             captcha: captcha.map(|captcha| Value::from_object(CaptchaConfig(captcha))),
             inner,

--- a/crates/templates/src/context/ext.rs
+++ b/crates/templates/src/context/ext.rs
@@ -54,6 +54,7 @@ impl SiteConfigExt for SiteConfig {
         SiteFeatures {
             password_registration: self.password_registration_enabled,
             password_login: self.password_login_enabled,
+            account_recovery: self.account_recovery_allowed,
         }
     }
 }

--- a/crates/templates/src/context/features.rs
+++ b/crates/templates/src/context/features.rs
@@ -27,6 +27,9 @@ pub struct SiteFeatures {
 
     /// Whether local password-based login is enabled.
     pub password_login: bool,
+
+    /// Whether email-based account recovery is enabled.
+    pub account_recovery: bool,
 }
 
 impl Object for SiteFeatures {
@@ -34,11 +37,16 @@ impl Object for SiteFeatures {
         match field.as_str()? {
             "password_registration" => Some(Value::from(self.password_registration)),
             "password_login" => Some(Value::from(self.password_login)),
+            "account_recovery" => Some(Value::from(self.account_recovery)),
             _ => None,
         }
     }
 
     fn enumerate(self: &Arc<Self>) -> Enumerator {
-        Enumerator::Str(&["password_registration", "password_login"])
+        Enumerator::Str(&[
+            "password_registration",
+            "password_login",
+            "account_recovery",
+        ])
     }
 }

--- a/crates/templates/src/forms.rs
+++ b/crates/templates/src/forms.rs
@@ -36,6 +36,9 @@ pub enum FieldError {
     /// Invalid value for this field
     Invalid,
 
+    /// The password confirmation doesn't match the password
+    PasswordMismatch,
+
     /// That value already exists
     Exists,
 

--- a/crates/templates/src/lib.rs
+++ b/crates/templates/src/lib.rs
@@ -46,12 +46,12 @@ pub use self::{
         DeviceLinkFormField, EmailAddContext, EmailRecoveryContext, EmailVerificationContext,
         EmailVerificationPageContext, EmptyContext, ErrorContext, FormPostContext, IndexContext,
         LoginContext, LoginFormField, NotFoundContext, PolicyViolationContext, PostAuthContext,
-        PostAuthContextInner, ReauthContext, ReauthFormField, RecoveryFinishContext,
-        RecoveryFinishFormField, RecoveryProgressContext, RecoveryStartContext,
-        RecoveryStartFormField, RegisterContext, RegisterFormField, SiteBranding, SiteConfigExt,
-        SiteFeatures, TemplateContext, UpstreamExistingLinkContext, UpstreamRegister,
-        UpstreamRegisterFormField, UpstreamSuggestLink, WithCaptcha, WithCsrf, WithLanguage,
-        WithOptionalSession, WithSession,
+        PostAuthContextInner, ReauthContext, ReauthFormField, RecoveryExpiredContext,
+        RecoveryFinishContext, RecoveryFinishFormField, RecoveryProgressContext,
+        RecoveryStartContext, RecoveryStartFormField, RegisterContext, RegisterFormField,
+        SiteBranding, SiteConfigExt, SiteFeatures, TemplateContext, UpstreamExistingLinkContext,
+        UpstreamRegister, UpstreamRegisterFormField, UpstreamSuggestLink, WithCaptcha, WithCsrf,
+        WithLanguage, WithOptionalSession, WithSession,
     },
     forms::{FieldError, FormError, FormField, FormState, ToFormState},
 };
@@ -357,6 +357,9 @@ register_templates! {
     /// Render the account recovery finish page
     pub fn render_recovery_finish(WithLanguage<WithCsrf<RecoveryFinishContext>>) { "pages/recovery/finish.html" }
 
+    /// Render the account recovery link expired page
+    pub fn render_recovery_expired(WithLanguage<WithCsrf<RecoveryExpiredContext>>) { "pages/recovery/expired.html" }
+
     /// Render the account recovery disabled page
     pub fn render_recovery_disabled(WithLanguage<EmptyContext>) { "pages/recovery/disabled.html" }
 
@@ -428,6 +431,7 @@ impl Templates {
         check::render_recovery_start(self, now, rng)?;
         check::render_recovery_progress(self, now, rng)?;
         check::render_recovery_finish(self, now, rng)?;
+        check::render_recovery_expired(self, now, rng)?;
         check::render_recovery_disabled(self, now, rng)?;
         check::render_reauth(self, now, rng)?;
         check::render_form_post::<EmptyContext>(self, now, rng)?;

--- a/crates/templates/src/lib.rs
+++ b/crates/templates/src/lib.rs
@@ -360,6 +360,9 @@ register_templates! {
     /// Render the account recovery link expired page
     pub fn render_recovery_expired(WithLanguage<WithCsrf<RecoveryExpiredContext>>) { "pages/recovery/expired.html" }
 
+    /// Render the account recovery link consumed page
+    pub fn render_recovery_consumed(WithLanguage<EmptyContext>) { "pages/recovery/consumed.html" }
+
     /// Render the account recovery disabled page
     pub fn render_recovery_disabled(WithLanguage<EmptyContext>) { "pages/recovery/disabled.html" }
 
@@ -432,6 +435,7 @@ impl Templates {
         check::render_recovery_progress(self, now, rng)?;
         check::render_recovery_finish(self, now, rng)?;
         check::render_recovery_expired(self, now, rng)?;
+        check::render_recovery_consumed(self, now, rng)?;
         check::render_recovery_disabled(self, now, rng)?;
         check::render_reauth(self, now, rng)?;
         check::render_form_post::<EmptyContext>(self, now, rng)?;

--- a/crates/templates/src/lib.rs
+++ b/crates/templates/src/lib.rs
@@ -22,7 +22,6 @@ use std::{collections::HashSet, sync::Arc};
 use anyhow::Context as _;
 use arc_swap::ArcSwap;
 use camino::{Utf8Path, Utf8PathBuf};
-use context::WithCaptcha;
 use mas_i18n::Translator;
 use mas_router::UrlBuilder;
 use mas_spa::ViteManifest;
@@ -44,13 +43,13 @@ mod macros;
 pub use self::{
     context::{
         AppContext, CompatSsoContext, ConsentContext, DeviceConsentContext, DeviceLinkContext,
-        DeviceLinkFormField, EmailAddContext, EmailVerificationContext,
+        DeviceLinkFormField, EmailAddContext, EmailRecoveryContext, EmailVerificationContext,
         EmailVerificationPageContext, EmptyContext, ErrorContext, FormPostContext, IndexContext,
         LoginContext, LoginFormField, NotFoundContext, PolicyViolationContext, PostAuthContext,
         PostAuthContextInner, ReauthContext, ReauthFormField, RecoveryStartContext,
         RecoveryStartFormField, RegisterContext, RegisterFormField, SiteBranding, SiteConfigExt,
         SiteFeatures, TemplateContext, UpstreamExistingLinkContext, UpstreamRegister,
-        UpstreamRegisterFormField, UpstreamSuggestLink, WithCsrf, WithLanguage,
+        UpstreamRegisterFormField, UpstreamSuggestLink, WithCaptcha, WithCsrf, WithLanguage,
         WithOptionalSession, WithSession,
     },
     forms::{FieldError, FormError, FormField, FormState, ToFormState},
@@ -359,6 +358,15 @@ register_templates! {
 
     /// Render the HTML error page
     pub fn render_error(ErrorContext) { "pages/error.html" }
+
+    /// Render the email recovery email (plain text variant)
+    pub fn render_email_recovery_txt(WithLanguage<EmailRecoveryContext>) { "emails/recovery.txt" }
+
+    /// Render the email recovery email (HTML text variant)
+    pub fn render_email_recovery_html(WithLanguage<EmailRecoveryContext>) { "emails/recovery.html" }
+
+    /// Render the email recovery subject
+    pub fn render_email_recovery_subject(WithLanguage<EmailRecoveryContext>) { "emails/recovery.subject" }
 
     /// Render the email verification email (plain text variant)
     pub fn render_email_verification_txt(WithLanguage<EmailVerificationContext>) { "emails/verification.txt" }

--- a/crates/templates/src/lib.rs
+++ b/crates/templates/src/lib.rs
@@ -357,6 +357,9 @@ register_templates! {
     /// Render the account recovery finish page
     pub fn render_recovery_finish(WithLanguage<WithCsrf<RecoveryFinishContext>>) { "pages/recovery/finish.html" }
 
+    /// Render the account recovery disabled page
+    pub fn render_recovery_disabled(WithLanguage<EmptyContext>) { "pages/recovery/disabled.html" }
+
     /// Render the re-authentication form
     pub fn render_reauth(WithLanguage<WithCsrf<WithSession<ReauthContext>>>) { "pages/reauth.html" }
 
@@ -425,6 +428,7 @@ impl Templates {
         check::render_recovery_start(self, now, rng)?;
         check::render_recovery_progress(self, now, rng)?;
         check::render_recovery_finish(self, now, rng)?;
+        check::render_recovery_disabled(self, now, rng)?;
         check::render_reauth(self, now, rng)?;
         check::render_form_post::<EmptyContext>(self, now, rng)?;
         check::render_error(self, now, rng)?;
@@ -455,6 +459,7 @@ mod tests {
         let features = SiteFeatures {
             password_login: true,
             password_registration: true,
+            account_recovery: true,
         };
         let vite_manifest_path =
             Utf8Path::new(env!("CARGO_MANIFEST_DIR")).join("../../frontend/dist/manifest.json");

--- a/crates/templates/src/lib.rs
+++ b/crates/templates/src/lib.rs
@@ -46,11 +46,11 @@ pub use self::{
         DeviceLinkFormField, EmailAddContext, EmailRecoveryContext, EmailVerificationContext,
         EmailVerificationPageContext, EmptyContext, ErrorContext, FormPostContext, IndexContext,
         LoginContext, LoginFormField, NotFoundContext, PolicyViolationContext, PostAuthContext,
-        PostAuthContextInner, ReauthContext, ReauthFormField, RecoveryStartContext,
-        RecoveryStartFormField, RegisterContext, RegisterFormField, SiteBranding, SiteConfigExt,
-        SiteFeatures, TemplateContext, UpstreamExistingLinkContext, UpstreamRegister,
-        UpstreamRegisterFormField, UpstreamSuggestLink, WithCaptcha, WithCsrf, WithLanguage,
-        WithOptionalSession, WithSession,
+        PostAuthContextInner, ReauthContext, ReauthFormField, RecoveryProgressContext,
+        RecoveryStartContext, RecoveryStartFormField, RegisterContext, RegisterFormField,
+        SiteBranding, SiteConfigExt, SiteFeatures, TemplateContext, UpstreamExistingLinkContext,
+        UpstreamRegister, UpstreamRegisterFormField, UpstreamSuggestLink, WithCaptcha, WithCsrf,
+        WithLanguage, WithOptionalSession, WithSession,
     },
     forms::{FieldError, FormError, FormField, FormState, ToFormState},
 };
@@ -350,6 +350,10 @@ register_templates! {
     /// Render the account recovery start page
     pub fn render_recovery_start(WithLanguage<WithCsrf<RecoveryStartContext>>) { "pages/recovery/start.html" }
 
+    /// Render the account recovery start page
+    pub fn render_recovery_progress(WithLanguage<WithCsrf<RecoveryProgressContext>>) { "pages/recovery/progress.html" }
+
+
     /// Render the re-authentication form
     pub fn render_reauth(WithLanguage<WithCsrf<WithSession<ReauthContext>>>) { "pages/reauth.html" }
 
@@ -416,6 +420,7 @@ impl Templates {
         check::render_account_add_email(self, now, rng)?;
         check::render_account_verify_email(self, now, rng)?;
         check::render_recovery_start(self, now, rng)?;
+        check::render_recovery_progress(self, now, rng)?;
         check::render_reauth(self, now, rng)?;
         check::render_form_post::<EmptyContext>(self, now, rng)?;
         check::render_error(self, now, rng)?;

--- a/crates/templates/src/lib.rs
+++ b/crates/templates/src/lib.rs
@@ -47,9 +47,10 @@ pub use self::{
         DeviceLinkFormField, EmailAddContext, EmailVerificationContext,
         EmailVerificationPageContext, EmptyContext, ErrorContext, FormPostContext, IndexContext,
         LoginContext, LoginFormField, NotFoundContext, PolicyViolationContext, PostAuthContext,
-        PostAuthContextInner, ReauthContext, ReauthFormField, RegisterContext, RegisterFormField,
-        SiteBranding, SiteConfigExt, SiteFeatures, TemplateContext, UpstreamExistingLinkContext,
-        UpstreamRegister, UpstreamRegisterFormField, UpstreamSuggestLink, WithCsrf, WithLanguage,
+        PostAuthContextInner, ReauthContext, ReauthFormField, RecoveryStartContext,
+        RecoveryStartFormField, RegisterContext, RegisterFormField, SiteBranding, SiteConfigExt,
+        SiteFeatures, TemplateContext, UpstreamExistingLinkContext, UpstreamRegister,
+        UpstreamRegisterFormField, UpstreamSuggestLink, WithCsrf, WithLanguage,
         WithOptionalSession, WithSession,
     },
     forms::{FieldError, FormError, FormField, FormState, ToFormState},
@@ -347,6 +348,9 @@ register_templates! {
     /// Render the email verification page
     pub fn render_account_add_email(WithLanguage<WithCsrf<WithSession<EmailAddContext>>>) { "pages/account/emails/add.html" }
 
+    /// Render the account recovery start page
+    pub fn render_recovery_start(WithLanguage<WithCsrf<RecoveryStartContext>>) { "pages/recovery/start.html" }
+
     /// Render the re-authentication form
     pub fn render_reauth(WithLanguage<WithCsrf<WithSession<ReauthContext>>>) { "pages/reauth.html" }
 
@@ -403,6 +407,7 @@ impl Templates {
         check::render_index(self, now, rng)?;
         check::render_account_add_email(self, now, rng)?;
         check::render_account_verify_email(self, now, rng)?;
+        check::render_recovery_start(self, now, rng)?;
         check::render_reauth(self, now, rng)?;
         check::render_form_post::<EmptyContext>(self, now, rng)?;
         check::render_error(self, now, rng)?;

--- a/crates/templates/src/lib.rs
+++ b/crates/templates/src/lib.rs
@@ -46,11 +46,12 @@ pub use self::{
         DeviceLinkFormField, EmailAddContext, EmailRecoveryContext, EmailVerificationContext,
         EmailVerificationPageContext, EmptyContext, ErrorContext, FormPostContext, IndexContext,
         LoginContext, LoginFormField, NotFoundContext, PolicyViolationContext, PostAuthContext,
-        PostAuthContextInner, ReauthContext, ReauthFormField, RecoveryProgressContext,
-        RecoveryStartContext, RecoveryStartFormField, RegisterContext, RegisterFormField,
-        SiteBranding, SiteConfigExt, SiteFeatures, TemplateContext, UpstreamExistingLinkContext,
-        UpstreamRegister, UpstreamRegisterFormField, UpstreamSuggestLink, WithCaptcha, WithCsrf,
-        WithLanguage, WithOptionalSession, WithSession,
+        PostAuthContextInner, ReauthContext, ReauthFormField, RecoveryFinishContext,
+        RecoveryFinishFormField, RecoveryProgressContext, RecoveryStartContext,
+        RecoveryStartFormField, RegisterContext, RegisterFormField, SiteBranding, SiteConfigExt,
+        SiteFeatures, TemplateContext, UpstreamExistingLinkContext, UpstreamRegister,
+        UpstreamRegisterFormField, UpstreamSuggestLink, WithCaptcha, WithCsrf, WithLanguage,
+        WithOptionalSession, WithSession,
     },
     forms::{FieldError, FormError, FormField, FormState, ToFormState},
 };
@@ -353,6 +354,8 @@ register_templates! {
     /// Render the account recovery start page
     pub fn render_recovery_progress(WithLanguage<WithCsrf<RecoveryProgressContext>>) { "pages/recovery/progress.html" }
 
+    /// Render the account recovery finish page
+    pub fn render_recovery_finish(WithLanguage<WithCsrf<RecoveryFinishContext>>) { "pages/recovery/finish.html" }
 
     /// Render the re-authentication form
     pub fn render_reauth(WithLanguage<WithCsrf<WithSession<ReauthContext>>>) { "pages/reauth.html" }
@@ -421,6 +424,7 @@ impl Templates {
         check::render_account_verify_email(self, now, rng)?;
         check::render_recovery_start(self, now, rng)?;
         check::render_recovery_progress(self, now, rng)?;
+        check::render_recovery_finish(self, now, rng)?;
         check::render_reauth(self, now, rng)?;
         check::render_form_post::<EmptyContext>(self, now, rng)?;
         check::render_error(self, now, rng)?;

--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -2038,6 +2038,10 @@
         "password_change_allowed": {
           "description": "Whether users are allowed to change their passwords. Defaults to `true`.",
           "type": "boolean"
+        },
+        "account_recovery_enabled": {
+          "description": "Whether email-based account recovery is enabled. Defaults to `false`.",
+          "type": "boolean"
         }
       }
     }

--- a/frontend/src/components/PageHeading/PageHeading.module.css
+++ b/frontend/src/components/PageHeading/PageHeading.module.css
@@ -66,6 +66,7 @@
       font: var(--cpd-font-heading-lg-semibold);
       letter-spacing: var(--cpd-font-letter-spacing-heading-xl);
       color: var(--cpd-color-text-primary);
+      text-wrap: balance;
     }
 
     & .text {

--- a/templates/components/button.html
+++ b/templates/components/button.html
@@ -14,16 +14,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 #}
 
-{% macro link(text, href="#", class="") %}
-  <a class="cpd-button {{ class }}" data-kind="primary" data-size="lg" href="{{ href | prefix_url }}">{{ text }}</a>
+{% macro link(text, href="#", class="", size="lg") %}
+  <a class="cpd-button {{ class }}" data-kind="primary" data-size="{{ size }}" href="{{ href | prefix_url }}">{{ text }}</a>
 {% endmacro %}
 
 {% macro link_text(text, href="#", class="") %}
   <a class="cpd-link {{ class }}" data-kind="primary" href="{{ href | prefix_url }}">{{ text }}</a>
 {% endmacro %}
 
-{% macro link_outline(text, href="#", class="") %}
-  <a class="cpd-button {{ class }}" data-kind="secondary" data-size="lg" href="{{ href | prefix_url }}">{{ text }}</a>
+{% macro link_outline(text, href="#", class="", size="lg") %}
+  <a class="cpd-button {{ class }}" data-kind="secondary" data-size="{{ size }}" href="{{ href | prefix_url }}">{{ text }}</a>
 {% endmacro %}
 
 {% macro link_tertiary(text, href="#", class="", size="lg") %}

--- a/templates/components/button.html
+++ b/templates/components/button.html
@@ -26,6 +26,10 @@ limitations under the License.
   <a class="cpd-button {{ class }}" data-kind="secondary" data-size="lg" href="{{ href | prefix_url }}">{{ text }}</a>
 {% endmacro %}
 
+{% macro link_tertiary(text, href="#", class="", size="lg") %}
+  <a class="cpd-button {{ class }}" data-kind="tertiary" data-size="{{ size }}" href="{{ href | prefix_url }}">{{ text }}</a>
+{% endmacro %}
+
 {% macro button(
   text,
   name="",
@@ -33,6 +37,7 @@ limitations under the License.
   class="",
   value="",
   disabled=False,
+  size="lg",
   autocomplete=False,
   autocorrect=False,
   autocapitalize=False) %}
@@ -43,7 +48,7 @@ limitations under the License.
     {% if disabled %}disabled{% endif %}
     class="cpd-button {{ class }}"
     data-kind="primary"
-    data-size="lg"
+    data-size="{{ size }}"
     {% if autocapitalize %}autocapitilize="{{ autocapitilize }}"{% endif %}
     {% if autocomplete %}autocomplete="{{ autocomplete }}"{% endif %}
     {% if autocorrect %}autocorrect="{{ autocorrect }}"{% endif %}
@@ -80,6 +85,7 @@ limitations under the License.
   class="",
   value="",
   disabled=False,
+  size="lg",
   autocomplete=False,
   autocorrect=False,
   autocapitalize=False) %}
@@ -89,7 +95,7 @@ limitations under the License.
     type="{{ type }}"
     class="cpd-button {{ class }}"
     data-kind="secondary"
-    data-size="lg"
+    data-size="{{ size }}"
     {% if disabled %}disabled{% endif %}
     {% if autocapitalize %}autocapitilize="{{ autocapitilize }}"{% endif %}
     {% if autocomplete %}autocomplete="{{ autocomplete }}"{% endif %}

--- a/templates/components/field.html
+++ b/templates/components/field.html
@@ -70,6 +70,8 @@ limitations under the License.
               {{ _("mas.errors.username_taken") }}
             {% elif error.kind == "policy" %}
               {{ _("mas.errors.denied_policy", policy=error.message) }}
+            {% elif error.kind == "password_mismatch" %}
+              {{ _("mas.errors.password_mismatch") }}
             {% else %}
               {{ error.kind }}
             {% endif %}

--- a/templates/emails/recovery.html
+++ b/templates/emails/recovery.html
@@ -1,0 +1,55 @@
+{#
+Copyright 2024 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-#}
+
+{%- set _ = translator(lang) -%}
+
+<!doctype html>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="{{ lang }}">
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <style type="text/css">
+        a#button:hover { background-color: #3C4045!important; }
+        a#button:active { background-color: #4C5158!important; }
+    </style>
+</head>
+
+<body style="
+    color: black;
+    background-color: white;
+    font-family: Inter, system-ui, ui-sans-serif, sans-serif;
+">
+    {{ _("mas.emails.recovery.headline", server_name=branding.server_name) }}<br />
+    <br />
+    {{ _("mas.emails.recovery.click_button") }}<br />
+    <br />
+    <a id="button" href="{{ recovery_link }}" target="_blank" style="
+        display: inline-block;
+        transition: background-color 0.1s ease;
+        font-size: 18px; 
+        font-size: 1.125rem; 
+        font-weight: 600;
+        color: #FFF;
+        background-color: #1B1D22;
+        padding: 16px 32px;
+        padding: 1rem 2rem;
+        border-radius: 32px;
+        border-radius: 2rem;
+        text-decoration: none;
+    ">{{ _("mas.emails.recovery.create_new_password") }}</a><br />
+    <br />
+    {{ _("mas.emails.recovery.you_can_ignore") }}
+</body>
+</html>

--- a/templates/emails/recovery.subject
+++ b/templates/emails/recovery.subject
@@ -1,0 +1,22 @@
+{#
+Copyright 2024 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-#}
+
+{%- set _ = translator(lang) -%}
+{%- set mxid -%}
+    @{{ user.username }}:{{ branding.server_name }}
+{%- endset -%}
+
+{{ _("mas.emails.recovery.subject", mxid=mxid) }}

--- a/templates/emails/recovery.txt
+++ b/templates/emails/recovery.txt
@@ -1,0 +1,24 @@
+{#
+Copyright 2024 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-#}
+
+{%- set _ = translator(lang) -%}
+{{ _("mas.emails.recovery.headline", server_name=branding.server_name) }}
+
+{{ _("mas.emails.recovery.copy_link") }}
+
+    {{ recovery_link }}
+
+{{ _("mas.emails.recovery.you_can_ignore") }}

--- a/templates/pages/login.html
+++ b/templates/pages/login.html
@@ -19,7 +19,7 @@ limitations under the License.
 {% from "components/idp_brand.html" import logo %}
 
 {% block content %}
-  <main class="flex flex-col gap-6">
+  <main class="flex flex-col gap-10">
     {% if features.password_login %}
       <header class="page-heading">
         <div class="icon">
@@ -58,6 +58,10 @@ limitations under the License.
         {% call(f) field.field(label=_("common.password"), name="password", form_state=form) %}
           <input {{ field.attributes(f) }} class="cpd-text-control" type="password" autocomplete="password" required />
         {% endcall %}
+        
+        {% if features.account_recovery %}
+          {{ button.link_text(text=_("mas.login.forgot_password"), href="/recover", class="self-center") }}
+        {% endif %}
 
         {{ button.button(text=_("action.continue")) }}
       </form>

--- a/templates/pages/recovery/consumed.html
+++ b/templates/pages/recovery/consumed.html
@@ -1,0 +1,32 @@
+{#
+Copyright 2024 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+#}
+
+{% extends "base.html" %}
+
+{% block content %}
+  <header class="page-heading">
+    <div class="icon invalid">
+      {{ icon.error() }}
+    </div>
+
+    <div class="header">
+      <h1 class="title">{{ _("mas.recovery.consumed.heading") }}</h1>
+      <p class="text">{{ _("mas.recovery.consumed.description") }}</p>
+    </div>
+
+    {{ button.link_outline(text=_("action.start_over"), href="/login") }}
+  </header>
+{% endblock content %}

--- a/templates/pages/recovery/disabled.html
+++ b/templates/pages/recovery/disabled.html
@@ -1,0 +1,32 @@
+{#
+Copyright 2024 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+#}
+
+{% extends "base.html" %}
+
+{% block content %}
+  <header class="page-heading">
+    <div class="icon invalid">
+      {{ icon.lock_solid() }}
+    </div>
+
+    <div class="header">
+      <h1 class="title">{{ _("mas.recovery.disabled.heading") }}</h1>
+      <p class="text">{{ _("mas.recovery.disabled.description") }}</p>
+    </div>
+
+    {{ button.link_outline(text=_("action.back"), href="/login") }}
+  </header>
+{% endblock content %}

--- a/templates/pages/recovery/expired.html
+++ b/templates/pages/recovery/expired.html
@@ -1,0 +1,40 @@
+{#
+Copyright 2024 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+#}
+
+{% extends "base.html" %}
+
+{% block content %}
+  <header class="page-heading">
+    <div class="icon invalid">
+      {{ icon.error() }}
+    </div>
+
+    <div class="header">
+      <h1 class="title">{{ _("mas.recovery.expired.heading") }}</h1>
+      <p class="text [&>span]:font-medium">{{ _("mas.recovery.expired.description", email=session.email) }}</p>
+    </div>
+  </header>
+
+  <div class="flex flex-col gap-6">
+    <form class="cpd-form-root" method="POST" action="{{ '/recover/progress/' + session.id | prefix_url }}">
+      <input type="hidden" name="csrf" value="{{ csrf_token }}" />
+
+      {{ button.button(text=_("mas.recovery.expired.resend_email"), type="submit") }}
+    </form>
+
+    {{ button.link_outline(text=_("action.start_over"), href="/login") }}
+  </div>
+{% endblock content %}

--- a/templates/pages/recovery/finish.html
+++ b/templates/pages/recovery/finish.html
@@ -1,0 +1,55 @@
+{#
+Copyright 2024 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+#}
+
+{% extends "base.html" %}
+
+{% block content %}
+  <header class="page-heading">
+    <div class="icon">
+      {{ icon.lock_solid() }}
+    </div>
+
+    <div class="header">
+      <h1 class="title">{{ _("mas.recovery.finish.heading") }}</h1>
+      <p class="text">{{ _("mas.recovery.finish.description") }}</p>
+    </div>
+  </header>
+
+  <form class="cpd-form-root" method="POST">
+    {# Hidden username field so that password manager can save the username #}
+    <input class="hidden" aria-hidden="true" type="text" name="username" autocomplete="username" value="{{ user.username }}" />
+
+    {% if form.errors is not empty %}
+      {% for error in form.errors %}
+        <div class="text-critical font-medium">
+          {{ errors.form_error_message(error=error) }}
+        </div>
+      {% endfor %}
+    {% endif %}
+
+    <input type="hidden" name="csrf" value="{{ csrf_token }}" />
+
+    {% call(f) field.field(label=_("mas.recovery.finish.new"), name="new_password", form_state=form) %}
+      <input {{ field.attributes(f) }} class="cpd-text-control" type="password" autofocus autocomplete="new-password" required />
+    {% endcall %}
+
+    {% call(f) field.field(label=_("mas.recovery.finish.confirm"), name="new_password_confirm", form_state=form) %}
+      <input {{ field.attributes(f) }} class="cpd-text-control" type="password" autocomplete="new-password" required />
+    {% endcall %}
+
+    {{ button.button(text=_("mas.recovery.finish.save_and_continue"), type="submit") }}
+  </form>
+{% endblock content %}

--- a/templates/pages/recovery/progress.html
+++ b/templates/pages/recovery/progress.html
@@ -1,0 +1,40 @@
+{#
+Copyright 2024 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+#}
+
+{% extends "base.html" %}
+
+{% block content %}
+  <header class="page-heading">
+    <div class="icon">
+      {{ icon.send_solid() }}
+    </div>
+
+    <div class="header">
+      <h1 class="title">{{ _("mas.recovery.progress.heading") }}</h1>
+      <p class="text [&>span]:font-medium">{{ _("mas.recovery.progress.description", email=session.email) }}</p>
+    </div>
+  </header>
+
+  <div class="flex flex-col gap-6">
+    <form class="cpd-form-root" method="POST">
+      <input type="hidden" name="csrf" value="{{ csrf_token }}" />
+
+      {{ button.button_outline(text=_("mas.recovery.progress.resend_email"), type="submit") }}
+    </form>
+
+    {{ button.link_tertiary(text=_("mas.recovery.progress.change_email"), href="/recover") }}
+  </div>
+{% endblock content %}

--- a/templates/pages/recovery/start.html
+++ b/templates/pages/recovery/start.html
@@ -1,0 +1,48 @@
+{#
+Copyright 2024 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+#}
+
+{% extends "base.html" %}
+
+{% block content %}
+  <header class="page-heading">
+    <div class="icon">
+      {{ icon.email_solid() }}
+    </div>
+
+    <div class="header">
+      <h1 class="title">{{ _("mas.recovery.start.heading") }}</h1>
+      <p class="text">{{ _("mas.recovery.start.description") }}</p>
+    </div>
+  </header>
+
+  <form class="cpd-form-root" method="POST">
+    {% if form.errors is not empty %}
+      {% for error in form.errors %}
+        <div class="text-critical font-medium">
+        {{ errors.form_error_message(error=error) }}
+        </div>
+      {% endfor %}
+    {% endif %}
+
+    <input type="hidden" name="csrf" value="{{ csrf_token }}" />
+
+    {% call(f) field.field(label=_("common.email_address"), name="email", form_state=form) %}
+      <input {{ field.attributes(f) }} class="cpd-text-control" type="email" autocomplete="email" required />
+    {% endcall %}
+
+    {{ button.button(text=_("action.continue"), type="submit") }}
+  </form>
+{% endblock content %}

--- a/templates/pages/register.html
+++ b/templates/pages/register.html
@@ -49,11 +49,11 @@ limitations under the License.
         <input {{ field.attributes(f) }} class="cpd-text-control" type="email" autocomplete="email" required />
       {% endcall %}
 
-      {% call(f) field.field(label=_("common.password"), name="password") %}
+      {% call(f) field.field(label=_("common.password"), name="password", form_state=form) %}
         <input {{ field.attributes(f) }} class="cpd-text-control" type="password" autocomplete="new-password" required />
       {% endcall %}
 
-      {% call(f) field.field(label=_("common.password_confirm"), name="password_confirm") %}
+      {% call(f) field.field(label=_("common.password_confirm"), name="password_confirm", form_state=form) %}
         <input {{ field.attributes(f) }} class="cpd-text-control" type="password" autocomplete="new-password" required />
       {% endcall %}
 

--- a/translations/en.json
+++ b/translations/en.json
@@ -221,6 +221,32 @@
         "context": "emails/verification.html:19:3-51, emails/verification.txt:19:3-51",
         "description": "Greeting at the top of emails sent to the user"
       },
+      "recovery": {
+        "click_button": "Click on the button below to create a new password:",
+        "@click_button": {
+          "context": "emails/recovery.html:36:7-44"
+        },
+        "copy_link": "Copy the following link and paste it into a browser to create a new password:",
+        "@copy_link": {
+          "context": "emails/recovery.txt:20:3-37"
+        },
+        "create_new_password": "Create new password",
+        "@create_new_password": {
+          "context": "emails/recovery.html:51:9-53"
+        },
+        "headline": "You requested a password reset for your %(server_name)s account.",
+        "@headline": {
+          "context": "emails/recovery.html:34:7-74, emails/recovery.txt:18:3-70"
+        },
+        "subject": "Reset your account password (%(mxid)s)",
+        "@subject": {
+          "context": "emails/recovery.subject:22:3-46"
+        },
+        "you_can_ignore": "If you didn't ask for a new password, you can ignore this email. Your current password will continue to work.",
+        "@you_can_ignore": {
+          "context": "emails/recovery.html:53:7-46, emails/recovery.txt:24:3-42"
+        }
+      },
       "verify": {
         "body_html": "Your verification code to confirm this email address is: <strong>%(code)s</strong>",
         "@body_html": {

--- a/translations/en.json
+++ b/translations/en.json
@@ -284,7 +284,7 @@
       },
       "password_mismatch": "Password fields don't match",
       "@password_mismatch": {
-        "context": "components/errors.html:21:7-40"
+        "context": "components/errors.html:21:7-40, components/field.html:74:17-50"
       },
       "username_taken": "This username is already taken",
       "@username_taken": {
@@ -356,7 +356,7 @@
     },
     "or_separator": "Or",
     "@or_separator": {
-      "context": "components/field.html:91:10-31",
+      "context": "components/field.html:93:10-31",
       "description": "Separator between the login methods"
     },
     "policy_violation": {
@@ -376,6 +376,33 @@
       }
     },
     "recovery": {
+      "finish": {
+        "confirm": "Enter new password again",
+        "@confirm": {
+          "context": "pages/recovery/finish.html:49:33-65",
+          "description": "Label for the password confirmation field"
+        },
+        "description": "Choose a new password for your account.",
+        "@description": {
+          "context": "pages/recovery/finish.html:27:25-61",
+          "description": "Description for the final password recovery page"
+        },
+        "heading": "Reset your password",
+        "@heading": {
+          "context": "pages/recovery/finish.html:26:27-59",
+          "description": "Heading for the final password recovery page"
+        },
+        "new": "New password",
+        "@new": {
+          "context": "pages/recovery/finish.html:45:33-61",
+          "description": "Label for the new password field"
+        },
+        "save_and_continue": "Save and continue",
+        "@save_and_continue": {
+          "context": "pages/recovery/finish.html:53:26-68",
+          "description": "Button to save the new password and continue"
+        }
+      },
       "progress": {
         "change_email": "Try a different email",
         "@change_email": {

--- a/translations/en.json
+++ b/translations/en.json
@@ -6,7 +6,7 @@
     },
     "continue": "Continue",
     "@continue": {
-      "context": "pages/account/emails/add.html:45:26-46, pages/account/emails/verify.html:60:26-46, pages/consent.html:63:28-48, pages/device_consent.html:129:13-33, pages/device_link.html:48:26-46, pages/login.html:62:30-50, pages/reauth.html:40:28-48, pages/register.html:84:28-48, pages/sso.html:45:28-48"
+      "context": "pages/account/emails/add.html:45:26-46, pages/account/emails/verify.html:60:26-46, pages/consent.html:63:28-48, pages/device_consent.html:129:13-33, pages/device_link.html:48:26-46, pages/login.html:62:30-50, pages/reauth.html:40:28-48, pages/recovery/start.html:45:26-46, pages/register.html:84:28-48, pages/sso.html:45:28-48"
     },
     "create_account": "Create Account",
     "@create_account": {
@@ -67,7 +67,7 @@
     },
     "email_address": "Email address",
     "@email_address": {
-      "context": "pages/account/emails/add.html:41:33-58, pages/register.html:48:35-60, pages/upstream_oauth2/do_register.html:87:37-62"
+      "context": "pages/account/emails/add.html:41:33-58, pages/recovery/start.html:42:33-58, pages/register.html:48:35-60, pages/upstream_oauth2/do_register.html:87:37-62"
     },
     "mxid": "Matrix ID",
     "@mxid": {
@@ -347,6 +347,20 @@
       "logged_as": "Logged as <span class=\"font-semibold\">%(username)s</span>",
       "@logged_as": {
         "context": "pages/policy_violation.html:43:11-86"
+      }
+    },
+    "recovery": {
+      "start": {
+        "description": "An email will be sent with a link to reset your password.",
+        "@description": {
+          "context": "pages/recovery/start.html:27:25-60",
+          "description": "The description of the page to initiate an account recovery"
+        },
+        "heading": "Enter your email to continue",
+        "@heading": {
+          "context": "pages/recovery/start.html:26:27-58",
+          "description": "The title of the page to initiate an account recovery"
+        }
       }
     },
     "register": {

--- a/translations/en.json
+++ b/translations/en.json
@@ -376,6 +376,28 @@
       }
     },
     "recovery": {
+      "progress": {
+        "change_email": "Try a different email",
+        "@change_email": {
+          "context": "pages/recovery/progress.html:38:33-72",
+          "description": "Button to change the email address for the password recovery link"
+        },
+        "description": "We sent an email with a link to reset your password if there's an account using <span>%(email)s</span>.",
+        "@description": {
+          "context": "pages/recovery/progress.html:27:46-105",
+          "description": "The description of the password recovery page, informing the user that an email has been sent to reset their password"
+        },
+        "heading": "Check your email",
+        "@heading": {
+          "context": "pages/recovery/progress.html:26:27-61",
+          "description": "The title of the password recovery page, informing the user that an email has been sent to reset their password"
+        },
+        "resend_email": "Resend email",
+        "@resend_email": {
+          "context": "pages/recovery/progress.html:35:36-75",
+          "description": "Button to resend the email with the password recovery link"
+        }
+      },
       "start": {
         "description": "An email will be sent with a link to reset your password.",
         "@description": {

--- a/translations/en.json
+++ b/translations/en.json
@@ -1,16 +1,20 @@
 {
   "action": {
+    "back": "Back",
+    "@back": {
+      "context": "pages/recovery/disabled.html:30:32-48"
+    },
     "cancel": "Cancel",
     "@cancel": {
-      "context": "pages/consent.html:75:11-29, pages/device_consent.html:132:13-31, pages/login.html:100:13-31, pages/policy_violation.html:52:13-31, pages/register.html:89:13-31"
+      "context": "pages/consent.html:75:11-29, pages/device_consent.html:132:13-31, pages/login.html:104:13-31, pages/policy_violation.html:52:13-31, pages/register.html:89:13-31"
     },
     "continue": "Continue",
     "@continue": {
-      "context": "pages/account/emails/add.html:45:26-46, pages/account/emails/verify.html:60:26-46, pages/consent.html:63:28-48, pages/device_consent.html:129:13-33, pages/device_link.html:48:26-46, pages/login.html:62:30-50, pages/reauth.html:40:28-48, pages/recovery/start.html:45:26-46, pages/register.html:84:28-48, pages/sso.html:45:28-48"
+      "context": "pages/account/emails/add.html:45:26-46, pages/account/emails/verify.html:60:26-46, pages/consent.html:63:28-48, pages/device_consent.html:129:13-33, pages/device_link.html:48:26-46, pages/login.html:66:30-50, pages/reauth.html:40:28-48, pages/recovery/start.html:46:26-46, pages/register.html:84:28-48, pages/sso.html:45:28-48"
     },
     "create_account": "Create Account",
     "@create_account": {
-      "context": "pages/login.html:72:35-61, pages/upstream_oauth2/do_register.html:157:26-52"
+      "context": "pages/login.html:76:35-61, pages/upstream_oauth2/do_register.html:157:26-52"
     },
     "sign_in": "Sign in",
     "@sign_in": {
@@ -294,16 +298,21 @@
     "login": {
       "call_to_register": "Don't have an account yet?",
       "@call_to_register": {
-        "context": "pages/login.html:68:15-46"
+        "context": "pages/login.html:72:15-46"
       },
       "continue_with_provider": "Continue with %(provider)s",
       "@continue_with_provider": {
-        "context": "pages/login.html:87:13-65",
+        "context": "pages/login.html:91:13-65",
         "description": "Button to log in with an upstream provider"
       },
       "description": "Please sign in to continue:",
       "@description": {
         "context": "pages/login.html:38:31-57"
+      },
+      "forgot_password": "Forgot password?",
+      "@forgot_password": {
+        "context": "pages/login.html:63:35-65",
+        "description": "On the login page, link to the account recovery process"
       },
       "headline": "Sign in",
       "@headline": {
@@ -321,7 +330,7 @@
       },
       "no_login_methods": "No login methods available.",
       "@no_login_methods": {
-        "context": "pages/login.html:94:11-42"
+        "context": "pages/login.html:98:11-42"
       }
     },
     "navbar": {
@@ -376,6 +385,16 @@
       }
     },
     "recovery": {
+      "disabled": {
+        "description": "If you have lost your credentials, please contact the administrator to recover your account.",
+        "@description": {
+          "context": "pages/recovery/disabled.html:27:25-63"
+        },
+        "heading": "Account recovery is disabled",
+        "@heading": {
+          "context": "pages/recovery/disabled.html:26:27-61"
+        }
+      },
       "finish": {
         "confirm": "Enter new password again",
         "@confirm": {

--- a/translations/en.json
+++ b/translations/en.json
@@ -23,6 +23,10 @@
     "sign_out": "Sign out",
     "@sign_out": {
       "context": "pages/consent.html:71:28-48, pages/device_consent.html:141:30-50, pages/index.html:36:28-48, pages/policy_violation.html:46:28-48, pages/sso.html:53:28-48, pages/upstream_oauth2/link_mismatch.html:32:24-44, pages/upstream_oauth2/suggest_link.html:40:26-46"
+    },
+    "start_over": "Start over",
+    "@start_over": {
+      "context": "pages/recovery/expired.html:38:32-54"
     }
   },
   "app": {
@@ -393,6 +397,22 @@
         "heading": "Account recovery is disabled",
         "@heading": {
           "context": "pages/recovery/disabled.html:26:27-61"
+        }
+      },
+      "expired": {
+        "description": "Request a new email that will be sent to: <span>%(email)s</span>.",
+        "@description": {
+          "context": "pages/recovery/expired.html:27:46-104",
+          "description": "Description on the page shown when a user tries to use an expired recovery link"
+        },
+        "heading": "The link to reset your password has expired",
+        "@heading": {
+          "context": "pages/recovery/expired.html:26:27-60",
+          "description": "Title on the page shown when a user tries to use an expired recovery link"
+        },
+        "resend_email": "Resend email",
+        "@resend_email": {
+          "context": "pages/recovery/expired.html:35:28-66"
         }
       },
       "finish": {

--- a/translations/en.json
+++ b/translations/en.json
@@ -26,7 +26,7 @@
     },
     "start_over": "Start over",
     "@start_over": {
-      "context": "pages/recovery/expired.html:38:32-54"
+      "context": "pages/recovery/consumed.html:30:32-54, pages/recovery/expired.html:38:32-54"
     }
   },
   "app": {
@@ -389,6 +389,18 @@
       }
     },
     "recovery": {
+      "consumed": {
+        "description": "To create a new password, start over and select “Forgot password”.",
+        "@description": {
+          "context": "pages/recovery/consumed.html:27:25-63",
+          "description": "Description on the error page shown when a user tries to use a recovery link that has already been used"
+        },
+        "heading": "The link to reset your password has already been used",
+        "@heading": {
+          "context": "pages/recovery/consumed.html:26:27-61",
+          "description": "Title on the error page shown when a user tries to use a recovery link that has already been used"
+        }
+      },
       "disabled": {
         "description": "If you have lost your credentials, please contact the administrator to recover your account.",
         "@description": {


### PR DESCRIPTION
Fixes #13 

This implements the password recovery flow as designed [here](https://www.figma.com/design/HUysJAhv6cK6p1Pc81Fxaa/Matrix-Authentication-Service-(MAS)?node-id=5354-4833&t=JASaGhnRh6Gj6FU2-4).

The feature is disabled by default.

A few things to do still to exactly match the designs:

 - The password form isn't interactive at all
 - The recovery email is missing the ['user box'](https://www.figma.com/design/HUysJAhv6cK6p1Pc81Fxaa/Matrix-Authentication-Service-(MAS)?node-id=5352-10257&t=JASaGhnRh6Gj6FU2-4). This is mostly because querying the displayname was potentially annoying here, and I'm not sure about implementing that box in an email (`<table>` maybe?)
 - We're not sending a confirmation email once the password has been changed. I think we should do this separately to also add the same notification to the password change flow

Open questions:

 - Should the initial form have a CAPTCHA? It's basically an open form to spam someone's email
 - I wonder if we should move that page to the React app? That would work by extending the `setPassword` API to accept a recovery 'ticket', and make it easier to have the same form validation logic

I made it so that it's reviewable commit by commit