### PR TITLE
frontend: remove double separator when password auth is disabled

### DIFF
--- a/frontend/src/routes/_account.index.lazy.tsx
+++ b/frontend/src/routes/_account.index.lazy.tsx
@@ -79,10 +79,12 @@ function Index(): React.ReactElement {
           )}
         </div>
 
-        <Separator />
-
         {siteConfig.passwordLoginEnabled && (
-          <AccountManagementPasswordPreview siteConfig={siteConfig} />
+          <>
+            <Separator />
+
+            <AccountManagementPasswordPreview siteConfig={siteConfig} />
+          </>
         )}
 
         <Separator />


### PR DESCRIPTION
When password auth is disabled, we had two separators on the account index page.

<img width="568" alt="image" src="https://github.com/user-attachments/assets/8964da02-8fc3-4430-80f9-86254ff03965">
