### PR TITLE
Remove macOS binaries build in CI and remove cargo-zigbuild from Docker image

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -63,10 +63,10 @@ jobs:
       - name: Install zig
         uses: goto-bus-stop/setup-zig@v2
         with:
-          version: 0.11.0
+          version: 0.13.0
 
       - name: Install cargo-zigbuild
-        run: curl -L https://github.com/rust-cross/cargo-zigbuild/releases/download/v0.18.4/cargo-zigbuild-v0.18.4.x86_64-unknown-linux-musl.tar.gz | tar -z -x -C /usr/local/bin
+        run: curl -L https://github.com/rust-cross/cargo-zigbuild/releases/download/v0.19.0/cargo-zigbuild-v0.19.0.x86_64-unknown-linux-musl.tar.gz | tar -z -x -C /usr/local/bin
 
       - name: Download the macOS SDK
         run: curl -L "https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX11.3.sdk.tar.xz" | tar -J -x -C /opt

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,13 +2,13 @@ name: Build
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
     tags:
-      - 'v*'
+      - "v*"
 
   # Only run for pull requests if relevant files were changed
   pull_request:
-    branches: [ main ]
+    branches: [main]
     paths:
       - Dockerfile
       - docker-bake.hcl
@@ -21,8 +21,8 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   CARGO_NET_GIT_FETCH_WITH_CLI: "true"
-  #SCCACHE_GHA_ENABLED: "true"
-  #RUSTC_WRAPPER: "sccache"
+  SCCACHE_GHA_ENABLED: "true"
+  RUSTC_WRAPPER: "sccache"
   IMAGE: ghcr.io/matrix-org/matrix-authentication-service
   IMAGE_SYN2MAS: ghcr.io/matrix-org/matrix-authentication-service/syn2mas
   BUILDCACHE: ghcr.io/matrix-org/matrix-authentication-service/buildcache
@@ -32,9 +32,6 @@ jobs:
   build-binaries:
     name: Build binaries
     runs-on: ubuntu-22.04
-
-    env:
-      SDKROOT: /opt/MacOSX11.3.sdk
 
     permissions:
       contents: read
@@ -54,11 +51,9 @@ jobs:
           targets: |
             x86_64-unknown-linux-gnu
             aarch64-unknown-linux-gnu
-            x86_64-apple-darwin
-            aarch64-apple-darwin
 
-      #- name: Setup sccache
-      #  uses: mozilla-actions/sccache-action@v0.0.5
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.5
 
       - name: Install zig
         uses: goto-bus-stop/setup-zig@v2
@@ -66,10 +61,7 @@ jobs:
           version: 0.13.0
 
       - name: Install cargo-zigbuild
-        run: curl -L https://github.com/rust-cross/cargo-zigbuild/releases/download/v0.19.0/cargo-zigbuild-v0.19.0.x86_64-unknown-linux-musl.tar.gz | tar -z -x -C /usr/local/bin
-
-      - name: Download the macOS SDK
-        run: curl -L "https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX11.3.sdk.tar.xz" | tar -J -x -C /opt
+        run: curl -L https://github.com/rust-cross/cargo-zigbuild/releases/download/v0.19.1/cargo-zigbuild-v0.19.1.x86_64-unknown-linux-musl.tar.gz | tar -z -x -C /usr/local/bin
 
       - name: Install frontend Node
         uses: actions/setup-node@v4.0.3
@@ -88,44 +80,45 @@ jobs:
         working-directory: ./policies
         run: make
 
-      - name: Force Cargo to create the target directory
-        # Run `cargo clean` with an empty package name to force it to create the target directory
-        # This fails because there is no package with an empty name, but the target directory is created
-        # See https://github.com/rust-lang/cargo/issues/12441
-        # This is needed because `cargo-zigbuild` sometimes (wrongly) creates the target directory
-        # See https://github.com/rust-cross/cargo-zigbuild/issues/165
-        run: |
-          cargo clean -p '' \
-            --target x86_64-unknown-linux-gnu \
-            --target aarch64-unknown-linux-gnu \
-            --target x86_64-apple-darwin \
-            --target aarch64-apple-darwin \
-            || true
-
       - name: Build the binary
         run: |
           cargo zigbuild \
             --release \
             --target x86_64-unknown-linux-gnu.2.17 \
             --target aarch64-unknown-linux-gnu.2.17 \
-            --target x86_64-apple-darwin \
-            --target aarch64-apple-darwin \
             --no-default-features \
             --features dist \
             -p mas-cli
+
+      - name: Create one archive per architecture
+        run: |
+          for arch in x86_64 aarch64; do
+            # Create one directory per architecture
+            mkdir -p dist/${arch}/share/
+            # Copy the artifacts to the right place
+            cp policies/policy.wasm dist/${arch}/share/policy.wasm
+            cp frontend/dist/manifest.json dist/${arch}/share/manifest.json
+            cp -r frontend/dist/ dist/${arch}/share/assets
+            cp -r templates/ dist/${arch}/share/templates
+            cp -r translations/ dist/${arch}/share/translations
+            cp LICENSE dist/${arch}/LICENSE
+            chmod -R u=rwX,go=rX dist/${arch}/
+
+            # Copy the binary to the right place
+            cp target/${arch}-unknown-linux-gnu/release/mas-cli dist/${arch}/
+            chmod u=rwx,go=rx dist/${arch}/mas-cli
+
+            # Create the archive
+            tar -czvf mas-cli-${arch}-linux.tar.gz --owner=0 --group=0 -C dist/${arch}/ .
+          done
 
       - name: Upload the artifacts
         uses: actions/upload-artifact@v4.3.5
         with:
           name: binaries
           path: |
-            target/*/release/mas-cli
-            frontend/dist/
-            policies/policy.wasm
-            templates/
-            translations/
-            LICENSE
-
+            mas-cli-aarch64-linux.tar.gz
+            mas-cli-x86_64-linux.tar.gz
 
   build-image:
     name: Build and push Docker image
@@ -261,7 +254,6 @@ jobs:
             "${{ env.IMAGE }}@${{ fromJSON(steps.output.outputs.metadata).regular.digest }}" \
             "${{ env.IMAGE }}@${{ fromJSON(steps.output.outputs.metadata).debug.digest }}" \
             "${{ env.IMAGE_SYN2MAS }}@${{ fromJSON(steps.output.outputs.metadata).syn2mas.digest }}"
-          
 
   syn2mas:
     name: Release syn2mas on NPM
@@ -291,7 +283,6 @@ jobs:
           provenance: true
           dry-run: ${{ !startsWith(github.ref, 'refs/tags/') }}
 
-
   release:
     name: Release
     if: startsWith(github.ref, 'refs/tags/')
@@ -307,38 +298,15 @@ jobs:
           name: binaries
           path: artifacts
 
-      - name: Prepare the archive directory
-        run: |
-          mkdir -p dist/share/
-          mv artifacts/policies/policy.wasm dist/share/policy.wasm
-          mv artifacts/frontend/dist/manifest.json dist/share/manifest.json
-          mv artifacts/frontend/dist/ dist/share/assets
-          mv artifacts/templates/ dist/share/templates
-          mv artifacts/translations/ dist/share/translations
-          mv artifacts/LICENSE dist/LICENSE
-          chmod -R u=rwX,go=rX dist/
-
-      - name: Create the archives
-        run: |
-          for arch in x86_64 aarch64; do
-            mv artifacts/target/${arch}-unknown-linux-gnu/release/mas-cli dist/mas-cli
-            chmod u=rwx,go=rx dist/mas-cli
-            tar -czvf mas-cli-${arch}-linux.tar.gz --owner=0 --group=0 -C dist/ .
-          
-            mv artifacts/target/${arch}-apple-darwin/release/mas-cli dist/mas-cli
-            chmod u=rwx,go=rx dist/mas-cli
-            tar -czvf mas-cli-${arch}-macos.tar.gz --owner=0 --group=0 -C dist/ .
-          done
-
       - name: Prepare a release
         uses: softprops/action-gh-release@v2
         with:
           body: |
             ### Docker image
-            
-            Regular image: 
-            
-              - Digest: 
+
+            Regular image:
+
+              - Digest:
                 ```
                 ${{ env.IMAGE }}@${{ fromJSON(needs.build-image.outputs.metadata).regular.digest }}
                 ```
@@ -347,10 +315,10 @@ jobs:
                 ${{ join(fromJSON(needs.build-image.outputs.metadata).regular.tags, '
                 ') }}
                 ```
-            
-            Debug variant: 
-            
-              - Digest: 
+
+            Debug variant:
+
+              - Digest:
                 ```
                 ${{ env.IMAGE }}@${{ fromJSON(needs.build-image.outputs.metadata).debug.digest }}
                 ```
@@ -359,10 +327,10 @@ jobs:
                 ${{ join(fromJSON(needs.build-image.outputs.metadata).debug.tags, '
                 ') }}
                 ```
-            
-            `syn2mas` migration tool: 
-            
-              - Digest: 
+
+            `syn2mas` migration tool:
+
+              - Digest:
                 ```
                 ${{ env.IMAGE_SYN2MAS }}@${{ fromJSON(needs.build-image.outputs.metadata).syn2mas.digest }}
                 ```
@@ -373,8 +341,6 @@ jobs:
                 ```
 
           files: |
-            mas-cli-aarch64-linux.tar.gz
-            mas-cli-aarch64-macos.tar.gz
-            mas-cli-x86_64-linux.tar.gz
-            mas-cli-x86_64-macos.tar.gz
+            artifacts/mas-cli-aarch64-linux.tar.gz
+            artifacts/mas-cli-x86_64-linux.tar.gz
           draft: true

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,8 +21,8 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   CARGO_NET_GIT_FETCH_WITH_CLI: "true"
-  SCCACHE_GHA_ENABLED: "true"
-  RUSTC_WRAPPER: "sccache"
+  #SCCACHE_GHA_ENABLED: "true"
+  #RUSTC_WRAPPER: "sccache"
   IMAGE: ghcr.io/matrix-org/matrix-authentication-service
   IMAGE_SYN2MAS: ghcr.io/matrix-org/matrix-authentication-service/syn2mas
   BUILDCACHE: ghcr.io/matrix-org/matrix-authentication-service/buildcache
@@ -57,8 +57,8 @@ jobs:
             x86_64-apple-darwin
             aarch64-apple-darwin
 
-      - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.5
+      #- name: Setup sccache
+      #  uses: mozilla-actions/sccache-action@v0.0.5
 
       - name: Install zig
         uses: goto-bus-stop/setup-zig@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,14 +9,12 @@
 ARG DEBIAN_VERSION=12
 ARG DEBIAN_VERSION_NAME=bookworm
 ARG RUSTC_VERSION=1.80.0
-# XXX: Upgrade to 0.10.0 blocked by https://github.com/ziglang/zig/issues/10915#issuecomment-1354548110
-# XXX: Upgrade to 0.11.0 blocked by https://github.com/rust-cross/cargo-zigbuild/issues/162
-ARG ZIG_VERSION=0.9.1
-ARG NODEJS_VERSION=20.12.2
+ARG ZIG_VERSION=0.13.0
+ARG NODEJS_VERSION=20.15.0
 ARG OPA_VERSION=0.64.1
-ARG CARGO_AUDITABLE_VERSION=0.6.3
-ARG CARGO_CHEF_VERSION=0.1.66
-ARG CARGO_ZIGBUILD_VERSION=0.18.4
+ARG CARGO_AUDITABLE_VERSION=0.6.4
+ARG CARGO_CHEF_VERSION=0.1.67
+ARG CARGO_ZIGBUILD_VERSION=0.19.0
 
 ##########################################
 ## Build stage that builds the frontend ##

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,12 +9,10 @@
 ARG DEBIAN_VERSION=12
 ARG DEBIAN_VERSION_NAME=bookworm
 ARG RUSTC_VERSION=1.80.0
-ARG ZIG_VERSION=0.13.0
 ARG NODEJS_VERSION=20.15.0
 ARG OPA_VERSION=0.64.1
 ARG CARGO_AUDITABLE_VERSION=0.6.4
 ARG CARGO_CHEF_VERSION=0.1.67
-ARG CARGO_ZIGBUILD_VERSION=0.19.0
 
 ##########################################
 ## Build stage that builds the frontend ##
@@ -65,26 +63,17 @@ FROM --platform=${BUILDPLATFORM} docker.io/library/rust:${RUSTC_VERSION}-${DEBIA
 
 ARG CARGO_AUDITABLE_VERSION
 ARG CARGO_CHEF_VERSION
-ARG CARGO_ZIGBUILD_VERSION
 ARG RUSTC_VERSION
-ARG ZIG_VERSION
 
 # Make cargo use the git cli for fetching dependencies
 ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
 
-# Install pinned versions of cargo-chef, cargo-zigbuild and cargo-auditable
+# Install pinned versions of cargo-chef and cargo-auditable
 # Network access: to fetch dependencies
 RUN --network=default \
   cargo install --locked \
   cargo-chef@=${CARGO_CHEF_VERSION} \
-  cargo-zigbuild@=${CARGO_ZIGBUILD_VERSION} \
   cargo-auditable@=${CARGO_AUDITABLE_VERSION}
-
-# Download zig compiler for cross-compilation
-# Network access: to download zig
-RUN --network=default \
-  curl -L "https://ziglang.org/download/${ZIG_VERSION}/zig-linux-$(uname -m)-${ZIG_VERSION}.tar.xz" | tar -J -x -C /usr/local && \
-  ln -s "/usr/local/zig-linux-$(uname -m)-${ZIG_VERSION}/zig" /usr/local/bin/zig
 
 # Install all cross-compilation targets
 # Network access: to download the targets
@@ -93,6 +82,31 @@ RUN --network=default \
   --toolchain "${RUSTC_VERSION}" \
   x86_64-unknown-linux-gnu \
   aarch64-unknown-linux-gnu
+
+RUN --network=none \
+  dpkg --add-architecture arm64 && \
+  dpkg --add-architecture amd64
+
+ARG BUILDPLATFORM
+
+# Install cross-compilation toolchains for all supported targets
+# Network access: to install apt packages
+RUN --network=default \
+  apt-get update && apt-get install -y \
+  $(if [ "${BUILDPLATFORM}" != "linux/arm64" ]; then echo "g++-aarch64-linux-gnu"; fi) \
+  $(if [ "${BUILDPLATFORM}" != "linux/amd64" ]; then echo "g++-x86-64-linux-gnu"; fi) \
+  libc6-dev-amd64-cross \
+  libc6-dev-arm64-cross \
+  g++
+
+# Setup the cross-compilation environment
+ENV \
+  CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc \
+  CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc \
+  CXX_aarch64_unknown_linux_gnu=aarch64-linux-gnu-g++ \
+  CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=x86_64-linux-gnu-gcc \
+  CC_x86_64_unknown_linux_gnu=x86_64-linux-gnu-gcc \
+  CXX_x86_64_unknown_linux_gnu=x86_64-linux-gnu-g++
 
 # Set the working directory
 WORKDIR /app
@@ -116,7 +130,6 @@ COPY --from=planner /app/recipe.json recipe.json
 # Network access: cargo-chef cook fetches the dependencies
 RUN --network=default \
   cargo chef cook \
-  --zigbuild \
   --bin mas-cli \
   --release \
   --recipe-path recipe.json \
@@ -132,7 +145,7 @@ COPY ./crates /app/crates
 ENV SQLX_OFFLINE=true
 # Network access: cargo auditable needs it
 RUN --network=default \
-  cargo auditable zigbuild \
+  cargo auditable build \
   --locked \
   --release \
   --bin mas-cli \
@@ -160,7 +173,7 @@ COPY ./translations/ /share/translations
 ##################################
 ## Runtime stage, debug variant ##
 ##################################
-FROM --platform=${TARGETPLATFORM} gcr.io/distroless/base-nossl-debian${DEBIAN_VERSION}:debug-nonroot AS debug
+FROM --platform=${TARGETPLATFORM} gcr.io/distroless/cc-debian${DEBIAN_VERSION}:debug-nonroot AS debug
 
 ARG TARGETARCH
 COPY --from=builder /usr/local/bin/mas-cli-${TARGETARCH} /usr/local/bin/mas-cli
@@ -172,7 +185,7 @@ ENTRYPOINT ["/usr/local/bin/mas-cli"]
 ###################
 ## Runtime stage ##
 ###################
-FROM --platform=${TARGETPLATFORM} gcr.io/distroless/base-nossl-debian${DEBIAN_VERSION}:nonroot
+FROM --platform=${TARGETPLATFORM} gcr.io/distroless/cc-debian${DEBIAN_VERSION}:nonroot
 
 ARG TARGETARCH
 COPY --from=builder /usr/local/bin/mas-cli-${TARGETARCH} /usr/local/bin/mas-cli


### PR DESCRIPTION
Building of macOS binaries started failing since we moved to the aws-lc-rs backend for crypto instead of the ring one. This removes the building of those binaries, since probably no one uses them?

This upgrades to the latests `cargo-zigbuild` and `zig`

This also removes `cargo-zigbuild` from the docker build, as we don't care about supporting old glibc there