### PR TITLE
Document policy settings for changing the policy wasm file

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -335,9 +335,9 @@ Policy settings
 ```yaml
 policy:
   # Path to the WASM module
-  # Default for docker feature: `/usr/local/share/mas-cli/policy.wasm`
-  # Default for dist feature: `./share/policy.wasm`
-  # Default otherwise: `./policies/policy.wasm`
+  # Default in Docker distribution: `/usr/local/share/mas-cli/policy.wasm`
+  # Default in pre-built binaries: `./share/policy.wasm`
+  # Default in locally-built binaries: `./policies/policy.wasm`
   wasm_module: ./policies/policy.wasm
   # Entrypoint to use when evaluating client registrations
   client_registration_entrypoint: client_registration/violation

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -334,6 +334,23 @@ Policy settings
 
 ```yaml
 policy:
+  # Path to the WASM module
+  # Default for docker feature: `/usr/local/share/mas-cli/policy.wasm`
+  # Default for dist feature: `./share/policy.wasm`
+  # Default otherwise: `./policies/policy.wasm`
+  wasm_module: ./policies/policy.wasm
+  # Entrypoint to use when evaluating client registrations
+  client_registration_entrypoint: client_registration/violation
+  # Entrypoint to use when evaluating user registrations
+  register_entrypoint: register/violation
+  # Entrypoint to use when evaluating authorization grants
+  authorization_grant_entrypoint: authorization_grant/violation
+  # Entrypoint to use when changing password
+  password_entrypoint: password/violation
+  # Entrypoint to use when adding an email address
+  email_entrypoint: email/violation
+
+  # This data is being passed to the policy
   data:
     # Users which are allowed to ask for admin access. If possible, use the
     # can_request_admin flag on users instead.


### PR DESCRIPTION
This is something I felt was missing and lead me to asking in the room if replacing the policy with something application specific would be possible. In the code, after asking, it became clear. So I figured it makes sense to add it to the config reference.