### PR TITLE
Fully sync the devices with the homeserver

### DIFF
--- a/crates/handlers/src/compat/login.rs
+++ b/crates/handlers/src/compat/login.rs
@@ -419,6 +419,9 @@ async fn user_password_login(
             .await?;
     }
 
+    // Lock the user sync to make sure we don't get into a race condition
+    repo.user().acquire_lock_for_sync(&user).await?;
+
     // Now that the user credentials have been verified, start a new compat session
     let device = Device::generate(&mut rng);
     let mxid = homeserver.mxid(&user.username);

--- a/crates/handlers/src/compat/login_sso_complete.rs
+++ b/crates/handlers/src/compat/login_sso_complete.rs
@@ -202,6 +202,9 @@ pub async fn post(
         redirect_uri
     };
 
+    // Lock the user sync to make sure we don't get into a race condition
+    repo.user().acquire_lock_for_sync(&session.user).await?;
+
     let device = Device::generate(&mut rng);
     let mxid = homeserver.mxid(&session.user.username);
     homeserver

--- a/crates/handlers/src/compat/login_sso_complete.rs
+++ b/crates/handlers/src/compat/login_sso_complete.rs
@@ -27,10 +27,10 @@ use mas_axum_utils::{
     FancyError, SessionInfoExt,
 };
 use mas_data_model::Device;
+use mas_matrix::BoxHomeserverConnection;
 use mas_router::{CompatLoginSsoAction, PostAuthAction, UrlBuilder};
 use mas_storage::{
     compat::{CompatSessionRepository, CompatSsoLoginRepository},
-    job::{JobRepositoryExt, ProvisionDeviceJob},
     BoxClock, BoxRepository, BoxRng, Clock, RepositoryAccess,
 };
 use mas_templates::{CompatSsoContext, ErrorContext, TemplateContext, Templates};
@@ -136,6 +136,7 @@ pub async fn post(
     PreferredLanguage(locale): PreferredLanguage,
     State(templates): State<Templates>,
     State(url_builder): State<UrlBuilder>,
+    State(homeserver): State<BoxHomeserverConnection>,
     cookie_jar: CookieJar,
     Path(id): Path<Ulid>,
     Query(params): Query<Params>,
@@ -202,9 +203,11 @@ pub async fn post(
     };
 
     let device = Device::generate(&mut rng);
-    repo.job()
-        .schedule_job(ProvisionDeviceJob::new(&session.user, &device))
-        .await?;
+    let mxid = homeserver.mxid(&session.user.username);
+    homeserver
+        .create_device(&mxid, device.as_str())
+        .await
+        .context("Failed to provision device")?;
 
     let compat_session = repo
         .compat_session()

--- a/crates/handlers/src/graphql/mutations/compat_session.rs
+++ b/crates/handlers/src/graphql/mutations/compat_session.rs
@@ -16,7 +16,7 @@ use anyhow::Context as _;
 use async_graphql::{Context, Enum, InputObject, Object, ID};
 use mas_storage::{
     compat::CompatSessionRepository,
-    job::{DeleteDeviceJob, JobRepositoryExt},
+    job::{JobRepositoryExt, SyncDevicesJob},
     RepositoryAccess,
 };
 
@@ -101,10 +101,8 @@ impl CompatSessionMutations {
             .await?
             .context("Could not load user")?;
 
-        // Schedule a job to delete the device.
-        repo.job()
-            .schedule_job(DeleteDeviceJob::new(&user, &session.device))
-            .await?;
+        // Schedule a job to sync the devices of the user with the homeserver
+        repo.job().schedule_job(SyncDevicesJob::new(&user)).await?;
 
         let session = repo.compat_session().finish(&clock, session).await?;
 

--- a/crates/handlers/src/graphql/mutations/oauth2_session.rs
+++ b/crates/handlers/src/graphql/mutations/oauth2_session.rs
@@ -168,6 +168,9 @@ impl OAuth2SessionMutations {
             .add(&mut rng, &clock, &client, Some(&user), None, scope)
             .await?;
 
+        // Lock the user sync to make sure we don't get into a race condition
+        repo.user().acquire_lock_for_sync(&user).await?;
+
         // Look for devices to provision
         let mxid = homeserver.mxid(&user.username);
         for scope in &*session.scope {

--- a/crates/handlers/src/lib.rs
+++ b/crates/handlers/src/lib.rs
@@ -186,6 +186,7 @@ where
     Encrypter: FromRef<S>,
     HttpClientFactory: FromRef<S>,
     SiteConfig: FromRef<S>,
+    BoxHomeserverConnection: FromRef<S>,
     BoxClock: FromRequestParts<S>,
     BoxRng: FromRequestParts<S>,
     Policy: FromRequestParts<S>,

--- a/crates/handlers/src/oauth2/introspection.rs
+++ b/crates/handlers/src/oauth2/introspection.rs
@@ -461,6 +461,7 @@ mod tests {
     use hyper::{Request, StatusCode};
     use mas_data_model::{AccessToken, RefreshToken};
     use mas_iana::oauth::OAuthTokenTypeHint;
+    use mas_matrix::{HomeserverConnection, ProvisionRequest};
     use mas_router::{OAuth2Introspection, OAuth2RegistrationEndpoint, SimpleRoute};
     use mas_storage::Clock;
     use oauth2_types::{
@@ -515,6 +516,13 @@ mod tests {
         let user = repo
             .user()
             .add(&mut state.rng(), &state.clock, "alice".to_owned())
+            .await
+            .unwrap();
+
+        let mxid = state.homeserver_connection.mxid(&user.username);
+        state
+            .homeserver_connection
+            .provision_user(&ProvisionRequest::new(mxid, &user.sub))
             .await
             .unwrap();
 
@@ -700,6 +708,13 @@ mod tests {
         let user = repo
             .user()
             .add(&mut state.rng(), &state.clock, "alice".to_owned())
+            .await
+            .unwrap();
+
+        let mxid = state.homeserver_connection.mxid(&user.username);
+        state
+            .homeserver_connection
+            .provision_user(&ProvisionRequest::new(mxid, &user.sub))
             .await
             .unwrap();
 

--- a/crates/handlers/src/oauth2/token.rs
+++ b/crates/handlers/src/oauth2/token.rs
@@ -461,6 +461,11 @@ async fn authorization_code_grant(
         params = params.with_id_token(id_token);
     }
 
+    // Lock the user sync to make sure we don't get into a race condition
+    repo.user()
+        .acquire_lock_for_sync(&browser_session.user)
+        .await?;
+
     // Look for device to provision
     let mxid = homeserver.mxid(&browser_session.user.username);
     for scope in &*session.scope {
@@ -747,6 +752,11 @@ async fn device_code_grant(
 
         params = params.with_id_token(id_token);
     }
+
+    // Lock the user sync to make sure we don't get into a race condition
+    repo.user()
+        .acquire_lock_for_sync(&browser_session.user)
+        .await?;
 
     // Look for device to provision
     let mxid = homeserver.mxid(&browser_session.user.username);

--- a/crates/matrix/src/lib.rs
+++ b/crates/matrix/src/lib.rs
@@ -14,7 +14,7 @@
 
 mod mock;
 
-use std::sync::Arc;
+use std::{collections::HashSet, sync::Arc};
 
 pub use self::mock::HomeserverConnection as MockHomeserverConnection;
 
@@ -262,6 +262,19 @@ pub trait HomeserverConnection: Send + Sync {
     /// not be deleted.
     async fn delete_device(&self, mxid: &str, device_id: &str) -> Result<(), Self::Error>;
 
+    /// Sync the list of devices of a user with the homeserver.
+    ///
+    /// # Parameters
+    ///
+    /// * `mxid` - The Matrix ID of the user to sync the devices for.
+    /// * `devices` - The list of devices to sync.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the homeserver is unreachable or the devices could
+    /// not be synced.
+    async fn sync_devices(&self, mxid: &str, devices: HashSet<String>) -> Result<(), Self::Error>;
+
     /// Delete a user on the homeserver.
     ///
     /// # Parameters
@@ -341,6 +354,10 @@ impl<T: HomeserverConnection + Send + Sync + ?Sized> HomeserverConnection for &T
         (**self).delete_device(mxid, device_id).await
     }
 
+    async fn sync_devices(&self, mxid: &str, devices: HashSet<String>) -> Result<(), Self::Error> {
+        (**self).sync_devices(mxid, devices).await
+    }
+
     async fn delete_user(&self, mxid: &str, erase: bool) -> Result<(), Self::Error> {
         (**self).delete_user(mxid, erase).await
     }
@@ -385,6 +402,10 @@ impl<T: HomeserverConnection + ?Sized> HomeserverConnection for Arc<T> {
 
     async fn delete_device(&self, mxid: &str, device_id: &str) -> Result<(), Self::Error> {
         (**self).delete_device(mxid, device_id).await
+    }
+
+    async fn sync_devices(&self, mxid: &str, devices: HashSet<String>) -> Result<(), Self::Error> {
+        (**self).sync_devices(mxid, devices).await
     }
 
     async fn delete_user(&self, mxid: &str, erase: bool) -> Result<(), Self::Error> {

--- a/crates/matrix/src/mock.rs
+++ b/crates/matrix/src/mock.rs
@@ -128,6 +128,13 @@ impl crate::HomeserverConnection for HomeserverConnection {
         Ok(())
     }
 
+    async fn sync_devices(&self, mxid: &str, devices: HashSet<String>) -> Result<(), Self::Error> {
+        let mut users = self.users.write().await;
+        let user = users.get_mut(mxid).context("User not found")?;
+        user.devices = devices;
+        Ok(())
+    }
+
     async fn delete_user(&self, mxid: &str, erase: bool) -> Result<(), Self::Error> {
         let mut users = self.users.write().await;
         let user = users.get_mut(mxid).context("User not found")?;

--- a/crates/storage-pg/.sqlx/query-e68a7084d44462d19f30902d7e6c1bd60bb771c6f075df15ab0137a7ffc896da.json
+++ b/crates/storage-pg/.sqlx/query-e68a7084d44462d19f30902d7e6c1bd60bb771c6f075df15ab0137a7ffc896da.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                SELECT pg_advisory_xact_lock($1)\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "pg_advisory_xact_lock",
+        "type_info": "Void"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "e68a7084d44462d19f30902d7e6c1bd60bb771c6f075df15ab0137a7ffc896da"
+}

--- a/crates/storage/src/job.rs
+++ b/crates/storage/src/job.rs
@@ -394,6 +394,31 @@ mod jobs {
         const NAME: &'static str = "delete-device";
     }
 
+    /// A job which syncs the list of devices of a user with the homeserver
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct SyncDevicesJob {
+        user_id: Ulid,
+    }
+
+    impl SyncDevicesJob {
+        /// Create a new job to sync the list of devices of a user with the
+        /// homeserver
+        #[must_use]
+        pub fn new(user: &User) -> Self {
+            Self { user_id: user.id }
+        }
+
+        /// The ID of the user to sync the devices for
+        #[must_use]
+        pub fn user_id(&self) -> Ulid {
+            self.user_id
+        }
+    }
+
+    impl Job for SyncDevicesJob {
+        const NAME: &'static str = "sync-devices";
+    }
+
     /// A job to deactivate and lock a user
     #[derive(Serialize, Deserialize, Debug, Clone)]
     pub struct DeactivateUserJob {
@@ -468,5 +493,5 @@ mod jobs {
 
 pub use self::jobs::{
     DeactivateUserJob, DeleteDeviceJob, ProvisionDeviceJob, ProvisionUserJob,
-    SendAccountRecoveryEmailsJob, VerifyEmailJob,
+    SendAccountRecoveryEmailsJob, SyncDevicesJob, VerifyEmailJob,
 };

--- a/crates/storage/src/job.rs
+++ b/crates/storage/src/job.rs
@@ -327,6 +327,9 @@ mod jobs {
     }
 
     /// A job to provision a device for a user on the homeserver.
+    ///
+    /// This job is deprecated, use the `SyncDevicesJob` instead. It is kept to
+    /// not break existing jobs in the database.
     #[derive(Serialize, Deserialize, Debug, Clone)]
     pub struct ProvisionDeviceJob {
         user_id: Ulid,
@@ -334,15 +337,6 @@ mod jobs {
     }
 
     impl ProvisionDeviceJob {
-        /// Create a new job to provision a device for a user on the homeserver.
-        #[must_use]
-        pub fn new(user: &User, device: &Device) -> Self {
-            Self {
-                user_id: user.id,
-                device_id: device.as_str().to_owned(),
-            }
-        }
-
         /// The ID of the user to provision the device for.
         #[must_use]
         pub fn user_id(&self) -> Ulid {
@@ -361,6 +355,9 @@ mod jobs {
     }
 
     /// A job to delete a device for a user on the homeserver.
+    ///
+    /// This job is deprecated, use the `SyncDevicesJob` instead. It is kept to
+    /// not break existing jobs in the database.
     #[derive(Serialize, Deserialize, Debug, Clone)]
     pub struct DeleteDeviceJob {
         user_id: Ulid,

--- a/crates/storage/src/user/mod.rs
+++ b/crates/storage/src/user/mod.rs
@@ -259,6 +259,19 @@ pub trait UserRepository: Send + Sync {
     ///
     /// Returns [`Self::Error`] if the underlying repository fails
     async fn count(&mut self, filter: UserFilter<'_>) -> Result<usize, Self::Error>;
+
+    /// Acquire a lock on the user to make sure device operations are done in a
+    /// sequential way. The lock is released when the repository is saved or
+    /// rolled back.
+    ///
+    /// # Parameters
+    ///
+    /// * `user`: The user to lock
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Self::Error`] if the underlying repository fails
+    async fn acquire_lock_for_sync(&mut self, user: &User) -> Result<(), Self::Error>;
 }
 
 repository_impl!(UserRepository:
@@ -284,4 +297,5 @@ repository_impl!(UserRepository:
         pagination: Pagination,
     ) -> Result<Page<User>, Self::Error>;
     async fn count(&mut self, filter: UserFilter<'_>) -> Result<usize, Self::Error>;
+    async fn acquire_lock_for_sync(&mut self, user: &User) -> Result<(), Self::Error>;
 );

--- a/crates/tasks/src/matrix.rs
+++ b/crates/tasks/src/matrix.rs
@@ -225,8 +225,9 @@ async fn sync_devices(
         }
     }
 
-    // We now have a complete list of devices, so we can sync them with the
-    // homeserver
+    // We now have a complete list of devices, we can now release the connection and
+    // sync with the homeserver
+    repo.save().await?;
     let mxid = matrix.mxid(&user.username);
     matrix.sync_devices(&mxid, devices).await?;
 


### PR DESCRIPTION
Fixes #2626

When we end session, instead of imperatively delete devices, we now sync the device list with Synapse.
This means that if two sessions have the same device, it will not wrongly delete the device.
It also means it's less likely for the device list to get out of sync.

This also makes all the devices creation synchronous, to make sure they exist on Synapse before we start using the new sessions.

This also uses per-user PG advisory locks around device syncing, to make sure we don't have race conditions when syncing those

<details><summary>Old rant about locking kept for posterity</summary>

**One thing which I'm very not sure about** is that there is potential races between the device creations and the device sync.
If there is an ongoing sync job, the sync job might build a list of devices from the database that doesn't have a new device. That device may already have been created from somewhere else on the homeserver, but haven't been committed yet to the database.
If this is the case, the device syncing job will delete from the homeserver the newly added device.

This is very unlikely to happen though, as we would need the user to login and logout at the same time. I'm not sure what the best way would be to make sure it never happens. A few possibilities I have in mind:

 - use a PG advisory lock around any device list modification
 - make device syncing/deletion only consider devices that were recently deleted (looking at the finished_at timestamp)
 - put the devices to delete in a staged zone, so that they get deleted a bit later on (30s-1min), confirming that they are indeed not in the database anymore
 - rework the job queue, so that we can schedule jobs in the future (like in 30s) and dedupe them. This way, any modification to the device list would trigger a full sync a little later, and those sync would happen only if there was no sync for that user in the last 30s
 - revert the 'synchronous' part of device creation, so that we do them through device syncs, which, assuming jobs are run one after another, should mean we don't have devices flipping from one state to another

</details>