### PR TITLE
Use a released version of opa-wasm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3884,7 +3884,8 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 [[package]]
 name = "opa-wasm"
 version = "0.1.0"
-source = "git+https://github.com/matrix-org/rust-opa-wasm.git#f7c46ad15059a14a4df8647b4b090928e47b1fe2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f4b727ebe10814d69fb4c1f538e1a0772e1f9b258d30c5a097d04158f8d6017"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/crates/policy/Cargo.toml
+++ b/crates/policy/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 
 [dependencies]
 anyhow.workspace = true
-opa-wasm = { git = "https://github.com/matrix-org/rust-opa-wasm.git" }
+opa-wasm = "0.1.0"
 serde.workspace = true
 serde_json.workspace = true
 schemars = { workspace = true, optional = true }

--- a/deny.toml
+++ b/deny.toml
@@ -76,7 +76,6 @@ skip = [
     { name = "heck", version = "0.4.1" },
     # we depend on old http/http-body/hyper versions, but some dependencies already upgraded
     { name = "http", version = "0.2.12" },
-    { name = "socket2", version = "0.4.10" },
     # sea-query-attr uses an old version of darling
     { name = "darling", version = "0.14.4" },
     { name = "darling_core", version = "0.14.4" },
@@ -97,7 +96,3 @@ unknown-registry = "warn"
 unknown-git = "warn"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 allow-git = []
-
-[sources.allow-org]
-# Allow our own crates
-github = ["matrix-org"]


### PR DESCRIPTION
I finially got the time to clean up and publish rust-opa-wasm to crates.io, so this changes the dependency to use the published version instead of the git URL
