### PR TITLE
graphql: Add a SetPasswordByRecovery mutation to perform account recovery

### DIFF
--- a/frontend/schema.graphql
+++ b/frontend/schema.graphql
@@ -765,6 +765,10 @@ type Mutation {
   """
   setPassword(input: SetPasswordInput!): SetPasswordPayload!
   """
+  Set the password for yourself, using a recovery ticket sent by e-mail.
+  """
+  setPasswordByRecovery(input: SetPasswordByRecoveryInput!): SetPasswordPayload!
+  """
   Create a new arbitrary OAuth 2.0 Session.
 
   Only available for administrators.
@@ -1254,6 +1258,22 @@ enum SetDisplayNameStatus {
 }
 
 """
+The input for the `setPasswordByRecovery` mutation.
+"""
+input SetPasswordByRecoveryInput {
+  """
+  The recovery ticket to use.
+  This identifies the user as well as proving authorisation to perform the
+  recovery operation.
+  """
+  ticket: String!
+  """
+  The new password for the user.
+  """
+  newPassword: String!
+}
+
+"""
 The input for the `setPassword` mutation.
 """
 input SetPasswordInput {
@@ -1321,6 +1341,23 @@ enum SetPasswordStatus {
   provider.
   """
   PASSWORD_CHANGES_DISABLED
+  """
+  The specified recovery ticket does not exist.
+  """
+  NO_SUCH_RECOVERY_TICKET
+  """
+  The specified recovery ticket has already been used and cannot be used
+  again.
+  """
+  RECOVERY_TICKET_ALREADY_USED
+  """
+  The specified recovery ticket has expired.
+  """
+  EXPIRED_RECOVERY_TICKET
+  """
+  Your account is locked and you can't change its password.
+  """
+  ACCOUNT_LOCKED
 }
 
 """

--- a/frontend/src/gql/graphql.ts
+++ b/frontend/src/gql/graphql.ts
@@ -497,6 +497,8 @@ export type Mutation = {
    * current password.
    */
   setPassword: SetPasswordPayload;
+  /** Set the password for yourself, using a recovery ticket sent by e-mail. */
+  setPasswordByRecovery: SetPasswordPayload;
   /** Set an email address as primary */
   setPrimaryEmail: SetPrimaryEmailPayload;
   /** Unlock a user. This is only available to administrators. */
@@ -581,6 +583,12 @@ export type MutationSetDisplayNameArgs = {
 /** The mutations root of the GraphQL interface. */
 export type MutationSetPasswordArgs = {
   input: SetPasswordInput;
+};
+
+
+/** The mutations root of the GraphQL interface. */
+export type MutationSetPasswordByRecoveryArgs = {
+  input: SetPasswordByRecoveryInput;
 };
 
 
@@ -945,6 +953,18 @@ export enum SetDisplayNameStatus {
   Set = 'SET'
 }
 
+/** The input for the `setPasswordByRecovery` mutation. */
+export type SetPasswordByRecoveryInput = {
+  /** The new password for the user. */
+  newPassword: Scalars['String']['input'];
+  /**
+   * The recovery ticket to use.
+   * This identifies the user as well as proving authorisation to perform the
+   * recovery operation.
+   */
+  ticket: Scalars['String']['input'];
+};
+
 /** The input for the `setPassword` mutation. */
 export type SetPasswordInput = {
   /**
@@ -971,8 +991,12 @@ export type SetPasswordPayload = {
 
 /** The status of the `setPassword` mutation. */
 export enum SetPasswordStatus {
+  /** Your account is locked and you can't change its password. */
+  AccountLocked = 'ACCOUNT_LOCKED',
   /** The password was updated. */
   Allowed = 'ALLOWED',
+  /** The specified recovery ticket has expired. */
+  ExpiredRecoveryTicket = 'EXPIRED_RECOVERY_TICKET',
   /**
    * The new password is invalid. For example, it may not meet configured
    * security requirements.
@@ -988,12 +1012,19 @@ export enum SetPasswordStatus {
   NotFound = 'NOT_FOUND',
   /** The user doesn't have a current password to attempt to match against. */
   NoCurrentPassword = 'NO_CURRENT_PASSWORD',
+  /** The specified recovery ticket does not exist. */
+  NoSuchRecoveryTicket = 'NO_SUCH_RECOVERY_TICKET',
   /**
    * Password support has been disabled.
    * This usually means that login is handled by an upstream identity
    * provider.
    */
   PasswordChangesDisabled = 'PASSWORD_CHANGES_DISABLED',
+  /**
+   * The specified recovery ticket has already been used and cannot be used
+   * again.
+   */
+  RecoveryTicketAlreadyUsed = 'RECOVERY_TICKET_ALREADY_USED',
   /** The supplied current password was wrong. */
   WrongPassword = 'WRONG_PASSWORD'
 }

--- a/frontend/src/gql/schema.ts
+++ b/frontend/src/gql/schema.ts
@@ -1457,6 +1457,29 @@ export default {
             ]
           },
           {
+            "name": "setPasswordByRecovery",
+            "type": {
+              "kind": "NON_NULL",
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "SetPasswordPayload",
+                "ofType": null
+              }
+            },
+            "args": [
+              {
+                "name": "input",
+                "type": {
+                  "kind": "NON_NULL",
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Any"
+                  }
+                }
+              }
+            ]
+          },
+          {
             "name": "setPrimaryEmail",
             "type": {
               "kind": "NON_NULL",


### PR DESCRIPTION
Replaces #2982 and instead adds a whole new mutation for the account recovery case. I was sceptical at first but think this is actually fairly fine.