### PR TITLE
Disallow OAuth 2.0 use of the GraphQL API by default

### DIFF
--- a/crates/cli/src/server.rs
+++ b/crates/cli/src/server.rs
@@ -201,9 +201,13 @@ pub fn build_router(
             mas_config::HttpResource::Human => {
                 router.merge(mas_handlers::human_router::<AppState>(templates.clone()))
             }
-            mas_config::HttpResource::GraphQL { playground } => {
-                router.merge(mas_handlers::graphql_router::<AppState>(*playground))
-            }
+            mas_config::HttpResource::GraphQL {
+                playground,
+                undocumented_oauth2_access,
+            } => router.merge(mas_handlers::graphql_router::<AppState>(
+                *playground,
+                *undocumented_oauth2_access,
+            )),
             mas_config::HttpResource::Assets { path } => {
                 let static_service = ServeDir::new(path)
                     .append_index_html_on_directories(false)

--- a/crates/config/src/sections/http.rs
+++ b/crates/config/src/sections/http.rs
@@ -291,8 +291,12 @@ pub enum Resource {
     /// GraphQL endpoint
     GraphQL {
         /// Enabled the GraphQL playground
-        #[serde(default)]
+        #[serde(default, skip_serializing_if = "std::ops::Not::not")]
         playground: bool,
+
+        /// Allow access for OAuth 2.0 clients (undocumented)
+        #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+        undocumented_oauth2_access: bool,
     },
 
     /// OAuth-related APIs
@@ -379,7 +383,10 @@ impl Default for HttpConfig {
                         Resource::Human,
                         Resource::OAuth,
                         Resource::Compat,
-                        Resource::GraphQL { playground: true },
+                        Resource::GraphQL {
+                            playground: false,
+                            undocumented_oauth2_access: false,
+                        },
                         Resource::Assets {
                             path: http_listener_assets_path_default(),
                         },

--- a/crates/handlers/src/test_utils.rs
+++ b/crates/handlers/src/test_utils.rs
@@ -249,7 +249,9 @@ impl TestState {
             .merge(crate::api_router())
             .merge(crate::compat_router())
             .merge(crate::human_router(self.templates.clone()))
-            .merge(crate::graphql_router(false))
+            // We enable undocumented_oauth2_access for the tests, as it is easier to query the API
+            // with it
+            .merge(crate::graphql_router(false, true))
             .merge(crate::admin_api_router().1)
             .with_state(self.clone())
             .into_service();

--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -35,8 +35,7 @@
                 "name": "compat"
               },
               {
-                "name": "graphql",
-                "playground": true
+                "name": "graphql"
               },
               {
                 "name": "assets"
@@ -742,7 +741,10 @@
             },
             "playground": {
               "description": "Enabled the GraphQL playground",
-              "default": false,
+              "type": "boolean"
+            },
+            "undocumented_oauth2_access": {
+              "description": "Allow access for OAuth 2.0 clients (undocumented)",
               "type": "boolean"
             }
           }


### PR DESCRIPTION
Fixes #3056

This adds a new flag on the `graphql` listener: `undocumented_oauth2_access`.
This is meant for internal use only as it is not documented, and not meant to be, as it is being replaced by the Admin API.

It also disables the GraphQL playground by default, as we don't really want people to mess with it anymore

What this *does not* cover is requesting the `urn:mas:graphql` scope. Right now, clients will still be able to request it, but I think this is fine.