### PR TITLE
Proof of concept of embedding a smaller react app

### DIFF
--- a/frontend/src/recovery.tsx
+++ b/frontend/src/recovery.tsx
@@ -1,0 +1,49 @@
+// Copyright 2024 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Form } from "@vector-im/compound-web";
+import { Suspense, StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { I18nextProvider } from "react-i18next";
+import { Provider as UrqlProvider } from "urql";
+
+import ErrorBoundary from "./components/ErrorBoundary";
+import LoadingScreen from "./components/LoadingScreen";
+import { client } from "./graphql";
+import i18n from "./i18n";
+import "./shared.css";
+
+createRoot(document.getElementById("recovery-form") as HTMLElement).render(
+  <StrictMode>
+    <UrqlProvider value={client}>
+      <ErrorBoundary>
+        <Suspense fallback={<LoadingScreen />}>
+          <I18nextProvider i18n={i18n}>
+            <Form.Root method="POST">
+              <Form.Field name="password">
+                <Form.Label>Password</Form.Label>
+                <Form.PasswordControl />
+              </Form.Field>
+              <Form.Field name="password_confirm">
+                <Form.Label>Confirm password</Form.Label>
+                <Form.PasswordControl />
+              </Form.Field>
+              <Form.Submit>Submit</Form.Submit>
+            </Form.Root>
+          </I18nextProvider>
+        </Suspense>
+      </ErrorBoundary>
+    </UrqlProvider>
+  </StrictMode>,
+);

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -64,6 +64,7 @@ export default defineConfig((env) => ({
     rollupOptions: {
       input: [
         resolve(__dirname, "src/main.tsx"),
+        resolve(__dirname, "src/recovery.tsx"),
         resolve(__dirname, "src/shared.css"),
         resolve(__dirname, "src/templates.css"),
       ],

--- a/templates/base.html
+++ b/templates/base.html
@@ -34,6 +34,7 @@ limitations under the License.
     {{ include_asset('src/shared.css') | indent(4) | safe }}
     {{ include_asset('src/templates.css') | indent(4) | safe }}
     {{ captcha.head() }}
+    {% block head %}{% endblock head %}
   </head>
   <body>
     <div class="layout-container">

--- a/templates/pages/recovery/finish.html
+++ b/templates/pages/recovery/finish.html
@@ -16,6 +16,11 @@ limitations under the License.
 
 {% extends "base.html" %}
 
+{% block head %}
+  {{ super() }}
+  {{ include_asset('src/recovery.tsx') | safe }}
+{% endblock head %}
+
 {% block content %}
   <header class="page-heading">
     <div class="icon">
@@ -28,28 +33,5 @@ limitations under the License.
     </div>
   </header>
 
-  <form class="cpd-form-root" method="POST">
-    {# Hidden username field so that password manager can save the username #}
-    <input class="hidden" aria-hidden="true" type="text" name="username" autocomplete="username" value="{{ user.username }}" />
-
-    {% if form.errors is not empty %}
-      {% for error in form.errors %}
-        <div class="text-critical font-medium">
-          {{ errors.form_error_message(error=error) }}
-        </div>
-      {% endfor %}
-    {% endif %}
-
-    <input type="hidden" name="csrf" value="{{ csrf_token }}" />
-
-    {% call(f) field.field(label=_("mas.recovery.finish.new"), name="new_password", form_state=form) %}
-      <input {{ field.attributes(f) }} class="cpd-text-control" type="password" autofocus autocomplete="new-password" required />
-    {% endcall %}
-
-    {% call(f) field.field(label=_("mas.recovery.finish.confirm"), name="new_password_confirm", form_state=form) %}
-      <input {{ field.attributes(f) }} class="cpd-text-control" type="password" autocomplete="new-password" required />
-    {% endcall %}
-
-    {{ button.button(text=_("mas.recovery.finish.save_and_continue"), type="submit") }}
-  </form>
+  <div id="recovery-form"></div>
 {% endblock content %}


### PR DESCRIPTION
Mainly for visibility, to prove that it's not that bad to do a small react 'island' somewhere

On top of #2985 

There are two approaches for this form:

 - We could make it submit 'in-app' with a GraphQL request. This means we still need to wire up the GraphQL endpoint (config thingy is not passed here)
 - We could make it submit natively (a regular form POST), but that means we still need to:
   - pass the csrf token to the react app
   - pass the minimum complexity
   - somehow surface errors if for some reason they failed on the backend side?
   - put in a `<noscript>` alternative?



OH AND CSS completely broke because CSS code splitting doesn't work :(

cc @reivilibre
