### PR TITLE
docker: remove redundant target platform

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -240,7 +240,7 @@ jobs:
         if: github.event_name != 'pull_request'
         run: |
           echo 'metadata<<EOF' >> $GITHUB_OUTPUT
-          echo '${{ steps.bake.outputs.metadata }}' | jq -c 'map_values({ digest: .["containerimage.digest"], tags: (.["image.name"] | split(",")) })' >> $GITHUB_OUTPUT
+          echo '${{ steps.bake.outputs.metadata }}' | jq -c 'with_entries(select(.value | (type == "object" and has("containerimage.digest")))) | map_values({ digest: .["containerimage.digest"], tags: (.["image.name"] | split(",")) })' >> $GITHUB_OUTPUT
           echo 'EOF' >> $GITHUB_OUTPUT
 
       - name: Sign the images with GitHub Actions provided token

--- a/Dockerfile
+++ b/Dockerfile
@@ -173,7 +173,7 @@ COPY ./translations/ /share/translations
 ##################################
 ## Runtime stage, debug variant ##
 ##################################
-FROM --platform=${TARGETPLATFORM} gcr.io/distroless/cc-debian${DEBIAN_VERSION}:debug-nonroot AS debug
+FROM gcr.io/distroless/cc-debian${DEBIAN_VERSION}:debug-nonroot AS debug
 
 ARG TARGETARCH
 COPY --from=builder /usr/local/bin/mas-cli-${TARGETARCH} /usr/local/bin/mas-cli
@@ -185,7 +185,7 @@ ENTRYPOINT ["/usr/local/bin/mas-cli"]
 ###################
 ## Runtime stage ##
 ###################
-FROM --platform=${TARGETPLATFORM} gcr.io/distroless/cc-debian${DEBIAN_VERSION}:nonroot
+FROM gcr.io/distroless/cc-debian${DEBIAN_VERSION}:nonroot
 
 ARG TARGETARCH
 COPY --from=builder /usr/local/bin/mas-cli-${TARGETARCH} /usr/local/bin/mas-cli

--- a/tools/syn2mas/Dockerfile
+++ b/tools/syn2mas/Dockerfile
@@ -19,9 +19,9 @@ COPY ./package.json ./package-lock.json ./
 RUN sed -i '/"prepare"/d' package.json
 RUN --network=default \
   npm ci \
-    --target_arch=amd64 \
-    --target_platform=linux \
-    --omit=dev
+  --target_arch=amd64 \
+  --target_platform=linux \
+  --omit=dev
 
 WORKDIR /deps/amd64
 
@@ -30,13 +30,13 @@ COPY ./package.json ./package-lock.json ./
 RUN sed -i '/"prepare"/d' package.json
 RUN --network=default \
   npm ci \
-    --target_arch=x64 \
-    --target_platform=linux \
-    --omit=dev
+  --target_arch=x64 \
+  --target_platform=linux \
+  --omit=dev
 
 
 # Runtime stage
-FROM --platform=${TARGETPLATFORM} gcr.io/distroless/nodejs18-debian12:debug-nonroot
+FROM gcr.io/distroless/nodejs18-debian12:debug-nonroot
 
 WORKDIR /syn2mas
 COPY ./package.json ./package-lock.json ./


### PR DESCRIPTION
This was a warning which broke the release process :(
I also made it so that the release process ignores warnings properly
