### PR TITLE
GraphQL API to list users with a few filters

### DIFF
--- a/crates/handlers/src/graphql/query/user.rs
+++ b/crates/handlers/src/graphql/query/user.rs
@@ -1,0 +1,75 @@
+// Copyright 2024 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use async_graphql::{Context, Object, ID};
+
+use crate::graphql::{
+    model::{NodeType, User},
+    state::ContextExt as _,
+    UserId,
+};
+
+#[derive(Default)]
+pub struct UserQuery;
+
+#[Object]
+impl UserQuery {
+    /// Fetch a user by its ID.
+    pub async fn user(
+        &self,
+        ctx: &Context<'_>,
+        id: ID,
+    ) -> Result<Option<User>, async_graphql::Error> {
+        let id = NodeType::User.extract_ulid(&id)?;
+
+        let requester = ctx.requester();
+        if !requester.is_owner_or_admin(&UserId(id)) {
+            return Ok(None);
+        }
+
+        // We could avoid the database lookup if the requester is the user we're looking
+        // for but that would make the code more complex and we're not very
+        // concerned about performance yet
+        let state = ctx.state();
+        let mut repo = state.repository().await?;
+        let user = repo.user().lookup(id).await?;
+        repo.cancel().await?;
+
+        Ok(user.map(User))
+    }
+
+    /// Fetch a user by its username.
+    async fn user_by_username(
+        &self,
+        ctx: &Context<'_>,
+        username: String,
+    ) -> Result<Option<User>, async_graphql::Error> {
+        let requester = ctx.requester();
+        let state = ctx.state();
+        let mut repo = state.repository().await?;
+
+        let user = repo.user().find_by_username(&username).await?;
+        let Some(user) = user else {
+            // We don't want to leak the existence of a user
+            return Ok(None);
+        };
+
+        // Users can only see themselves, except for admins
+        if !requester.is_owner_or_admin(&user) {
+            return Ok(None);
+        }
+
+        Ok(Some(User(user)))
+    }
+}

--- a/crates/storage-pg/src/user/mod.rs
+++ b/crates/storage-pg/src/user/mod.rs
@@ -16,15 +16,16 @@
 //! repositories
 
 use async_trait::async_trait;
-use chrono::{DateTime, Utc};
 use mas_data_model::User;
 use mas_storage::{user::UserRepository, Clock};
 use rand::RngCore;
+use sea_query::{Expr, PostgresQueryBuilder, Query};
+use sea_query_binder::SqlxBinder;
 use sqlx::PgConnection;
 use ulid::Ulid;
 use uuid::Uuid;
 
-use crate::{tracing::ExecuteExt, DatabaseError};
+use crate::{iden::Users, pagination::QueryBuilderExt, tracing::ExecuteExt, DatabaseError};
 
 mod email;
 mod password;
@@ -53,15 +54,28 @@ impl<'c> PgUserRepository<'c> {
     }
 }
 
-#[derive(Debug, Clone)]
-struct UserLookup {
-    user_id: Uuid,
-    username: String,
-    primary_user_email_id: Option<Uuid>,
-    created_at: DateTime<Utc>,
-    locked_at: Option<DateTime<Utc>>,
-    can_request_admin: bool,
+mod priv_ {
+    // The enum_def macro generates a public enum, which we don't want, because it
+    // triggers the missing docs warning
+    #![allow(missing_docs)]
+
+    use chrono::{DateTime, Utc};
+    use sea_query::enum_def;
+    use uuid::Uuid;
+
+    #[derive(Debug, Clone, sqlx::FromRow)]
+    #[enum_def]
+    pub(super) struct UserLookup {
+        pub(super) user_id: Uuid,
+        pub(super) username: String,
+        pub(super) primary_user_email_id: Option<Uuid>,
+        pub(super) created_at: DateTime<Utc>,
+        pub(super) locked_at: Option<DateTime<Utc>>,
+        pub(super) can_request_admin: bool,
+    }
 }
+
+use priv_::{UserLookup, UserLookupIden};
 
 impl From<UserLookup> for User {
     fn from(value: UserLookup) -> Self {
@@ -323,5 +337,104 @@ impl<'c> UserRepository for PgUserRepository<'c> {
         user.can_request_admin = can_request_admin;
 
         Ok(user)
+    }
+
+    #[tracing::instrument(
+        name = "db.user.list",
+        skip_all,
+        fields(
+            db.statement,
+        ),
+        err,
+    )]
+    async fn list(
+        &mut self,
+        filter: mas_storage::user::UserFilter<'_>,
+        pagination: mas_storage::Pagination,
+    ) -> Result<mas_storage::Page<User>, Self::Error> {
+        let (sql, arguments) = Query::select()
+            .expr_as(
+                Expr::col((Users::Table, Users::UserId)),
+                UserLookupIden::UserId,
+            )
+            .expr_as(
+                Expr::col((Users::Table, Users::Username)),
+                UserLookupIden::Username,
+            )
+            .expr_as(
+                Expr::col((Users::Table, Users::PrimaryUserEmailId)),
+                UserLookupIden::PrimaryUserEmailId,
+            )
+            .expr_as(
+                Expr::col((Users::Table, Users::CreatedAt)),
+                UserLookupIden::CreatedAt,
+            )
+            .expr_as(
+                Expr::col((Users::Table, Users::LockedAt)),
+                UserLookupIden::LockedAt,
+            )
+            .expr_as(
+                Expr::col((Users::Table, Users::CanRequestAdmin)),
+                UserLookupIden::CanRequestAdmin,
+            )
+            .from(Users::Table)
+            .and_where_option(filter.state().map(|state| {
+                if state.is_locked() {
+                    Expr::col((Users::Table, Users::LockedAt)).is_not_null()
+                } else {
+                    Expr::col((Users::Table, Users::LockedAt)).is_null()
+                }
+            }))
+            .and_where_option(filter.can_request_admin().map(|can_request_admin| {
+                Expr::col((Users::Table, Users::CanRequestAdmin)).eq(can_request_admin)
+            }))
+            .generate_pagination((Users::Table, Users::UserId), pagination)
+            .build_sqlx(PostgresQueryBuilder);
+
+        let edges: Vec<UserLookup> = sqlx::query_as_with(&sql, arguments)
+            .traced()
+            .fetch_all(&mut *self.conn)
+            .await?;
+
+        let page = pagination.process(edges).map(User::from);
+
+        Ok(page)
+    }
+
+    #[tracing::instrument(
+        name = "db.user.count",
+        skip_all,
+        fields(
+            db.statement,
+        ),
+        err,
+    )]
+    async fn count(
+        &mut self,
+        filter: mas_storage::user::UserFilter<'_>,
+    ) -> Result<usize, Self::Error> {
+        let (sql, arguments) = Query::select()
+            .expr(Expr::col((Users::Table, Users::UserId)).count())
+            .from(Users::Table)
+            .and_where_option(filter.state().map(|state| {
+                if state.is_locked() {
+                    Expr::col((Users::Table, Users::LockedAt)).is_not_null()
+                } else {
+                    Expr::col((Users::Table, Users::LockedAt)).is_null()
+                }
+            }))
+            .and_where_option(filter.can_request_admin().map(|can_request_admin| {
+                Expr::col((Users::Table, Users::CanRequestAdmin)).eq(can_request_admin)
+            }))
+            .build_sqlx(PostgresQueryBuilder);
+
+        let count: i64 = sqlx::query_scalar_with(&sql, arguments)
+            .traced()
+            .fetch_one(&mut *self.conn)
+            .await?;
+
+        count
+            .try_into()
+            .map_err(DatabaseError::to_invalid_operation)
     }
 }

--- a/frontend/schema.graphql
+++ b/frontend/schema.graphql
@@ -967,14 +967,6 @@ type Query {
   """
   oauth2Client(id: ID!): Oauth2Client
   """
-  Fetch a user by its ID.
-  """
-  user(id: ID!): User
-  """
-  Fetch a user by its username.
-  """
-  userByUsername(username: String!): User
-  """
   Fetch a browser session by its ID.
   """
   browserSession(id: ID!): BrowserSession
@@ -998,6 +990,14 @@ type Query {
   Get the current site configuration
   """
   siteConfig: SiteConfig!
+  """
+  Fetch a user by its ID.
+  """
+  user(id: ID!): User
+  """
+  Fetch a user by its username.
+  """
+  userByUsername(username: String!): User
   """
   Fetch an upstream OAuth 2.0 link by its ID.
   """

--- a/frontend/schema.graphql
+++ b/frontend/schema.graphql
@@ -999,6 +999,37 @@ type Query {
   """
   userByUsername(username: String!): User
   """
+  Get a list of users.
+
+  This is only available to administrators.
+  """
+  users(
+    """
+    List only users with the given state.
+    """
+    state: UserState
+    """
+    List only users with the given 'canRequestAdmin' value
+    """
+    canRequestAdmin: Boolean
+    """
+    Returns the elements in the list that come after the cursor.
+    """
+    after: String
+    """
+    Returns the elements in the list that come before the cursor.
+    """
+    before: String
+    """
+    Returns the first *n* elements from the list.
+    """
+    first: Int
+    """
+    Returns the last *n* elements from the list.
+    """
+    last: Int
+  ): UserConnection!
+  """
   Fetch an upstream OAuth 2.0 link by its ID.
   """
   upstreamOauth2Link(id: ID!): UpstreamOAuth2Link
@@ -1727,6 +1758,39 @@ type UserAgent {
   deviceType: DeviceType!
 }
 
+type UserConnection {
+  """
+  Information to aid in pagination.
+  """
+  pageInfo: PageInfo!
+  """
+  A list of edges.
+  """
+  edges: [UserEdge!]!
+  """
+  A list of nodes.
+  """
+  nodes: [User!]!
+  """
+  Identifies the total count of items in the connection.
+  """
+  totalCount: Int!
+}
+
+"""
+An edge in a connection.
+"""
+type UserEdge {
+  """
+  The item at the end of the edge
+  """
+  node: User!
+  """
+  A cursor for use in pagination
+  """
+  cursor: String!
+}
+
 """
 A user email address
 """
@@ -1795,6 +1859,20 @@ enum UserEmailState {
   The email address has been confirmed.
   """
   CONFIRMED
+}
+
+"""
+The state of a user.
+"""
+enum UserState {
+  """
+  The user is active.
+  """
+  ACTIVE
+  """
+  The user is locked.
+  """
+  LOCKED
 }
 
 """

--- a/frontend/src/gql/graphql.ts
+++ b/frontend/src/gql/graphql.ts
@@ -733,6 +733,12 @@ export type Query = {
   userByUsername?: Maybe<User>;
   /** Fetch a user email by its ID. */
   userEmail?: Maybe<UserEmail>;
+  /**
+   * Get a list of users.
+   *
+   * This is only available to administrators.
+   */
+  users: UserConnection;
   /** Get the viewer */
   viewer: Viewer;
   /** Get the viewer's session */
@@ -813,6 +819,17 @@ export type QueryUserByUsernameArgs = {
 /** The query root of the GraphQL interface. */
 export type QueryUserEmailArgs = {
   id: Scalars['ID']['input'];
+};
+
+
+/** The query root of the GraphQL interface. */
+export type QueryUsersArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  canRequestAdmin?: InputMaybe<Scalars['Boolean']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+  state?: InputMaybe<UserState>;
 };
 
 /** The input for the `removeEmail` mutation */
@@ -1212,6 +1229,27 @@ export type UserAgent = {
   version?: Maybe<Scalars['String']['output']>;
 };
 
+export type UserConnection = {
+  __typename?: 'UserConnection';
+  /** A list of edges. */
+  edges: Array<UserEdge>;
+  /** A list of nodes. */
+  nodes: Array<User>;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** Identifies the total count of items in the connection. */
+  totalCount: Scalars['Int']['output'];
+};
+
+/** An edge in a connection. */
+export type UserEdge = {
+  __typename?: 'UserEdge';
+  /** A cursor for use in pagination */
+  cursor: Scalars['String']['output'];
+  /** The item at the end of the edge */
+  node: User;
+};
+
 /** A user email address */
 export type UserEmail = CreationEvent & Node & {
   __typename?: 'UserEmail';
@@ -1255,6 +1293,14 @@ export enum UserEmailState {
   Confirmed = 'CONFIRMED',
   /** The email address is pending confirmation. */
   Pending = 'PENDING'
+}
+
+/** The state of a user. */
+export enum UserState {
+  /** The user is active. */
+  Active = 'ACTIVE',
+  /** The user is locked. */
+  Locked = 'LOCKED'
 }
 
 /** The input for the `verifyEmail` mutation */

--- a/frontend/src/gql/schema.ts
+++ b/frontend/src/gql/schema.ts
@@ -2248,6 +2248,61 @@ export default {
             ]
           },
           {
+            "name": "users",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "UserConnection",
+                "ofType": null
+              }
+            },
+            "args": [
+              {
+                "name": "after",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "before",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "canRequestAdmin",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "first",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "last",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              },
+              {
+                "name": "state",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Any"
+                }
+              }
+            ]
+          },
+          {
             "name": "viewer",
             "type": {
               "kind": "NON_NULL",
@@ -3376,6 +3431,102 @@ export default {
             "type": {
               "kind": "SCALAR",
               "name": "Any"
+            },
+            "args": []
+          }
+        ],
+        "interfaces": []
+      },
+      {
+        "kind": "OBJECT",
+        "name": "UserConnection",
+        "fields": [
+          {
+            "name": "edges",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "UserEdge",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "args": []
+          },
+          {
+            "name": "nodes",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "LIST",
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "User",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "args": []
+          },
+          {
+            "name": "pageInfo",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "PageInfo",
+                "ofType": null
+              }
+            },
+            "args": []
+          },
+          {
+            "name": "totalCount",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Any"
+              }
+            },
+            "args": []
+          }
+        ],
+        "interfaces": []
+      },
+      {
+        "kind": "OBJECT",
+        "name": "UserEdge",
+        "fields": [
+          {
+            "name": "cursor",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Any"
+              }
+            },
+            "args": []
+          },
+          {
+            "name": "node",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "User",
+                "ofType": null
+              }
             },
             "args": []
           }


### PR DESCRIPTION
This can be reviewed commit by commit, it is pretty straight forward.

It adds a new `users` API which lets administrators list users with two filters:

 - `state`, to only get active or locked users
 - `canRequestAdmin`, to only get users that have that flag set (or not)
