### PR TITLE
Bootstrap a new REST-like admin API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,6 +85,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "aide"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b0e3b97a21e41ec5c19bfd9b4fc1f7086be104f8b988681230247ffc91cc8ed"
+dependencies = [
+ "aide-macros",
+ "axum",
+ "axum-extra",
+ "bytes",
+ "cfg-if",
+ "http",
+ "indexmap 2.2.6",
+ "schemars",
+ "serde",
+ "serde_json",
+ "serde_qs",
+ "thiserror",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "aide-macros"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0487f8598afe49e6bc950a613a678bd962c4a6f431022ded62643c8b990301a"
+dependencies = [
+ "darling 0.20.9",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.68",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3283,6 +3318,7 @@ dependencies = [
 name = "mas-handlers"
 version = "0.9.0"
 dependencies = [
+ "aide",
  "anyhow",
  "argon2",
  "async-graphql",
@@ -3298,6 +3334,7 @@ dependencies = [
  "futures-util",
  "headers",
  "hyper",
+ "indexmap 2.2.6",
  "insta",
  "lettre",
  "mas-axum-utils",
@@ -3325,6 +3362,7 @@ dependencies = [
  "rand",
  "rand_chacha",
  "rustls 0.23.12",
+ "schemars",
  "sentry",
  "serde",
  "serde_json",
@@ -5249,6 +5287,7 @@ dependencies = [
  "chrono",
  "dyn-clone",
  "indexmap 1.9.3",
+ "indexmap 2.2.6",
  "schemars_derive",
  "serde",
  "serde_json",
@@ -5551,6 +5590,19 @@ checksum = "af99884400da37c88f5e9146b7f1fd0fbcae8f6eec4e9da38b67d05486f814a6"
 dependencies = [
  "itoa",
  "serde",
+]
+
+[[package]]
+name = "serde_qs"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd34f36fe4c5ba9654417139a9b3a20d2e1de6012ee678ad14d240c22c78d8d6"
+dependencies = [
+ "axum",
+ "futures",
+ "percent-encoding",
+ "serde",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,11 @@ mas-templates = { path = "./crates/templates/", version = "=0.9.0" }
 mas-tower = { path = "./crates/tower/", version = "=0.9.0" }
 oauth2-types = { path = "./crates/oauth2-types/", version = "=0.9.0" }
 
+# OpenAPI schema generation and validation
+[workspace.dependencies.aide]
+version = "0.13.4"
+features = ["axum", "axum-headers", "macros"]
+
 # GraphQL server
 [workspace.dependencies.async-graphql]
 version = "7.0.7"

--- a/crates/axum-utils/src/error_wrapper.rs
+++ b/crates/axum-utils/src/error_wrapper.rs
@@ -16,13 +16,9 @@ use axum::response::{IntoResponse, Response};
 use http::StatusCode;
 
 /// A simple wrapper around an error that implements [`IntoResponse`].
-pub struct ErrorWrapper<T>(pub T);
-
-impl<T> From<T> for ErrorWrapper<T> {
-    fn from(input: T) -> Self {
-        Self(input)
-    }
-}
+#[derive(Debug, thiserror::Error)]
+#[error(transparent)]
+pub struct ErrorWrapper<T>(#[from] pub T);
 
 impl<T> IntoResponse for ErrorWrapper<T>
 where

--- a/crates/cli/src/app_state.rs
+++ b/crates/cli/src/app_state.rs
@@ -30,7 +30,7 @@ use mas_matrix::BoxHomeserverConnection;
 use mas_matrix_synapse::SynapseConnection;
 use mas_policy::{Policy, PolicyFactory};
 use mas_router::UrlBuilder;
-use mas_storage::{BoxClock, BoxRepository, BoxRng, Repository, SystemClock};
+use mas_storage::{BoxClock, BoxRepository, BoxRng, SystemClock};
 use mas_storage_pg::PgRepository;
 use mas_templates::Templates;
 use opentelemetry::{
@@ -351,8 +351,6 @@ impl FromRequestParts<AppState> for BoxRepository {
             histogram.record(duration_ms, &[]);
         }
 
-        Ok(repo
-            .map_err(mas_storage::RepositoryError::from_error)
-            .boxed())
+        Ok(repo.boxed())
     }
 }

--- a/crates/cli/src/server.rs
+++ b/crates/cli/src/server.rs
@@ -228,6 +228,10 @@ pub fn build_router(
             mas_config::HttpResource::Compat => {
                 router.merge(mas_handlers::compat_router::<AppState>())
             }
+            mas_config::HttpResource::AdminApi => {
+                let (_, api_router) = mas_handlers::admin_api_router::<AppState>();
+                router.merge(api_router)
+            }
             // TODO: do a better handler here
             mas_config::HttpResource::ConnectionInfo => router.route(
                 "/connection-info",

--- a/crates/config/src/sections/http.rs
+++ b/crates/config/src/sections/http.rs
@@ -312,6 +312,9 @@ pub enum Resource {
         path: Utf8PathBuf,
     },
 
+    /// Admin API, served at `/api/admin/v1`
+    AdminApi,
+
     /// Mount a "/connection-info" handler which helps debugging informations on
     /// the upstream connection
     #[serde(rename = "connection-info")]

--- a/crates/handlers/Cargo.toml
+++ b/crates/handlers/Cargo.toml
@@ -36,7 +36,9 @@ axum-macros = "0.4.1"
 axum-extra.workspace = true
 rustls.workspace = true
 
+aide.workspace = true
 async-graphql.workspace = true
+schemars.workspace = true
 
 # Emails
 lettre.workspace = true
@@ -65,6 +67,7 @@ zeroize = "1.8.1"
 base64ct = "1.6.0"
 camino.workspace = true
 chrono.workspace = true
+indexmap = "2.2.6"
 psl = "2.1.55"
 time = "0.3.36"
 url.workspace = true

--- a/crates/handlers/src/activity_tracker/worker.rs
+++ b/crates/handlers/src/activity_tracker/worker.rs
@@ -15,7 +15,7 @@
 use std::{collections::HashMap, net::IpAddr};
 
 use chrono::{DateTime, Utc};
-use mas_storage::{user::BrowserSessionRepository, Repository, RepositoryAccess};
+use mas_storage::{user::BrowserSessionRepository, RepositoryAccess};
 use opentelemetry::{
     metrics::{Counter, Histogram},
     Key,

--- a/crates/handlers/src/admin/call_context.rs
+++ b/crates/handlers/src/admin/call_context.rs
@@ -1,0 +1,226 @@
+// Copyright 2024 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::convert::Infallible;
+
+use aide::OperationIo;
+use axum::{
+    extract::FromRequestParts,
+    response::{IntoResponse, Response},
+    Json,
+};
+use axum_extra::TypedHeader;
+use headers::{authorization::Bearer, Authorization};
+use hyper::StatusCode;
+use mas_data_model::{Session, User};
+use mas_storage::{BoxClock, BoxRepository, RepositoryError};
+use ulid::Ulid;
+
+use super::response::ErrorResponse;
+use crate::BoundActivityTracker;
+
+#[derive(Debug, thiserror::Error)]
+pub enum Rejection {
+    /// The authorization header is missing
+    #[error("Missing authorization header")]
+    MissingAuthorizationHeader,
+
+    /// The authorization header is invalid
+    #[error("Invalid authorization header")]
+    InvalidAuthorizationHeader,
+
+    /// Couldn't load the database repository
+    #[error("Couldn't load the database repository")]
+    RepositorySetup(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
+
+    /// A database operation failed
+    #[error("Invalid repository operation")]
+    Repository(#[from] RepositoryError),
+
+    /// The access token could not be found in the database
+    #[error("Unknown access token")]
+    UnknownAccessToken,
+
+    /// The access token provided expired
+    #[error("Access token expired")]
+    TokenExpired,
+
+    /// The session associated with the access token was revoked
+    #[error("Access token revoked")]
+    SessionRevoked,
+
+    /// The user associated with the session is locked
+    #[error("User locked")]
+    UserLocked,
+
+    /// Failed to load the session
+    #[error("Failed to load session {0}")]
+    LoadSession(Ulid),
+
+    /// Failed to load the user
+    #[error("Failed to load user {0}")]
+    LoadUser(Ulid),
+
+    /// The session does not have the `urn:mas:admin` scope
+    #[error("Missing urn:mas:admin scope")]
+    MissingScope,
+}
+
+impl Rejection {
+    fn status_code(&self) -> StatusCode {
+        match self {
+            Self::InvalidAuthorizationHeader | Self::MissingAuthorizationHeader => {
+                StatusCode::BAD_REQUEST
+            }
+            Self::UnknownAccessToken
+            | Self::TokenExpired
+            | Self::SessionRevoked
+            | Self::UserLocked
+            | Self::MissingScope => StatusCode::UNAUTHORIZED,
+            _ => StatusCode::INTERNAL_SERVER_ERROR,
+        }
+    }
+}
+
+impl IntoResponse for Rejection {
+    fn into_response(self) -> Response {
+        let response = ErrorResponse::from_error(&self);
+        let status = self.status_code();
+        (status, Json(response)).into_response()
+    }
+}
+
+/// An extractor which authorizes the request
+///
+/// Because we need to load the database repository and the clock, we keep them
+/// in the context to avoid creating two instances for each request.
+#[non_exhaustive]
+#[derive(OperationIo)]
+#[aide(input)]
+pub struct CallContext {
+    pub repo: BoxRepository,
+    pub clock: BoxClock,
+    pub user: Option<User>,
+    pub session: Session,
+}
+
+#[async_trait::async_trait]
+impl<S> FromRequestParts<S> for CallContext
+where
+    S: Send + Sync,
+    BoundActivityTracker: FromRequestParts<S, Rejection = Infallible>,
+    BoxRepository: FromRequestParts<S>,
+    BoxClock: FromRequestParts<S, Rejection = Infallible>,
+    <BoxRepository as FromRequestParts<S>>::Rejection:
+        Into<Box<dyn std::error::Error + Send + Sync + 'static>>,
+{
+    type Rejection = Rejection;
+
+    async fn from_request_parts(
+        parts: &mut axum::http::request::Parts,
+        state: &S,
+    ) -> Result<Self, Self::Rejection> {
+        let activity_tracker = BoundActivityTracker::from_request_parts(parts, state).await;
+        let activity_tracker = match activity_tracker {
+            Ok(t) => t,
+            Err(e) => match e {},
+        };
+
+        let clock = BoxClock::from_request_parts(parts, state).await;
+        let clock = match clock {
+            Ok(c) => c,
+            Err(e) => match e {},
+        };
+
+        // Load the database repository
+        let mut repo = BoxRepository::from_request_parts(parts, state)
+            .await
+            .map_err(Into::into)
+            .map_err(Rejection::RepositorySetup)?;
+
+        // Extract the access token from the authorization header
+        let token = TypedHeader::<Authorization<Bearer>>::from_request_parts(parts, state)
+            .await
+            .map_err(|e| {
+                // We map to two differentsson of errors depending on whether the header is
+                // missing or invalid
+                if e.is_missing() {
+                    Rejection::MissingAuthorizationHeader
+                } else {
+                    Rejection::InvalidAuthorizationHeader
+                }
+            })?;
+
+        let token = token.token();
+
+        // Look for the access token in the database
+        let token = repo
+            .oauth2_access_token()
+            .find_by_token(token)
+            .await?
+            .ok_or(Rejection::UnknownAccessToken)?;
+
+        // Look for the associated session in the database
+        let session = repo
+            .oauth2_session()
+            .lookup(token.session_id)
+            .await?
+            .ok_or_else(|| Rejection::LoadSession(token.session_id))?;
+
+        // Record the activity on the session
+        activity_tracker
+            .record_oauth2_session(&clock, &session)
+            .await;
+
+        // Load the user if there is one
+        let user = if let Some(user_id) = session.user_id {
+            let user = repo
+                .user()
+                .lookup(user_id)
+                .await?
+                .ok_or_else(|| Rejection::LoadUser(user_id))?;
+            Some(user)
+        } else {
+            None
+        };
+
+        // If there is a user for this session, check that it is not locked
+        if let Some(user) = &user {
+            if !user.is_valid() {
+                return Err(Rejection::UserLocked);
+            }
+        }
+
+        if !session.is_valid() {
+            return Err(Rejection::SessionRevoked);
+        }
+
+        if !token.is_valid(clock.now()) {
+            return Err(Rejection::TokenExpired);
+        }
+
+        // For now, we only check that the session has the admin scope
+        // Later we might want to check other route-specific scopes
+        if !session.scope.contains("urn:mas:admin") {
+            return Err(Rejection::MissingScope);
+        }
+
+        Ok(Self {
+            repo,
+            clock,
+            user,
+            session,
+        })
+    }
+}

--- a/crates/handlers/src/admin/mod.rs
+++ b/crates/handlers/src/admin/mod.rs
@@ -1,0 +1,94 @@
+// Copyright 2024 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use aide::{
+    axum::ApiRouter,
+    openapi::{OAuth2Flow, OAuth2Flows, OpenApi, SecurityScheme, Server, ServerVariable},
+};
+use axum::{Json, Router};
+use hyper::header::{ACCEPT, AUTHORIZATION, CONTENT_TYPE};
+use indexmap::IndexMap;
+use mas_http::CorsLayerExt;
+use mas_router::{OAuth2AuthorizationEndpoint, OAuth2TokenEndpoint, SimpleRoute};
+use tower_http::cors::{Any, CorsLayer};
+
+pub fn router<S>() -> (OpenApi, Router<S>)
+where
+    S: Clone + Send + Sync + 'static,
+{
+    let mut api = OpenApi::default();
+    let router = ApiRouter::<S>::new()
+        // TODO: add routes
+        .finish_api_with(&mut api, |t| {
+            t.title("Matrix Authentication Service admin API")
+                .security_scheme(
+                    "oauth2",
+                    SecurityScheme::OAuth2 {
+                        flows: OAuth2Flows {
+                            client_credentials: Some(OAuth2Flow::ClientCredentials {
+                                refresh_url: Some(OAuth2TokenEndpoint::PATH.to_owned()),
+                                token_url: OAuth2TokenEndpoint::PATH.to_owned(),
+                                scopes: IndexMap::from([(
+                                    "urn:mas:admin".to_owned(),
+                                    "Grant access to the admin API".to_owned(),
+                                )]),
+                            }),
+                            authorization_code: Some(OAuth2Flow::AuthorizationCode {
+                                authorization_url: OAuth2AuthorizationEndpoint::PATH.to_owned(),
+                                refresh_url: Some(OAuth2TokenEndpoint::PATH.to_owned()),
+                                token_url: OAuth2TokenEndpoint::PATH.to_owned(),
+                                scopes: IndexMap::from([(
+                                    "urn:mas:admin".to_owned(),
+                                    "Grant access to the admin API".to_owned(),
+                                )]),
+                            }),
+                            implicit: None,
+                            password: None,
+                        },
+                        description: None,
+                        extensions: IndexMap::default(),
+                    },
+                )
+                .security_requirement_scopes("oauth2", ["urn:mas:admin"])
+                .server(Server {
+                    url: "{base}".to_owned(),
+                    variables: IndexMap::from([(
+                        "base".to_owned(),
+                        ServerVariable {
+                            default: "/".to_owned(),
+                            ..ServerVariable::default()
+                        },
+                    )]),
+                    ..Server::default()
+                })
+        });
+
+    let router = router
+        // Serve the OpenAPI spec as JSON
+        .route(
+            "/api/spec.json",
+            axum::routing::get({
+                let res = Json(api.clone());
+                move || std::future::ready(res.clone())
+            }),
+        )
+        .layer(
+            CorsLayer::new()
+                .allow_origin(Any)
+                .allow_methods(Any)
+                .allow_otel_headers([AUTHORIZATION, ACCEPT, CONTENT_TYPE]),
+        );
+
+    (api, router)
+}

--- a/crates/handlers/src/admin/mod.rs
+++ b/crates/handlers/src/admin/mod.rs
@@ -24,6 +24,7 @@ use mas_router::{OAuth2AuthorizationEndpoint, OAuth2TokenEndpoint, SimpleRoute};
 use tower_http::cors::{Any, CorsLayer};
 
 mod call_context;
+mod model;
 mod response;
 
 use self::call_context::CallContext;

--- a/crates/handlers/src/admin/mod.rs
+++ b/crates/handlers/src/admin/mod.rs
@@ -25,7 +25,9 @@ use tower_http::cors::{Any, CorsLayer};
 
 mod call_context;
 mod model;
+mod params;
 mod response;
+mod v1;
 
 use self::call_context::CallContext;
 
@@ -36,7 +38,7 @@ where
 {
     let mut api = OpenApi::default();
     let router = ApiRouter::<S>::new()
-        // TODO: add routes
+        .nest("/api/admin/v1", self::v1::router())
         .finish_api_with(&mut api, |t| {
             t.title("Matrix Authentication Service admin API")
                 .security_scheme(

--- a/crates/handlers/src/admin/mod.rs
+++ b/crates/handlers/src/admin/mod.rs
@@ -16,16 +16,22 @@ use aide::{
     axum::ApiRouter,
     openapi::{OAuth2Flow, OAuth2Flows, OpenApi, SecurityScheme, Server, ServerVariable},
 };
-use axum::{Json, Router};
+use axum::{extract::FromRequestParts, Json, Router};
 use hyper::header::{ACCEPT, AUTHORIZATION, CONTENT_TYPE};
 use indexmap::IndexMap;
 use mas_http::CorsLayerExt;
 use mas_router::{OAuth2AuthorizationEndpoint, OAuth2TokenEndpoint, SimpleRoute};
 use tower_http::cors::{Any, CorsLayer};
 
+mod call_context;
+mod response;
+
+use self::call_context::CallContext;
+
 pub fn router<S>() -> (OpenApi, Router<S>)
 where
     S: Clone + Send + Sync + 'static,
+    CallContext: FromRequestParts<S>,
 {
     let mut api = OpenApi::default();
     let router = ApiRouter::<S>::new()

--- a/crates/handlers/src/admin/model.rs
+++ b/crates/handlers/src/admin/model.rs
@@ -1,0 +1,35 @@
+// Copyright 2024 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use ulid::Ulid;
+
+/// A resource, with a type and an ID
+#[allow(dead_code)]
+pub trait Resource {
+    /// The type of the resource
+    const KIND: &'static str;
+
+    /// The canonical path prefix for this kind of resource
+    const PATH: &'static str;
+
+    /// The ID of the resource
+    fn id(&self) -> Ulid;
+
+    /// The canonical path for this resource
+    ///
+    /// This is the concatenation of the canonical path prefix and the ID
+    fn path(&self) -> String {
+        format!("{}/{}", Self::PATH, self.id())
+    }
+}

--- a/crates/handlers/src/admin/params.rs
+++ b/crates/handlers/src/admin/params.rs
@@ -1,0 +1,154 @@
+// Copyright 2024 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Generated code from schemars violates this rule
+#![allow(clippy::str_to_string)]
+
+use std::num::NonZeroUsize;
+
+use aide::OperationIo;
+use async_trait::async_trait;
+use axum::{
+    extract::{
+        rejection::{PathRejection, QueryRejection},
+        FromRequestParts, Path, Query,
+    },
+    response::IntoResponse,
+    Json,
+};
+use axum_macros::FromRequestParts;
+use hyper::StatusCode;
+use mas_storage::pagination::PaginationDirection;
+use schemars::JsonSchema;
+use serde::Deserialize;
+use ulid::Ulid;
+
+use super::response::ErrorResponse;
+
+#[derive(Debug, thiserror::Error)]
+#[error("Invalid ULID in path")]
+pub struct UlidPathParamRejection(#[from] PathRejection);
+
+impl IntoResponse for UlidPathParamRejection {
+    fn into_response(self) -> axum::response::Response {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse::from_error(&self)),
+        )
+            .into_response()
+    }
+}
+
+#[derive(JsonSchema, Debug, Clone, Copy, Deserialize)]
+struct UlidInPath {
+    #[schemars(
+        with = "String",
+        title = "ULID",
+        description = "A ULID as per https://github.com/ulid/spec",
+        regex(pattern = r"^[0123456789ABCDEFGHJKMNPQRSTVWXYZ]{26}$")
+    )]
+    id: Ulid,
+}
+
+#[derive(FromRequestParts, OperationIo, Debug, Clone, Copy)]
+#[from_request(rejection(UlidPathParamRejection))]
+#[aide(input_with = "Path<UlidInPath>")]
+pub struct UlidPathParam(#[from_request(via(Path))] UlidInPath);
+
+impl std::ops::Deref for UlidPathParam {
+    type Target = Ulid;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0.id
+    }
+}
+
+/// The default page size if not specified
+const DEFAULT_PAGE_SIZE: usize = 10;
+
+#[derive(Deserialize, JsonSchema, Clone, Copy)]
+struct PaginationParams {
+    /// Retrieve the items before the given ID
+    #[serde(rename = "page[before]")]
+    #[schemars(with = "Option<String>")]
+    before: Option<Ulid>,
+
+    /// Retrieve the items after the given ID
+    #[serde(rename = "page[after]")]
+    #[schemars(with = "Option<String>")]
+    after: Option<Ulid>,
+
+    /// Retrieve the first N items
+    #[serde(rename = "page[first]")]
+    first: Option<NonZeroUsize>,
+
+    /// Retrieve the last N items
+    #[serde(rename = "page[last]")]
+    last: Option<NonZeroUsize>,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum PaginationRejection {
+    #[error("Invalid pagination parameters")]
+    Invalid(#[from] QueryRejection),
+
+    #[error("Cannot specify both `page[first]` and `page[last]` parameters")]
+    FirstAndLast,
+}
+
+impl IntoResponse for PaginationRejection {
+    fn into_response(self) -> axum::response::Response {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse::from_error(&self)),
+        )
+            .into_response()
+    }
+}
+
+/// An extractor for pagination parameters in the query string
+#[derive(OperationIo, Debug, Clone, Copy)]
+#[aide(input_with = "Query<PaginationParams>")]
+pub struct Pagination(pub mas_storage::Pagination);
+
+#[async_trait]
+impl<S: Send + Sync> FromRequestParts<S> for Pagination {
+    type Rejection = PaginationRejection;
+
+    async fn from_request_parts(
+        parts: &mut axum::http::request::Parts,
+        state: &S,
+    ) -> Result<Self, Self::Rejection> {
+        let params = Query::<PaginationParams>::from_request_parts(parts, state).await?;
+
+        // Figure out the direction and the count out of the first and last parameters
+        let (direction, count) = match (params.first, params.last) {
+            // Make sure we don't specify both first and last
+            (Some(_), Some(_)) => return Err(PaginationRejection::FirstAndLast),
+
+            // Default to forward pagination with a default page size
+            (None, None) => (PaginationDirection::Forward, DEFAULT_PAGE_SIZE),
+
+            (Some(first), None) => (PaginationDirection::Forward, first.into()),
+            (None, Some(last)) => (PaginationDirection::Backward, last.into()),
+        };
+
+        Ok(Self(mas_storage::Pagination {
+            before: params.before,
+            after: params.after,
+            direction,
+            count,
+        }))
+    }
+}

--- a/crates/handlers/src/admin/response.rs
+++ b/crates/handlers/src/admin/response.rs
@@ -14,8 +14,187 @@
 
 #![allow(clippy::module_name_repetitions)]
 
+use mas_storage::Pagination;
 use schemars::JsonSchema;
 use serde::Serialize;
+use ulid::Ulid;
+
+use super::model::Resource;
+
+/// Related links
+#[derive(Serialize, JsonSchema)]
+struct PaginationLinks {
+    /// The canonical link to the current page
+    #[serde(rename = "self")]
+    self_: String,
+
+    /// The link to the first page of results
+    first: String,
+
+    /// The link to the last page of results
+    last: String,
+
+    /// The link to the next page of results
+    ///
+    /// Only present if there is a next page
+    #[serde(skip_serializing_if = "Option::is_none")]
+    next: Option<String>,
+
+    /// The link to the previous page of results
+    ///
+    /// Only present if there is a previous page
+    #[serde(skip_serializing_if = "Option::is_none")]
+    prev: Option<String>,
+}
+
+#[derive(Serialize, JsonSchema)]
+struct PaginationMeta {
+    /// The total number of results
+    count: usize,
+}
+
+/// A top-level response with a page of resources
+#[derive(Serialize, JsonSchema)]
+pub struct PaginatedResponse<T> {
+    /// Response metadata
+    meta: PaginationMeta,
+
+    /// The list of resources
+    data: Vec<SingleResource<T>>,
+
+    /// Related links
+    links: PaginationLinks,
+}
+
+fn url_with_pagination(base: &str, pagination: Pagination) -> String {
+    let (path, query) = base.split_once('?').unwrap_or((base, ""));
+    let mut query = query.to_owned();
+
+    if let Some(before) = pagination.before {
+        query += &format!("&page[before]={before}");
+    }
+
+    if let Some(after) = pagination.after {
+        query += &format!("&page[after]={after}");
+    }
+
+    let count = pagination.count;
+    match pagination.direction {
+        mas_storage::pagination::PaginationDirection::Forward => {
+            query += &format!("&page[first]={count}");
+        }
+        mas_storage::pagination::PaginationDirection::Backward => {
+            query += &format!("&page[last]={count}");
+        }
+    }
+
+    // Remove the first '&'
+    let query = query.trim_start_matches('&');
+
+    format!("{path}?{query}")
+}
+
+impl<T: Resource> PaginatedResponse<T> {
+    pub fn new(
+        page: mas_storage::Page<T>,
+        current_pagination: Pagination,
+        count: usize,
+        base: &str,
+    ) -> Self {
+        let links = PaginationLinks {
+            self_: url_with_pagination(base, current_pagination),
+            first: url_with_pagination(base, Pagination::first(current_pagination.count)),
+            last: url_with_pagination(base, Pagination::last(current_pagination.count)),
+            next: page.has_next_page.then(|| {
+                url_with_pagination(
+                    base,
+                    current_pagination
+                        .clear_before()
+                        .after(page.edges.last().unwrap().id()),
+                )
+            }),
+            prev: if page.has_previous_page {
+                Some(url_with_pagination(
+                    base,
+                    current_pagination
+                        .clear_after()
+                        .before(page.edges.first().unwrap().id()),
+                ))
+            } else {
+                None
+            },
+        };
+
+        let data = page.edges.into_iter().map(SingleResource::new).collect();
+
+        Self {
+            meta: PaginationMeta { count },
+            data,
+            links,
+        }
+    }
+}
+
+/// A single resource, with its type, ID, attributes and related links
+#[derive(Serialize, JsonSchema)]
+struct SingleResource<T> {
+    /// The type of the resource
+    #[serde(rename = "type")]
+    type_: &'static str,
+
+    /// The ID of the resource
+    #[schemars(with = "String")]
+    id: Ulid,
+
+    /// The attributes of the resource
+    attributes: T,
+
+    /// Related links
+    links: SelfLinks,
+}
+
+impl<T: Resource> SingleResource<T> {
+    fn new(resource: T) -> Self {
+        let self_ = resource.path();
+        Self {
+            type_: T::KIND,
+            id: resource.id(),
+            attributes: resource,
+            links: SelfLinks { self_ },
+        }
+    }
+}
+
+/// Related links
+#[derive(Serialize, JsonSchema)]
+struct SelfLinks {
+    /// The canonical link to the current resource
+    #[serde(rename = "self")]
+    self_: String,
+}
+
+/// A top-level response with a single resource
+#[derive(Serialize, JsonSchema)]
+pub struct SingleResponse<T> {
+    data: SingleResource<T>,
+    links: SelfLinks,
+}
+
+impl<T: Resource> SingleResponse<T> {
+    /// Create a new single response with the given resource and link to itself
+    pub fn new(resource: T, self_: String) -> Self {
+        Self {
+            data: SingleResource::new(resource),
+            links: SelfLinks { self_ },
+        }
+    }
+
+    /// Create a new single response using the canonical path for the resource
+    pub fn new_canonical(resource: T) -> Self {
+        let self_ = resource.path();
+        Self::new(resource, self_)
+    }
+}
 
 /// A single error
 #[derive(Serialize, JsonSchema)]

--- a/crates/handlers/src/admin/response.rs
+++ b/crates/handlers/src/admin/response.rs
@@ -1,0 +1,53 @@
+// Copyright 2024 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![allow(clippy::module_name_repetitions)]
+
+use schemars::JsonSchema;
+use serde::Serialize;
+
+/// A single error
+#[derive(Serialize, JsonSchema)]
+struct Error {
+    /// A human-readable title for the error
+    title: String,
+}
+
+impl Error {
+    fn from_error(error: &(dyn std::error::Error + 'static)) -> Self {
+        Self {
+            title: error.to_string(),
+        }
+    }
+}
+
+/// A top-level response with a list of errors
+#[derive(Serialize, JsonSchema)]
+pub struct ErrorResponse {
+    /// The list of errors
+    errors: Vec<Error>,
+}
+
+impl ErrorResponse {
+    /// Create a new error response from any Rust error
+    pub fn from_error(error: &(dyn std::error::Error + 'static)) -> Self {
+        let mut errors = Vec::new();
+        let mut head = Some(error);
+        while let Some(error) = head {
+            errors.push(Error::from_error(error));
+            head = error.source();
+        }
+        Self { errors }
+    }
+}

--- a/crates/handlers/src/admin/v1/mod.rs
+++ b/crates/handlers/src/admin/v1/mod.rs
@@ -1,0 +1,37 @@
+// Copyright 2024 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use aide::axum::{routing::get_with, ApiRouter};
+use axum::extract::FromRequestParts;
+
+use super::call_context::CallContext;
+
+mod users;
+
+pub fn router<S>() -> ApiRouter<S>
+where
+    S: Clone + Send + Sync + 'static,
+    CallContext: FromRequestParts<S>,
+{
+    ApiRouter::<S>::new()
+        .api_route("/users", get_with(self::users::list, self::users::list_doc))
+        .api_route(
+            "/users/:id",
+            get_with(self::users::get, self::users::get_doc),
+        )
+        .api_route(
+            "/users/by-username/:username",
+            get_with(self::users::by_username, self::users::by_username_doc),
+        )
+}

--- a/crates/handlers/src/admin/v1/users/by_username.rs
+++ b/crates/handlers/src/admin/v1/users/by_username.rs
@@ -1,0 +1,87 @@
+// Copyright 2024 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use aide::{transform::TransformOperation, OperationIo};
+use axum::{extract::Path, response::IntoResponse, Json};
+use hyper::StatusCode;
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+use crate::{
+    admin::{
+        call_context::CallContext,
+        model::User,
+        response::{ErrorResponse, SingleResponse},
+    },
+    impl_from_error_for_route,
+};
+
+#[derive(Debug, thiserror::Error, OperationIo)]
+#[aide(output_with = "Json<ErrorResponse>")]
+pub enum RouteError {
+    #[error(transparent)]
+    Internal(Box<dyn std::error::Error + Send + Sync + 'static>),
+
+    #[error("User with username {0:?} not found")]
+    NotFound(String),
+}
+
+impl_from_error_for_route!(mas_storage::RepositoryError);
+
+impl IntoResponse for RouteError {
+    fn into_response(self) -> axum::response::Response {
+        let error = ErrorResponse::from_error(&self);
+        let status = match self {
+            Self::Internal(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            Self::NotFound(_) => StatusCode::NOT_FOUND,
+        };
+        (status, Json(error)).into_response()
+    }
+}
+
+#[derive(Deserialize, JsonSchema)]
+pub struct UsernamePathParam {
+    /// The username (localpart) of the user to get
+    username: String,
+}
+
+pub fn doc(operation: TransformOperation) -> TransformOperation {
+    operation
+        .description("Get a user by its username (localpart)")
+        .response_with::<200, Json<SingleResponse<User>>, _>(|t| {
+            let [sample, ..] = User::samples();
+            let response =
+                SingleResponse::new(sample, "/api/admin/v1/users/by-username/alice".to_owned());
+            t.description("User was found").example(response)
+        })
+        .response_with::<404, RouteError, _>(|t| {
+            let response = ErrorResponse::from_error(&RouteError::NotFound("alice".to_owned()));
+            t.description("User was not found").example(response)
+        })
+}
+
+#[tracing::instrument(name = "handler.admin.v1.users.by_username", skip_all, err)]
+pub async fn handler(
+    CallContext { mut repo, .. }: CallContext,
+    Path(UsernamePathParam { username }): Path<UsernamePathParam>,
+) -> Result<Json<SingleResponse<User>>, RouteError> {
+    let self_path = format!("/api/admin/v1/users/by-username/{username}");
+    let user = repo
+        .user()
+        .find_by_username(&username)
+        .await?
+        .ok_or(RouteError::NotFound(username))?;
+
+    Ok(Json(SingleResponse::new(User::from(user), self_path)))
+}

--- a/crates/handlers/src/admin/v1/users/get.rs
+++ b/crates/handlers/src/admin/v1/users/get.rs
@@ -1,0 +1,79 @@
+// Copyright 2024 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use aide::{transform::TransformOperation, OperationIo};
+use axum::{response::IntoResponse, Json};
+use hyper::StatusCode;
+use ulid::Ulid;
+
+use crate::{
+    admin::{
+        call_context::CallContext,
+        model::User,
+        params::UlidPathParam,
+        response::{ErrorResponse, SingleResponse},
+    },
+    impl_from_error_for_route,
+};
+
+#[derive(Debug, thiserror::Error, OperationIo)]
+#[aide(output_with = "Json<ErrorResponse>")]
+pub enum RouteError {
+    #[error(transparent)]
+    Internal(Box<dyn std::error::Error + Send + Sync + 'static>),
+
+    #[error("User ID {0} not found")]
+    NotFound(Ulid),
+}
+
+impl_from_error_for_route!(mas_storage::RepositoryError);
+
+impl IntoResponse for RouteError {
+    fn into_response(self) -> axum::response::Response {
+        let error = ErrorResponse::from_error(&self);
+        let status = match self {
+            Self::Internal(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            Self::NotFound(_) => StatusCode::NOT_FOUND,
+        };
+        (status, Json(error)).into_response()
+    }
+}
+
+pub fn doc(operation: TransformOperation) -> TransformOperation {
+    operation
+        .description("Get a user")
+        .response_with::<200, Json<SingleResponse<User>>, _>(|t| {
+            let [sample, ..] = User::samples();
+            let response = SingleResponse::new_canonical(sample);
+            t.description("User was found").example(response)
+        })
+        .response_with::<404, RouteError, _>(|t| {
+            let response = ErrorResponse::from_error(&RouteError::NotFound(Ulid::nil()));
+            t.description("User was not found").example(response)
+        })
+}
+
+#[tracing::instrument(name = "handler.admin.v1.users.get", skip_all, err)]
+pub async fn handler(
+    CallContext { mut repo, .. }: CallContext,
+    id: UlidPathParam,
+) -> Result<Json<SingleResponse<User>>, RouteError> {
+    let user = repo
+        .user()
+        .lookup(*id)
+        .await?
+        .ok_or(RouteError::NotFound(*id))?;
+
+    Ok(Json(SingleResponse::new_canonical(User::from(user))))
+}

--- a/crates/handlers/src/admin/v1/users/list.rs
+++ b/crates/handlers/src/admin/v1/users/list.rs
@@ -1,0 +1,135 @@
+// Copyright 2024 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use aide::{transform::TransformOperation, OperationIo};
+use axum::{
+    extract::{rejection::QueryRejection, Query},
+    response::IntoResponse,
+    Json,
+};
+use axum_macros::FromRequestParts;
+use hyper::StatusCode;
+use mas_storage::{user::UserFilter, Page};
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+use crate::{
+    admin::{
+        call_context::CallContext,
+        model::{Resource, User},
+        params::Pagination,
+        response::{ErrorResponse, PaginatedResponse},
+    },
+    impl_from_error_for_route,
+};
+
+#[derive(Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+enum UserStatus {
+    /// The user is active
+    Active,
+
+    /// The user is locked
+    Locked,
+}
+
+#[derive(FromRequestParts, Deserialize, JsonSchema, OperationIo)]
+#[aide(input_with = "Query<FilterParams>")]
+#[from_request(via(Query), rejection(RouteError))]
+pub struct FilterParams {
+    #[serde(rename = "filter[can_request_admin]")]
+    can_request_admin: Option<bool>,
+
+    #[serde(rename = "filter[status]")]
+    status: Option<UserStatus>,
+}
+
+impl<'a> From<&'a FilterParams> for UserFilter<'a> {
+    fn from(val: &'a FilterParams) -> Self {
+        let filter = UserFilter::default();
+
+        let filter = match val.can_request_admin {
+            Some(true) => filter.can_request_admin_only(),
+            Some(false) => filter.cannot_request_admin_only(),
+            None => filter,
+        };
+
+        let filter = match val.status {
+            Some(UserStatus::Active) => filter.active_only(),
+            Some(UserStatus::Locked) => filter.locked_only(),
+            None => filter,
+        };
+
+        filter
+    }
+}
+
+#[derive(Debug, thiserror::Error, OperationIo)]
+#[aide(output_with = "Json<ErrorResponse>")]
+pub enum RouteError {
+    #[error(transparent)]
+    Internal(Box<dyn std::error::Error + Send + Sync + 'static>),
+
+    #[error("Invalid filter parameters")]
+    InvalidFilter(#[from] QueryRejection),
+}
+
+impl_from_error_for_route!(mas_storage::RepositoryError);
+
+impl IntoResponse for RouteError {
+    fn into_response(self) -> axum::response::Response {
+        let error = ErrorResponse::from_error(&self);
+        let status = match self {
+            Self::Internal(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            Self::InvalidFilter(_) => StatusCode::BAD_REQUEST,
+        };
+        (status, Json(error)).into_response()
+    }
+}
+
+pub fn doc(operation: TransformOperation) -> TransformOperation {
+    operation
+        .description("List users")
+        .response_with::<200, Json<PaginatedResponse<User>>, _>(|t| {
+            let users = User::samples();
+            let pagination = mas_storage::Pagination::first(users.len());
+            let page = Page {
+                edges: users.into(),
+                has_next_page: true,
+                has_previous_page: false,
+            };
+
+            t.description("Paginated response of users")
+                .example(PaginatedResponse::new(page, pagination, 42, User::PATH))
+        })
+}
+
+#[tracing::instrument(name = "handler.admin.v1.users.list", skip_all, err)]
+pub async fn handler(
+    CallContext { mut repo, .. }: CallContext,
+    Pagination(pagination): Pagination,
+    filter: FilterParams,
+) -> Result<Json<PaginatedResponse<User>>, RouteError> {
+    let filter = UserFilter::from(&filter);
+
+    let page = repo.user().list(filter, pagination).await?;
+    let count = repo.user().count(filter).await?;
+
+    Ok(Json(PaginatedResponse::new(
+        page.map(User::from),
+        pagination,
+        count,
+        User::PATH,
+    )))
+}

--- a/crates/handlers/src/admin/v1/users/mod.rs
+++ b/crates/handlers/src/admin/v1/users/mod.rs
@@ -1,0 +1,23 @@
+// Copyright 2024 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod by_username;
+mod get;
+mod list;
+
+pub use self::{
+    by_username::{doc as by_username_doc, handler as by_username},
+    get::{doc as get_doc, handler as get},
+    list::{doc as list_doc, handler as list},
+};

--- a/crates/handlers/src/bin/api-schema.rs
+++ b/crates/handlers/src/bin/api-schema.rs
@@ -1,0 +1,72 @@
+// Copyright 2022 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![forbid(unsafe_code)]
+#![deny(
+    clippy::all,
+    clippy::str_to_string,
+    rustdoc::broken_intra_doc_links,
+    clippy::future_not_send
+)]
+#![warn(clippy::pedantic)]
+
+use std::io::Write;
+
+/// This is a dummy state, it should never be used.
+///
+/// We use it to generate the API schema, which doesn't execute any request.
+#[derive(Clone)]
+struct DummyState;
+
+macro_rules! impl_from_request_parts {
+    ($type:ty) => {
+        #[axum::async_trait]
+        impl axum::extract::FromRequestParts<DummyState> for $type {
+            type Rejection = std::convert::Infallible;
+
+            async fn from_request_parts(
+                _parts: &mut axum::http::request::Parts,
+                _state: &DummyState,
+            ) -> Result<Self, Self::Rejection> {
+                unimplemented!("This is a dummy state, it should never be used")
+            }
+        }
+    };
+}
+
+macro_rules! impl_from_ref {
+    ($type:ty) => {
+        impl axum::extract::FromRef<DummyState> for $type {
+            fn from_ref(_input: &DummyState) -> Self {
+                unimplemented!("This is a dummy state, it should never be used")
+            }
+        }
+    };
+}
+
+impl_from_request_parts!(mas_storage::BoxRepository);
+impl_from_request_parts!(mas_storage::BoxClock);
+impl_from_request_parts!(mas_handlers::BoundActivityTracker);
+impl_from_ref!(mas_keystore::Keystore);
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let (api, _) = mas_handlers::admin_api_router::<DummyState>();
+    let mut stdout = std::io::stdout();
+    serde_json::to_writer_pretty(&mut stdout, &api)?;
+
+    // Make sure we end with a newline
+    stdout.write_all(b"\n")?;
+
+    Ok(())
+}

--- a/crates/handlers/src/graphql/mod.rs
+++ b/crates/handlers/src/graphql/mod.rs
@@ -40,9 +40,7 @@ use mas_axum_utils::{
 use mas_data_model::{BrowserSession, Session, SiteConfig, User};
 use mas_matrix::HomeserverConnection;
 use mas_policy::{InstantiateError, Policy, PolicyFactory};
-use mas_storage::{
-    BoxClock, BoxRepository, BoxRng, Clock, Repository, RepositoryError, SystemClock,
-};
+use mas_storage::{BoxClock, BoxRepository, BoxRng, Clock, RepositoryError, SystemClock};
 use mas_storage_pg::PgRepository;
 use opentelemetry_semantic_conventions::trace::{GRAPHQL_DOCUMENT, GRAPHQL_OPERATION_NAME};
 use rand::{thread_rng, SeedableRng};
@@ -82,7 +80,7 @@ impl state::State for GraphQLState {
             .await
             .map_err(RepositoryError::from_error)?;
 
-        Ok(repo.map_err(RepositoryError::from_error).boxed())
+        Ok(repo.boxed())
     }
 
     async fn policy(&self) -> Result<Policy, InstantiateError> {

--- a/crates/handlers/src/lib.rs
+++ b/crates/handlers/src/lib.rs
@@ -53,6 +53,7 @@ use sqlx::PgPool;
 use tower::util::AndThenLayer;
 use tower_http::cors::{Any, CorsLayer};
 
+mod admin;
 mod compat;
 mod graphql;
 mod health;
@@ -89,6 +90,7 @@ pub use mas_axum_utils::{
 
 pub use self::{
     activity_tracker::{ActivityTracker, Bound as BoundActivityTracker},
+    admin::router as admin_api_router,
     graphql::{
         schema as graphql_schema, schema_builder as graphql_schema_builder, Schema as GraphQLSchema,
     },

--- a/crates/handlers/src/test_utils.rs
+++ b/crates/handlers/src/test_utils.rs
@@ -43,7 +43,7 @@ use mas_keystore::{Encrypter, JsonWebKey, JsonWebKeySet, Keystore, PrivateKey};
 use mas_matrix::{BoxHomeserverConnection, HomeserverConnection, MockHomeserverConnection};
 use mas_policy::{InstantiateError, Policy, PolicyFactory};
 use mas_router::{SimpleRoute, UrlBuilder};
-use mas_storage::{clock::MockClock, BoxClock, BoxRepository, BoxRng, Repository};
+use mas_storage::{clock::MockClock, BoxClock, BoxRepository, BoxRng};
 use mas_storage_pg::{DatabaseError, PgRepository};
 use mas_templates::{SiteConfigExt, Templates};
 use rand::SeedableRng;
@@ -272,9 +272,7 @@ impl TestState {
 
     pub async fn repository(&self) -> Result<BoxRepository, DatabaseError> {
         let repo = PgRepository::from_pool(&self.pool).await?;
-        Ok(repo
-            .map_err(mas_storage::RepositoryError::from_error)
-            .boxed())
+        Ok(repo.boxed())
     }
 
     /// Returns a new random number generator.
@@ -330,9 +328,7 @@ impl graphql::State for TestGraphQLState {
             .await
             .map_err(mas_storage::RepositoryError::from_error)?;
 
-        Ok(repo
-            .map_err(mas_storage::RepositoryError::from_error)
-            .boxed())
+        Ok(repo.boxed())
     }
 
     async fn policy(&self) -> Result<Policy, InstantiateError> {
@@ -500,9 +496,7 @@ impl FromRequestParts<TestState> for BoxRepository {
         state: &TestState,
     ) -> Result<Self, Self::Rejection> {
         let repo = PgRepository::from_pool(&state.pool).await?;
-        Ok(repo
-            .map_err(mas_storage::RepositoryError::from_error)
-            .boxed())
+        Ok(repo.boxed())
     }
 }
 

--- a/crates/storage-pg/src/compat/mod.rs
+++ b/crates/storage-pg/src/compat/mod.rs
@@ -36,7 +36,7 @@ mod tests {
             CompatSessionRepository, CompatSsoLoginFilter,
         },
         user::UserRepository,
-        Clock, Pagination, Repository, RepositoryAccess,
+        Clock, Pagination, RepositoryAccess,
     };
     use rand::SeedableRng;
     use rand_chacha::ChaChaRng;

--- a/crates/storage-pg/src/oauth2/mod.rs
+++ b/crates/storage-pg/src/oauth2/mod.rs
@@ -36,7 +36,7 @@ mod tests {
     use mas_storage::{
         clock::MockClock,
         oauth2::{OAuth2DeviceCodeGrantParams, OAuth2SessionFilter, OAuth2SessionRepository},
-        Clock, Pagination, Repository,
+        Clock, Pagination,
     };
     use oauth2_types::{
         requests::{GrantType, ResponseMode},

--- a/crates/storage-pg/src/user/tests.rs
+++ b/crates/storage-pg/src/user/tests.rs
@@ -19,7 +19,7 @@ use mas_storage::{
         BrowserSessionFilter, BrowserSessionRepository, UserEmailFilter, UserEmailRepository,
         UserFilter, UserPasswordRepository, UserRepository,
     },
-    Pagination, Repository, RepositoryAccess,
+    Pagination, RepositoryAccess,
 };
 use rand::SeedableRng;
 use rand_chacha::ChaChaRng;

--- a/crates/storage/src/pagination.rs
+++ b/crates/storage/src/pagination.rs
@@ -104,10 +104,24 @@ impl Pagination {
         self
     }
 
+    /// Clear the before cursor
+    #[must_use]
+    pub const fn clear_before(mut self) -> Self {
+        self.before = None;
+        self
+    }
+
     /// Get items after the given cursor
     #[must_use]
     pub const fn after(mut self, id: Ulid) -> Self {
         self.after = Some(id);
+        self
+    }
+
+    /// Clear the after cursor
+    #[must_use]
+    pub const fn clear_after(mut self) -> Self {
+        self.after = None;
         self
     }
 

--- a/crates/storage/src/repository.rs
+++ b/crates/storage/src/repository.rs
@@ -34,7 +34,6 @@ use crate::{
         BrowserSessionRepository, UserEmailRepository, UserPasswordRepository,
         UserRecoveryRepository, UserRepository, UserTermsRepository,
     },
-    MapErr,
 };
 
 /// A [`Repository`] helps interacting with the underlying storage backend.
@@ -43,21 +42,6 @@ pub trait Repository<E>:
 where
     E: std::error::Error + Send + Sync + 'static,
 {
-    /// Construct a (boxed) typed-erased repository
-    fn boxed(self) -> BoxRepository<E>
-    where
-        Self: Sync + Sized + 'static,
-    {
-        Box::new(self)
-    }
-
-    /// Map the error type of all the methods of a [`Repository`]
-    fn map_err<Mapper>(self, mapper: Mapper) -> MapErr<Self, Mapper>
-    where
-        Self: Sized,
-    {
-        MapErr::new(self, mapper)
-    }
 }
 
 /// An opaque, type-erased error
@@ -80,7 +64,7 @@ impl RepositoryError {
 }
 
 /// A type-erased [`Repository`]
-pub type BoxRepository<E = RepositoryError> = Box<dyn Repository<E> + Send + Sync + 'static>;
+pub type BoxRepository = Box<dyn Repository<RepositoryError> + Send + Sync + 'static>;
 
 /// A [`RepositoryTransaction`] can be saved or cancelled, after a series
 /// of operations.
@@ -113,7 +97,7 @@ pub trait RepositoryTransaction {
 /// repository is used at a time.
 ///
 /// When adding a new repository, you should add a new method to this trait, and
-/// update the implementations for [`MapErr`] and [`Box<R>`] below.
+/// update the implementations for [`crate::MapErr`] and [`Box<R>`] below.
 ///
 /// Note: this used to have generic associated types to avoid boxing all the
 /// repository traits, but that was removed because it made almost impossible to
@@ -218,7 +202,7 @@ pub trait RepositoryAccess: Send {
 }
 
 /// Implementations of the [`RepositoryAccess`], [`RepositoryTransaction`] and
-/// [`Repository`] for the [`MapErr`] wrapper and [`Box<R>`]
+/// [`Repository`] for the [`crate::MapErr`] wrapper and [`Box<R>`]
 mod impls {
     use futures_util::{future::BoxFuture, FutureExt, TryFutureExt};
 

--- a/crates/storage/src/utils.rs
+++ b/crates/storage/src/utils.rs
@@ -26,7 +26,10 @@ pub struct MapErr<R, F> {
 }
 
 impl<R, F> MapErr<R, F> {
-    pub(crate) fn new(inner: R, mapper: F) -> Self {
+    /// Create a new [`MapErr`] wrapper from an inner repository and a mapper
+    /// function
+    #[must_use]
+    pub fn new(inner: R, mapper: F) -> Self {
         Self {
             inner,
             mapper,

--- a/crates/tasks/src/lib.rs
+++ b/crates/tasks/src/lib.rs
@@ -18,7 +18,7 @@ use apalis_core::{executor::TokioExecutor, layers::extensions::Extension, monito
 use mas_email::Mailer;
 use mas_matrix::HomeserverConnection;
 use mas_router::UrlBuilder;
-use mas_storage::{BoxClock, BoxRepository, Repository, SystemClock};
+use mas_storage::{BoxClock, BoxRepository, SystemClock};
 use mas_storage_pg::{DatabaseError, PgRepository};
 use rand::SeedableRng;
 use sqlx::{Pool, Postgres};
@@ -83,10 +83,7 @@ impl State {
     }
 
     pub async fn repository(&self) -> Result<BoxRepository, DatabaseError> {
-        let repo = PgRepository::from_pool(self.pool())
-            .await?
-            .map_err(mas_storage::RepositoryError::from_error)
-            .boxed();
+        let repo = PgRepository::from_pool(self.pool()).await?.boxed();
 
         Ok(repo)
     }

--- a/docs/api.schema.json
+++ b/docs/api.schema.json
@@ -1,0 +1,50 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Matrix Authentication Service admin API",
+    "version": ""
+  },
+  "servers": [
+    {
+      "url": "{base}",
+      "variables": {
+        "base": {
+          "default": "/",
+          "description": null
+        }
+      }
+    }
+  ],
+  "paths": {},
+  "components": {
+    "securitySchemes": {
+      "oauth2": {
+        "type": "oauth2",
+        "flows": {
+          "clientCredentials": {
+            "refreshUrl": "/oauth2/token",
+            "tokenUrl": "/oauth2/token",
+            "scopes": {
+              "urn:mas:admin": "Grant access to the admin API"
+            }
+          },
+          "authorizationCode": {
+            "authorizationUrl": "/authorize",
+            "tokenUrl": "/oauth2/token",
+            "refreshUrl": "/oauth2/token",
+            "scopes": {
+              "urn:mas:admin": "Grant access to the admin API"
+            }
+          }
+        }
+      }
+    }
+  },
+  "security": [
+    {
+      "oauth2": [
+        "urn:mas:admin"
+      ]
+    }
+  ]
+}

--- a/docs/api.schema.json
+++ b/docs/api.schema.json
@@ -15,7 +15,293 @@
       }
     }
   ],
-  "paths": {},
+  "paths": {
+    "/api/admin/v1/users": {
+      "get": {
+        "description": "List users",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "page[before]",
+            "description": "Retrieve the items before the given ID",
+            "schema": {
+              "description": "Retrieve the items before the given ID",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page[after]",
+            "description": "Retrieve the items after the given ID",
+            "schema": {
+              "description": "Retrieve the items after the given ID",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page[first]",
+            "description": "Retrieve the first N items",
+            "schema": {
+              "description": "Retrieve the first N items",
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint",
+              "minimum": 1.0
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page[last]",
+            "description": "Retrieve the last N items",
+            "schema": {
+              "description": "Retrieve the last N items",
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint",
+              "minimum": 1.0
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filter[can_request_admin]",
+            "schema": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filter[status]",
+            "schema": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/UserStatus"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "style": "form"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated response of users",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedResponse_for_User"
+                },
+                "example": {
+                  "meta": {
+                    "count": 42
+                  },
+                  "data": [
+                    {
+                      "type": "user",
+                      "id": "01040G2081040G2081040G2081",
+                      "attributes": {
+                        "username": "alice",
+                        "created_at": "1970-01-01T00:00:00Z",
+                        "locked_at": null,
+                        "can_request_admin": false
+                      },
+                      "links": {
+                        "self": "/api/admin/v1/users/01040G2081040G2081040G2081"
+                      }
+                    },
+                    {
+                      "type": "user",
+                      "id": "02081040G2081040G2081040G2",
+                      "attributes": {
+                        "username": "bob",
+                        "created_at": "1970-01-01T00:00:00Z",
+                        "locked_at": null,
+                        "can_request_admin": true
+                      },
+                      "links": {
+                        "self": "/api/admin/v1/users/02081040G2081040G2081040G2"
+                      }
+                    },
+                    {
+                      "type": "user",
+                      "id": "030C1G60R30C1G60R30C1G60R3",
+                      "attributes": {
+                        "username": "charlie",
+                        "created_at": "1970-01-01T00:00:00Z",
+                        "locked_at": "1970-01-01T00:00:00Z",
+                        "can_request_admin": false
+                      },
+                      "links": {
+                        "self": "/api/admin/v1/users/030C1G60R30C1G60R30C1G60R3"
+                      }
+                    }
+                  ],
+                  "links": {
+                    "self": "/api/admin/v1/users?page[first]=3",
+                    "first": "/api/admin/v1/users?page[first]=3",
+                    "last": "/api/admin/v1/users?page[last]=3",
+                    "next": "/api/admin/v1/users?page[after]=030C1G60R30C1G60R30C1G60R3&page[first]=3"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/v1/users/{id}": {
+      "get": {
+        "description": "Get a user",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "description": "A ULID as per https://github.com/ulid/spec",
+            "required": true,
+            "schema": {
+              "title": "ULID",
+              "description": "A ULID as per https://github.com/ulid/spec",
+              "type": "string",
+              "pattern": "^[0123456789ABCDEFGHJKMNPQRSTVWXYZ]{26}$"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "User was found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SingleResponse_for_User"
+                },
+                "example": {
+                  "data": {
+                    "type": "user",
+                    "id": "01040G2081040G2081040G2081",
+                    "attributes": {
+                      "username": "alice",
+                      "created_at": "1970-01-01T00:00:00Z",
+                      "locked_at": null,
+                      "can_request_admin": false
+                    },
+                    "links": {
+                      "self": "/api/admin/v1/users/01040G2081040G2081040G2081"
+                    }
+                  },
+                  "links": {
+                    "self": "/api/admin/v1/users/01040G2081040G2081040G2081"
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "User was not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "errors": [
+                    {
+                      "title": "User ID 00000000000000000000000000 not found"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/v1/users/by-username/{username}": {
+      "get": {
+        "description": "Get a user by its username (localpart)",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "username",
+            "description": "The username (localpart) of the user to get",
+            "required": true,
+            "schema": {
+              "description": "The username (localpart) of the user to get",
+              "type": "string"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "User was found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SingleResponse_for_User"
+                },
+                "example": {
+                  "data": {
+                    "type": "user",
+                    "id": "01040G2081040G2081040G2081",
+                    "attributes": {
+                      "username": "alice",
+                      "created_at": "1970-01-01T00:00:00Z",
+                      "locked_at": null,
+                      "can_request_admin": false
+                    },
+                    "links": {
+                      "self": "/api/admin/v1/users/01040G2081040G2081040G2081"
+                    }
+                  },
+                  "links": {
+                    "self": "/api/admin/v1/users/by-username/alice"
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "User was not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "errors": [
+                    {
+                      "title": "User with username \"alice\" not found"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
   "components": {
     "securitySchemes": {
       "oauth2": {
@@ -35,6 +321,305 @@
             "scopes": {
               "urn:mas:admin": "Grant access to the admin API"
             }
+          }
+        }
+      }
+    },
+    "schemas": {
+      "PaginationParams": {
+        "type": "object",
+        "properties": {
+          "page[before]": {
+            "description": "Retrieve the items before the given ID",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "page[after]": {
+            "description": "Retrieve the items after the given ID",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "page[first]": {
+            "description": "Retrieve the first N items",
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "uint",
+            "minimum": 1.0
+          },
+          "page[last]": {
+            "description": "Retrieve the last N items",
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "uint",
+            "minimum": 1.0
+          }
+        }
+      },
+      "FilterParams": {
+        "type": "object",
+        "properties": {
+          "filter[can_request_admin]": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "filter[status]": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/UserStatus"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        }
+      },
+      "UserStatus": {
+        "oneOf": [
+          {
+            "description": "The user is active",
+            "type": "string",
+            "enum": [
+              "active"
+            ]
+          },
+          {
+            "description": "The user is locked",
+            "type": "string",
+            "enum": [
+              "locked"
+            ]
+          }
+        ]
+      },
+      "PaginatedResponse_for_User": {
+        "description": "A top-level response with a page of resources",
+        "type": "object",
+        "required": [
+          "data",
+          "links",
+          "meta"
+        ],
+        "properties": {
+          "meta": {
+            "description": "Response metadata",
+            "$ref": "#/components/schemas/PaginationMeta"
+          },
+          "data": {
+            "description": "The list of resources",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SingleResource_for_User"
+            }
+          },
+          "links": {
+            "description": "Related links",
+            "$ref": "#/components/schemas/PaginationLinks"
+          }
+        }
+      },
+      "PaginationMeta": {
+        "type": "object",
+        "required": [
+          "count"
+        ],
+        "properties": {
+          "count": {
+            "description": "The total number of results",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0.0
+          }
+        }
+      },
+      "SingleResource_for_User": {
+        "description": "A single resource, with its type, ID, attributes and related links",
+        "type": "object",
+        "required": [
+          "attributes",
+          "id",
+          "links",
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "description": "The type of the resource",
+            "type": "string"
+          },
+          "id": {
+            "description": "The ID of the resource",
+            "type": "string"
+          },
+          "attributes": {
+            "description": "The attributes of the resource",
+            "$ref": "#/components/schemas/User"
+          },
+          "links": {
+            "description": "Related links",
+            "$ref": "#/components/schemas/SelfLinks"
+          }
+        }
+      },
+      "User": {
+        "description": "A user",
+        "type": "object",
+        "required": [
+          "can_request_admin",
+          "created_at",
+          "username"
+        ],
+        "properties": {
+          "username": {
+            "description": "The username (localpart) of the user",
+            "type": "string"
+          },
+          "created_at": {
+            "description": "When the user was created",
+            "type": "string",
+            "format": "date-time"
+          },
+          "locked_at": {
+            "description": "When the user was locked. If null, the user is not locked.",
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
+          },
+          "can_request_admin": {
+            "description": "Whether the user can request admin privileges.",
+            "type": "boolean"
+          }
+        }
+      },
+      "SelfLinks": {
+        "description": "Related links",
+        "type": "object",
+        "required": [
+          "self"
+        ],
+        "properties": {
+          "self": {
+            "description": "The canonical link to the current resource",
+            "type": "string"
+          }
+        }
+      },
+      "PaginationLinks": {
+        "description": "Related links",
+        "type": "object",
+        "required": [
+          "first",
+          "last",
+          "self"
+        ],
+        "properties": {
+          "self": {
+            "description": "The canonical link to the current page",
+            "type": "string"
+          },
+          "first": {
+            "description": "The link to the first page of results",
+            "type": "string"
+          },
+          "last": {
+            "description": "The link to the last page of results",
+            "type": "string"
+          },
+          "next": {
+            "description": "The link to the next page of results\n\nOnly present if there is a next page",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "prev": {
+            "description": "The link to the previous page of results\n\nOnly present if there is a previous page",
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      },
+      "ErrorResponse": {
+        "description": "A top-level response with a list of errors",
+        "type": "object",
+        "required": [
+          "errors"
+        ],
+        "properties": {
+          "errors": {
+            "description": "The list of errors",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      },
+      "Error": {
+        "description": "A single error",
+        "type": "object",
+        "required": [
+          "title"
+        ],
+        "properties": {
+          "title": {
+            "description": "A human-readable title for the error",
+            "type": "string"
+          }
+        }
+      },
+      "UlidInPath": {
+        "type": "object",
+        "required": [
+          "id"
+        ],
+        "properties": {
+          "id": {
+            "title": "ULID",
+            "description": "A ULID as per https://github.com/ulid/spec",
+            "type": "string",
+            "pattern": "^[0123456789ABCDEFGHJKMNPQRSTVWXYZ]{26}$"
+          }
+        }
+      },
+      "SingleResponse_for_User": {
+        "description": "A top-level response with a single resource",
+        "type": "object",
+        "required": [
+          "data",
+          "links"
+        ],
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/SingleResource_for_User"
+          },
+          "links": {
+            "$ref": "#/components/schemas/SelfLinks"
+          }
+        }
+      },
+      "UsernamePathParam": {
+        "type": "object",
+        "required": [
+          "username"
+        ],
+        "properties": {
+          "username": {
+            "description": "The username (localpart) of the user to get",
+            "type": "string"
           }
         }
       }

--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -789,6 +789,21 @@
           }
         },
         {
+          "description": "Admin API, served at `/api/admin/v1`",
+          "type": "object",
+          "required": [
+            "name"
+          ],
+          "properties": {
+            "name": {
+              "type": "string",
+              "enum": [
+                "adminapi"
+              ]
+            }
+          }
+        },
+        {
           "description": "Mount a \"/connection-info\" handler which helps debugging informations on the upstream connection",
           "type": "object",
           "required": [

--- a/misc/update.sh
+++ b/misc/update.sh
@@ -5,12 +5,14 @@ set -eu
 export SQLX_OFFLINE=1
 BASE_DIR="$(dirname "$0")/.."
 CONFIG_SCHEMA="${BASE_DIR}/docs/config.schema.json"
+API_SCHEMA="${BASE_DIR}/docs/api.schema.json"
 GRAPHQL_SCHEMA="${BASE_DIR}/frontend/schema.graphql"
 POLICIES_SCHEMA="${BASE_DIR}/policies/schema/"
 
 set -x
 cargo run -p mas-config > "${CONFIG_SCHEMA}"
 cargo run -p mas-handlers --bin graphql-schema > "${GRAPHQL_SCHEMA}"
+cargo run -p mas-handlers --bin api-schema > "${API_SCHEMA}"
 cargo run -p mas-i18n-scan -- --update "${BASE_DIR}/templates/" "${BASE_DIR}/translations/en.json"
 OUT_DIR="${POLICIES_SCHEMA}" cargo run -p mas-policy --features jsonschema
 


### PR DESCRIPTION
I made this reviewable commit-by-commit.

Related to #2240

This adds a new admin API, served under `/api/admin/v1`.
There is an auto-generated OpenAPI spec which is available both in the docs and served under `/api/spec.json`.

I tried to make the API responses follow the JSON API spec, so that we have a consistent API design.

As a first step, I implemented a simple `GET /api/admin/v1/users` endpoint which returns a list of users, a `GET /api/admin/v1/users/{id}` endpoint which returns a single user by its ID, and a `GET /api/admin/v1/users/by-username/{username}` endpoint which returns a single user by its username.

The whole API is currently gated behind the `urn:mas:admin` scope.

Follow up things to do:

 - host/generate a documentation, either in-process or on the hosted docs site
 - document how to enable the admin API and use it
 - implement more endpoints
 - add tests
 - introduce more fine-grained scopes
