### PR TITLE
Allow reactivating users on the homeserver

### DIFF
--- a/crates/handlers/src/graphql/model/matrix.rs
+++ b/crates/handlers/src/graphql/model/matrix.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 The Matrix.org Foundation C.I.C.
+// Copyright 2023, 2024 The Matrix.org Foundation C.I.C.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -25,6 +25,9 @@ pub struct MatrixUser {
 
     /// The avatar URL of the user, if any.
     avatar_url: Option<String>,
+
+    /// Whether the user is deactivated on the homeserver.
+    deactivated: bool,
 }
 
 impl MatrixUser {
@@ -40,6 +43,7 @@ impl MatrixUser {
             mxid,
             display_name: info.displayname,
             avatar_url: info.avatar_url,
+            deactivated: info.deactivated,
         })
     }
 }

--- a/crates/matrix-synapse/src/lib.rs
+++ b/crates/matrix-synapse/src/lib.rs
@@ -217,6 +217,7 @@ impl HomeserverConnection for SynapseConnection {
         Ok(MatrixUser {
             displayname: body.display_name,
             avatar_url: body.avatar_url,
+            deactivated: body.deactivated.unwrap_or(false),
         })
     }
 

--- a/crates/matrix/src/lib.rs
+++ b/crates/matrix/src/lib.rs
@@ -26,6 +26,7 @@ pub type BoxHomeserverConnection<Error = anyhow::Error> =
 pub struct MatrixUser {
     pub displayname: Option<String>,
     pub avatar_url: Option<String>,
+    pub deactivated: bool,
 }
 
 #[derive(Debug, Default)]

--- a/crates/matrix/src/lib.rs
+++ b/crates/matrix/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 The Matrix.org Foundation C.I.C.
+// Copyright 2023, 2024 The Matrix.org Foundation C.I.C.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -288,6 +288,18 @@ pub trait HomeserverConnection: Send + Sync {
     /// be deleted.
     async fn delete_user(&self, mxid: &str, erase: bool) -> Result<(), Self::Error>;
 
+    /// Reactivate a user on the homeserver.
+    ///
+    /// # Parameters
+    ///
+    /// * `mxid` - The Matrix ID of the user to reactivate.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the homeserver is unreachable or the user could not
+    /// be reactivated.
+    async fn reactivate_user(&self, mxid: &str) -> Result<(), Self::Error>;
+
     /// Set the displayname of a user on the homeserver.
     ///
     /// # Parameters
@@ -362,6 +374,10 @@ impl<T: HomeserverConnection + Send + Sync + ?Sized> HomeserverConnection for &T
         (**self).delete_user(mxid, erase).await
     }
 
+    async fn reactivate_user(&self, mxid: &str) -> Result<(), Self::Error> {
+        (**self).reactivate_user(mxid).await
+    }
+
     async fn set_displayname(&self, mxid: &str, displayname: &str) -> Result<(), Self::Error> {
         (**self).set_displayname(mxid, displayname).await
     }
@@ -410,6 +426,10 @@ impl<T: HomeserverConnection + ?Sized> HomeserverConnection for Arc<T> {
 
     async fn delete_user(&self, mxid: &str, erase: bool) -> Result<(), Self::Error> {
         (**self).delete_user(mxid, erase).await
+    }
+
+    async fn reactivate_user(&self, mxid: &str) -> Result<(), Self::Error> {
+        (**self).reactivate_user(mxid).await
     }
 
     async fn set_displayname(&self, mxid: &str, displayname: &str) -> Result<(), Self::Error> {

--- a/crates/matrix/src/mock.rs
+++ b/crates/matrix/src/mock.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 The Matrix.org Foundation C.I.C.
+// Copyright 2023, 2024 The Matrix.org Foundation C.I.C.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -145,6 +145,10 @@ impl crate::HomeserverConnection for HomeserverConnection {
             user.displayname = None;
         }
 
+        Ok(())
+    }
+
+    async fn reactivate_user(&self, _mxid: &str) -> Result<(), Self::Error> {
         Ok(())
     }
 

--- a/crates/storage/src/job.rs
+++ b/crates/storage/src/job.rs
@@ -455,6 +455,34 @@ mod jobs {
         const NAME: &'static str = "deactivate-user";
     }
 
+    /// A job to reactivate a user
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct ReactivateUserJob {
+        user_id: Ulid,
+    }
+
+    impl ReactivateUserJob {
+        /// Create a new job to reactivate a user
+        ///
+        /// # Parameters
+        ///
+        /// * `user` - The user to reactivate
+        #[must_use]
+        pub fn new(user: &User) -> Self {
+            Self { user_id: user.id }
+        }
+
+        /// The ID of the user to reactivate
+        #[must_use]
+        pub fn user_id(&self) -> Ulid {
+            self.user_id
+        }
+    }
+
+    impl Job for ReactivateUserJob {
+        const NAME: &'static str = "reactivate-user";
+    }
+
     /// Send account recovery emails
     #[derive(Serialize, Deserialize, Debug, Clone)]
     pub struct SendAccountRecoveryEmailsJob {
@@ -489,6 +517,6 @@ mod jobs {
 }
 
 pub use self::jobs::{
-    DeactivateUserJob, DeleteDeviceJob, ProvisionDeviceJob, ProvisionUserJob,
+    DeactivateUserJob, DeleteDeviceJob, ProvisionDeviceJob, ProvisionUserJob, ReactivateUserJob,
     SendAccountRecoveryEmailsJob, SyncDevicesJob, VerifyEmailJob,
 };

--- a/frontend/schema.graphql
+++ b/frontend/schema.graphql
@@ -698,6 +698,10 @@ type MatrixUser {
   The avatar URL of the user, if any.
   """
   avatarUrl: String
+  """
+  Whether the user is deactivated on the homeserver.
+  """
+  deactivated: Boolean!
 }
 
 """

--- a/frontend/schema.graphql
+++ b/frontend/schema.graphql
@@ -735,6 +735,10 @@ type Mutation {
   """
   lockUser(input: LockUserInput!): LockUserPayload!
   """
+  Unlock a user. This is only available to administrators.
+  """
+  unlockUser(input: UnlockUserInput!): UnlockUserPayload!
+  """
   Set whether a user can request admin. This is only available to
   administrators.
   """
@@ -1397,6 +1401,44 @@ type SiteConfig implements Node {
   The ID of the site configuration.
   """
   id: ID!
+}
+
+"""
+The input for the `unlockUser` mutation.
+"""
+input UnlockUserInput {
+  """
+  The ID of the user to unlock
+  """
+  userId: ID!
+}
+
+"""
+The payload for the `unlockUser` mutation.
+"""
+type UnlockUserPayload {
+  """
+  Status of the operation
+  """
+  status: UnlockUserStatus!
+  """
+  The user that was unlocked.
+  """
+  user: User
+}
+
+"""
+The status of the `unlockUser` mutation.
+"""
+enum UnlockUserStatus {
+  """
+  The user was unlocked.
+  """
+  UNLOCKED
+  """
+  The user was not found.
+  """
+  NOT_FOUND
 }
 
 type UpstreamOAuth2Link implements Node & CreationEvent {

--- a/frontend/src/gql/graphql.ts
+++ b/frontend/src/gql/graphql.ts
@@ -449,6 +449,8 @@ export type MatrixUser = {
   __typename?: 'MatrixUser';
   /** The avatar URL of the user, if any. */
   avatarUrl?: Maybe<Scalars['String']['output']>;
+  /** Whether the user is deactivated on the homeserver. */
+  deactivated: Scalars['Boolean']['output'];
   /** The display name of the user, if any. */
   displayName?: Maybe<Scalars['String']['output']>;
   /** The Matrix ID of the user. */

--- a/frontend/src/gql/graphql.ts
+++ b/frontend/src/gql/graphql.ts
@@ -497,6 +497,8 @@ export type Mutation = {
   setPassword: SetPasswordPayload;
   /** Set an email address as primary */
   setPrimaryEmail: SetPrimaryEmailPayload;
+  /** Unlock a user. This is only available to administrators. */
+  unlockUser: UnlockUserPayload;
   /** Submit a verification code for an email address */
   verifyEmail: VerifyEmailPayload;
 };
@@ -583,6 +585,12 @@ export type MutationSetPasswordArgs = {
 /** The mutations root of the GraphQL interface. */
 export type MutationSetPrimaryEmailArgs = {
   input: SetPrimaryEmailInput;
+};
+
+
+/** The mutations root of the GraphQL interface. */
+export type MutationUnlockUserArgs = {
+  input: UnlockUserInput;
 };
 
 
@@ -1039,6 +1047,29 @@ export type SiteConfig = Node & {
   /** The URL to the terms of service. */
   tosUri?: Maybe<Scalars['Url']['output']>;
 };
+
+/** The input for the `unlockUser` mutation. */
+export type UnlockUserInput = {
+  /** The ID of the user to unlock */
+  userId: Scalars['ID']['input'];
+};
+
+/** The payload for the `unlockUser` mutation. */
+export type UnlockUserPayload = {
+  __typename?: 'UnlockUserPayload';
+  /** Status of the operation */
+  status: UnlockUserStatus;
+  /** The user that was unlocked. */
+  user?: Maybe<User>;
+};
+
+/** The status of the `unlockUser` mutation. */
+export enum UnlockUserStatus {
+  /** The user was not found. */
+  NotFound = 'NOT_FOUND',
+  /** The user was unlocked. */
+  Unlocked = 'UNLOCKED'
+}
 
 export type UpstreamOAuth2Link = CreationEvent & Node & {
   __typename?: 'UpstreamOAuth2Link';

--- a/frontend/src/gql/schema.ts
+++ b/frontend/src/gql/schema.ts
@@ -1121,6 +1121,17 @@ export default {
             "args": []
           },
           {
+            "name": "deactivated",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Any"
+              }
+            },
+            "args": []
+          },
+          {
             "name": "displayName",
             "type": {
               "kind": "SCALAR",

--- a/frontend/src/gql/schema.ts
+++ b/frontend/src/gql/schema.ts
@@ -1469,6 +1469,29 @@ export default {
             ]
           },
           {
+            "name": "unlockUser",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "UnlockUserPayload",
+                "ofType": null
+              }
+            },
+            "args": [
+              {
+                "name": "input",
+                "type": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Any"
+                  }
+                }
+              }
+            ]
+          },
+          {
             "name": "verifyEmail",
             "type": {
               "kind": "NON_NULL",
@@ -2621,6 +2644,33 @@ export default {
             "name": "Node"
           }
         ]
+      },
+      {
+        "kind": "OBJECT",
+        "name": "UnlockUserPayload",
+        "fields": [
+          {
+            "name": "status",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Any"
+              }
+            },
+            "args": []
+          },
+          {
+            "name": "user",
+            "type": {
+              "kind": "OBJECT",
+              "name": "User",
+              "ofType": null
+            },
+            "args": []
+          }
+        ],
+        "interfaces": []
       },
       {
         "kind": "OBJECT",


### PR DESCRIPTION
- **Add a way to reactivate users on the homeserver**
- **GraphQL API to unlock a user**
- **Show whether the user is deactivated on the homeserver in the GraphQL API**

Fixes #2101
Fixes #2375
