### PR TITLE
Bump sqlx to 0.8.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,7 +69,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
- "getrandom",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -934,13 +933,13 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.104"
+version = "1.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74b6a57f98764a267ff415d50a25e6e166f3831a5071af4995296ea97d210490"
+checksum = "57b6a275aa2903740dc87da01c62040406b8812552e97129a63ea8850a17c6e6"
 dependencies = [
  "jobserver",
  "libc",
- "once_cell",
+ "shlex",
 ]
 
 [[package]]
@@ -2297,9 +2296,9 @@ dependencies = [
 
 [[package]]
 name = "hashlink"
-version = "0.8.4"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
 dependencies = [
  "hashbrown 0.14.5",
 ]
@@ -2333,9 +2332,6 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-dependencies = [
- "unicode-segmentation",
-]
 
 [[package]]
 name = "heck"
@@ -2482,12 +2478,12 @@ dependencies = [
  "http",
  "hyper",
  "hyper-util",
- "rustls 0.23.12",
+ "rustls",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 0.26.3",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -3078,14 +3074,14 @@ dependencies = [
  "nom",
  "percent-encoding",
  "quoted_printable",
- "rustls 0.23.12",
- "rustls-pemfile 2.1.3",
+ "rustls",
+ "rustls-pemfile",
  "socket2 0.5.7",
  "tokio",
  "tokio-rustls",
  "tracing",
  "url",
- "webpki-roots 0.26.3",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -3112,9 +3108,9 @@ checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.27.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4e226dcd58b4be396f7bd3c20da8fdee2911400705297ba7d2d7cc2c30f716"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
  "cc",
  "pkg-config",
@@ -3277,7 +3273,7 @@ dependencies = [
  "prometheus",
  "rand",
  "rand_chacha",
- "rustls 0.23.12",
+ "rustls",
  "sentry",
  "sentry-tower",
  "sentry-tracing",
@@ -3312,7 +3308,7 @@ dependencies = [
  "pem-rfc7468",
  "rand",
  "rand_chacha",
- "rustls-pemfile 2.1.3",
+ "rustls-pemfile",
  "rustls-pki-types",
  "schemars",
  "serde",
@@ -3406,7 +3402,7 @@ dependencies = [
  "psl",
  "rand",
  "rand_chacha",
- "rustls 0.23.12",
+ "rustls",
  "schemars",
  "sentry",
  "serde",
@@ -3446,7 +3442,7 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-semantic-conventions",
  "pin-project-lite",
- "rustls 0.23.12",
+ "rustls",
  "rustls-platform-verifier",
  "serde",
  "serde_json",
@@ -3594,7 +3590,7 @@ dependencies = [
  "hyper-util",
  "libc",
  "pin-project-lite",
- "rustls-pemfile 2.1.3",
+ "rustls-pemfile",
  "socket2 0.5.7",
  "thiserror",
  "tokio",
@@ -3659,7 +3655,7 @@ dependencies = [
  "oauth2-types",
  "rand",
  "rand_chacha",
- "rustls 0.23.12",
+ "rustls",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -4873,7 +4869,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.12",
+ "rustls",
  "thiserror",
  "tokio",
  "tracing",
@@ -4889,7 +4885,7 @@ dependencies = [
  "rand",
  "ring",
  "rustc-hash",
- "rustls 0.23.12",
+ "rustls",
  "slab",
  "thiserror",
  "tinyvec",
@@ -5091,8 +5087,8 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.12",
- "rustls-pemfile 2.1.3",
+ "rustls",
+ "rustls-pemfile",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -5105,7 +5101,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 0.26.3",
+ "webpki-roots",
  "winreg",
 ]
 
@@ -5214,17 +5210,6 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
-dependencies = [
- "ring",
- "rustls-webpki 0.101.7",
- "sct",
-]
-
-[[package]]
-name = "rustls"
 version = "0.23.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c58f8c84392efc0a126acce10fa59ff7b3d2ac06ab451a33f2741989b806b044"
@@ -5234,7 +5219,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.102.6",
+ "rustls-webpki",
  "subtle",
  "zeroize",
 ]
@@ -5246,19 +5231,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f1fb85efa936c42c6d5fc28d2629bb51e4b2f4b8a5211e297d599cc5a093792"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile 2.1.3",
+ "rustls-pemfile",
  "rustls-pki-types",
  "schannel",
  "security-framework",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
-dependencies = [
- "base64 0.21.7",
 ]
 
 [[package]]
@@ -5288,13 +5264,13 @@ dependencies = [
  "jni",
  "log",
  "once_cell",
- "rustls 0.23.12",
+ "rustls",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.102.6",
+ "rustls-webpki",
  "security-framework",
  "security-framework-sys",
- "webpki-roots 0.26.3",
+ "webpki-roots",
  "winapi",
 ]
 
@@ -5303,16 +5279,6 @@ name = "rustls-platform-verifier-android"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84e217e7fdc8466b5b35d30f8c0a30febd29173df4a3a0c2115d306b9c4117ad"
-
-[[package]]
-name = "rustls-webpki"
-version = "0.101.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
-dependencies = [
- "ring",
- "untrusted",
-]
 
 [[package]]
 name = "rustls-webpki"
@@ -5411,20 +5377,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
 name = "sea-query"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e5073b2cfed767511a57d18115f3b3d8bcb5690bf8c89518caec6cb22c0cd74"
+version = "0.32.0-rc.1"
+source = "git+https://github.com/sandhose/sea-query?branch=binder/relax-sqlx-dependency#513cee7ea623fd5d26a80fbd6132ace8d17acf22"
 dependencies = [
  "chrono",
  "inherent",
@@ -5436,8 +5391,7 @@ dependencies = [
 [[package]]
 name = "sea-query-attr"
 version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "168a31e0ef5a791ad26aa97c502eaed8d2a1ffdc22b3249f9947c1e12be6b477"
+source = "git+https://github.com/sandhose/sea-query?branch=binder/relax-sqlx-dependency#513cee7ea623fd5d26a80fbd6132ace8d17acf22"
 dependencies = [
  "darling 0.14.4",
  "heck 0.4.1",
@@ -5447,9 +5401,8 @@ dependencies = [
 
 [[package]]
 name = "sea-query-binder"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "754965d4aee6145bec25d0898e5c931e6c22859789ce62fd85a42a15ed5a8ce3"
+version = "0.7.0-rc.1"
+source = "git+https://github.com/sandhose/sea-query?branch=binder/relax-sqlx-dependency#513cee7ea623fd5d26a80fbd6132ace8d17acf22"
 dependencies = [
  "chrono",
  "sea-query",
@@ -5460,8 +5413,7 @@ dependencies = [
 [[package]]
 name = "sea-query-derive"
 version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25a82fcb49253abcb45cdcb2adf92956060ec0928635eb21b4f7a6d8f25ab0bc"
+source = "git+https://github.com/sandhose/sea-query?branch=binder/relax-sqlx-dependency#513cee7ea623fd5d26a80fbd6132ace8d17acf22"
 dependencies = [
  "heck 0.4.1",
  "proc-macro2",
@@ -5921,9 +5873,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx"
-version = "0.7.4"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9a2ccff1a000a5a59cd33da541d9f2fdcd9e6e8229cc200565942bff36d0aaa"
+checksum = "fcfa89bea9500db4a0d038513d7a060566bfc51d46d1c014847049a45cce85e8"
 dependencies = [
  "sqlx-core",
  "sqlx-macros",
@@ -5934,11 +5886,10 @@ dependencies = [
 
 [[package]]
 name = "sqlx-core"
-version = "0.7.4"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24ba59a9342a3d9bab6c56c118be528b27c9b60e490080e9711a04dccac83ef6"
+checksum = "d06e2f2bd861719b1f3f0c7dbe1d80c30bf59e76cf019f07d9014ed7eefb8e08"
 dependencies = [
- "ahash",
  "atoi",
  "byteorder",
  "bytes",
@@ -5946,12 +5897,13 @@ dependencies = [
  "crc",
  "crossbeam-queue",
  "either",
- "event-listener 2.5.3",
+ "event-listener 5.3.1",
  "futures-channel",
  "futures-core",
  "futures-intrusive",
  "futures-io",
  "futures-util",
+ "hashbrown 0.14.5",
  "hashlink",
  "hex",
  "indexmap 2.4.0",
@@ -5961,8 +5913,8 @@ dependencies = [
  "once_cell",
  "paste",
  "percent-encoding",
- "rustls 0.21.12",
- "rustls-pemfile 1.0.4",
+ "rustls",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "sha2",
@@ -5974,31 +5926,31 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
- "webpki-roots 0.25.4",
+ "webpki-roots",
 ]
 
 [[package]]
 name = "sqlx-macros"
-version = "0.7.4"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea40e2345eb2faa9e1e5e326db8c34711317d2b5e08d0d5741619048a803127"
+checksum = "2f998a9defdbd48ed005a89362bd40dd2117502f15294f61c8d47034107dbbdc"
 dependencies = [
  "proc-macro2",
  "quote",
  "sqlx-core",
  "sqlx-macros-core",
- "syn 1.0.109",
+ "syn 2.0.68",
 ]
 
 [[package]]
 name = "sqlx-macros-core"
-version = "0.7.4"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5833ef53aaa16d860e92123292f1f6a3d53c34ba8b1969f152ef1a7bb803f3c8"
+checksum = "3d100558134176a2629d46cec0c8891ba0be8910f7896abfdb75ef4ab6f4e7ce"
 dependencies = [
  "dotenvy",
  "either",
- "heck 0.4.1",
+ "heck 0.5.0",
  "hex",
  "once_cell",
  "proc-macro2",
@@ -6010,7 +5962,7 @@ dependencies = [
  "sqlx-mysql",
  "sqlx-postgres",
  "sqlx-sqlite",
- "syn 1.0.109",
+ "syn 2.0.68",
  "tempfile",
  "tokio",
  "url",
@@ -6018,12 +5970,12 @@ dependencies = [
 
 [[package]]
 name = "sqlx-mysql"
-version = "0.7.4"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ed31390216d20e538e447a7a9b959e06ed9fc51c37b514b46eb758016ecd418"
+checksum = "936cac0ab331b14cb3921c62156d913e4c15b74fb6ec0f3146bd4ef6e4fb3c12"
 dependencies = [
  "atoi",
- "base64 0.21.7",
+ "base64 0.22.1",
  "bitflags 2.6.0",
  "byteorder",
  "bytes",
@@ -6062,12 +6014,12 @@ dependencies = [
 
 [[package]]
 name = "sqlx-postgres"
-version = "0.7.4"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c824eb80b894f926f89a0b9da0c7f435d27cdd35b8c655b114e58223918577e"
+checksum = "9734dbce698c67ecf67c442f768a5e90a49b2a4d61a9f1d59f73874bd4cf0710"
 dependencies = [
  "atoi",
- "base64 0.21.7",
+ "base64 0.22.1",
  "bitflags 2.6.0",
  "byteorder",
  "chrono",
@@ -6103,9 +6055,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-sqlite"
-version = "0.7.4"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b244ef0a8414da0bed4bb1910426e890b19e5e9bccc27ada6b797d05c55ae0aa"
+checksum = "a75b419c3c1b1697833dd927bdc4c6545a620bc1bbafabd44e1efbe9afcd337e"
 dependencies = [
  "atoi",
  "chrono",
@@ -6119,10 +6071,10 @@ dependencies = [
  "log",
  "percent-encoding",
  "serde",
+ "serde_urlencoded",
  "sqlx-core",
  "tracing",
  "url",
- "urlencoding",
  "uuid",
 ]
 
@@ -6402,7 +6354,7 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
- "rustls 0.23.12",
+ "rustls",
  "rustls-pki-types",
  "tokio",
 ]
@@ -7177,12 +7129,6 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "webpki-roots"
-version = "0.25.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "webpki-roots"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -195,6 +195,22 @@ version = "0.3.3"
 version = "0.8.21"
 features = ["url", "chrono", "preserve_order"]
 
+# Query builder
+[workspace.dependencies.sea-query]
+version = "0.32.0-rc.1"
+features = ["derive", "attr", "with-uuid", "with-chrono", "postgres-array"]
+
+# Query builder
+[workspace.dependencies.sea-query-binder]
+version = "0.7.0-rc.1"
+features = [
+    "sqlx",
+    "sqlx-postgres",
+    "with-uuid",
+    "with-chrono",
+    "postgres-array",
+]
+
 # Sentry error tracking
 [workspace.dependencies.sentry]
 version = "0.34.0"
@@ -222,9 +238,10 @@ features = ["preserve_order"]
 
 # SQL database support
 [workspace.dependencies.sqlx]
-version = "0.7.4"
+version = "0.8.1"
 features = [
-    "runtime-tokio-rustls",
+    "runtime-tokio",
+    "tls-rustls-aws-lc-rs",
     "postgres",
     "migrate",
     "chrono",
@@ -294,3 +311,8 @@ sha2.opt-level = 3
 digest.opt-level = 3
 block-buffer.opt-level = 3
 generic-array.opt-level = 3
+
+[patch.crates-io]
+# Waiting for https://github.com/SeaQL/sea-query/pull/810
+sea-query = { git = "https://github.com/sandhose/sea-query", branch = "binder/relax-sqlx-dependency" }
+sea-query-binder = { git = "https://github.com/sandhose/sea-query", branch = "binder/relax-sqlx-dependency" }

--- a/crates/storage-pg/Cargo.toml
+++ b/crates/storage-pg/Cargo.toml
@@ -14,8 +14,8 @@ workspace = true
 [dependencies]
 async-trait.workspace = true
 sqlx.workspace = true
-sea-query = { version = "0.31.0", features = ["derive", "attr", "with-uuid", "with-chrono", "postgres-array"] }
-sea-query-binder = { version = "0.6.0", features = ["sqlx-postgres", "with-uuid", "with-chrono", "postgres-array"] }
+sea-query.workspace = true
+sea-query-binder.workspace = true
 chrono.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/deny.toml
+++ b/deny.toml
@@ -54,17 +54,11 @@ multiple-versions = "deny"
 skip = [
     { name = "base64", version = "0.21.7" },         # many dependencies depends on this old version
     { name = "syn", version = "1.0.109" },           # sea-query, sqlx depend on the old version
-    { name = "event-listener", version = "2.5.3" },  # sqlx-core depend on the old version
     { name = "regex-syntax", version = "0.6.29" },   # tracing-subscriber[env-filter] -> matchers depends on the old version
     { name = "regex-automata", version = "0.1.10" }, # ^
     { name = "regex-automata", version = "0.2.0" },  # icu_list depends on this old version
     { name = "indexmap", version = "1.9.3" },        # schemars depends on this old version
     { name = "hashbrown" },                          # Too many versions :(
-    # sqlx uses old versions of those:
-    { name = "rustls", version = "0.21.10" },
-    { name = "rustls-pemfile", version = "1.0.4" },
-    { name = "rustls-webpki", version = "0.101.7" },
-    { name = "webpki-roots", version = "0.25.3" },
     # axum-macros, sqlx-macros and sea-query-attr use an old version
     { name = "heck", version = "0.4.1" },
     # sea-query-attr uses an old version of darling
@@ -95,4 +89,4 @@ deny = ["oldtime"]
 unknown-registry = "warn"
 unknown-git = "warn"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
-allow-git = []
+allow-git = ["https://github.com/sandhose/sea-query"]


### PR DESCRIPTION
This bumps sqlx to 0.8.1, which has a fix for [RUSTSEC-2024-0363](https://rustsec.org/advisories/RUSTSEC-2024-0363.html).
We don't believe that we're affected by this, as this requires 4GB+ of user-provided input, and we're limiting request bodies anyway.

`sea-query-binder` has an overly strict version requirement on `sqlx`, so I made a PR on their side to relax it, and in the meantime I'm using `[patch.crates-io]` to override the depedency.

This bump also means that we're not keeping two versions of rustls around anymore, yay!
