### PR TITLE
Fix dependabot updates not updating the lockfile

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -87,6 +87,5 @@
     "vite-plugin-graphql-codegen": "^3.3.8",
     "vite-plugin-manifest-sri": "^0.2.0",
     "vitest": "^1.4.0"
-  },
-  "packageManager": "pnpm@8.6.10+sha1.98fe2755061026799bfa30e7dc8d6d48e9c3edf0"
+  }
 }


### PR DESCRIPTION
For some reason, I probably mistyped `pnpm` instead of `npm`, and it added itself as 'packageManager', which meant that dependabot stopped updating lockfiles :(